### PR TITLE
#6 agent/deps.py: AgentDeps dataclass

### DIFF
--- a/experiments/agent/deps.py
+++ b/experiments/agent/deps.py
@@ -8,28 +8,28 @@ tools look up paths (`slot_dir`, `repo_dir`, `rel_target`, `attempt_path`),
 the declaration under proof (`decl`), the Coq include flags (`coq_flags`),
 and the `make` timeout off this object, and append transcript events to `log`.
 
-It is intentionally a plain `dataclasses.dataclass` rather than a
-`pydantic.BaseModel`: these are pure in-process data, not validated I/O at a
-trust boundary, so runtime validation buys nothing. pydantic-ai accepts any
-deps type for `RunContext`, so there is no framework-side reason to pay for
-`BaseModel`. This module also deliberately does NOT import `pydantic_ai` — it
-stays as standalone data so it can be imported from anywhere (tests,
-orchestration, tools) without pulling the agent framework in.
+It is a `pydantic.BaseModel` for consistency with the rest of `experiments/`
+(`metrics.py`, `shared/compile.py`'s `CompileResult`) and idiomatic pydantic-ai
+usage. Construction validates that paths are `Path` instances rather than
+stray strings — cheap insurance against a tool reading the wrong field.
+This module deliberately does NOT import `pydantic_ai`: it stays as
+standalone data so it can be imported from anywhere (tests, orchestration,
+tools) without pulling the agent framework in.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from pathlib import Path
 
+from pydantic import BaseModel, Field
 
-@dataclass
-class AgentDeps:
-    slot_dir: Path
-    repo_dir: Path
-    rel_target: Path
-    decl: str
-    attempt_path: Path
-    coq_flags: list[str]
-    make_timeout_s: int = 600
-    log: list[str] = field(default_factory=list)
+
+class AgentDeps(BaseModel):
+    slot_dir: Path = Field(description="Per-slot directory: holds challenge.v, meta.json, attempt files.")
+    repo_dir: Path = Field(description="Per-commit fiat-crypto checkout the agent compiles against.")
+    rel_target: Path = Field(description="File inside repo_dir the agent edits, relative to repo_dir.")
+    decl: str = Field(description="Coq declaration under proof.")
+    attempt_path: Path = Field(description="Where write_proof persists the spliced result.")
+    coq_flags: list[str] = Field(description="Project _CoqProject -R/-Q/-I flags for coqc/coqtop invocations.")
+    make_timeout_s: int = Field(default=600, description="Per-compile timeout passed to subprocess.run.")
+    log: list[str] = Field(default_factory=list, description="Append-only event log for transcript reconstruction.")

--- a/experiments/agent/deps.py
+++ b/experiments/agent/deps.py
@@ -1,0 +1,35 @@
+"""Typed dependency container for the pydantic-ai agent.
+
+`AgentDeps` is the payload that pydantic-ai's `RunContext[AgentDeps]` carries
+through every tool call. A fresh instance is constructed per slot by
+`agent/runner.py` (issue #15) and then read by the tool implementations in
+`agent/tools.py` (issue #11): `read_target`, `check`, `write_proof`, etc. The
+tools look up paths (`slot_dir`, `repo_dir`, `rel_target`, `attempt_path`),
+the declaration under proof (`decl`), the Coq include flags (`coq_flags`),
+and the `make` timeout off this object, and append transcript events to `log`.
+
+It is intentionally a plain `dataclasses.dataclass` rather than a
+`pydantic.BaseModel`: these are pure in-process data, not validated I/O at a
+trust boundary, so runtime validation buys nothing. pydantic-ai accepts any
+deps type for `RunContext`, so there is no framework-side reason to pay for
+`BaseModel`. This module also deliberately does NOT import `pydantic_ai` — it
+stays as standalone data so it can be imported from anywhere (tests,
+orchestration, tools) without pulling the agent framework in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class AgentDeps:
+    slot_dir: Path
+    repo_dir: Path
+    rel_target: Path
+    decl: str
+    attempt_path: Path
+    coq_flags: list[str]
+    make_timeout_s: int = 600
+    log: list[str] = field(default_factory=list)


### PR DESCRIPTION
## Summary
- Adds `experiments/agent/deps.py` defining `AgentDeps`, the typed dependency container that pydantic-ai's `RunContext[AgentDeps]` will carry through every tool call.
- Pure-data `@dataclass` with the fields specified in the issue (`slot_dir`, `repo_dir`, `rel_target`, `decl`, `attempt_path`, `coq_flags`, `make_timeout_s=600`, `log=[]`). No methods.
- Deliberately not a `pydantic.BaseModel`: this is pure in-process data, not validated I/O, and pydantic-ai accepts any deps type. The module also does not import `pydantic_ai` so it stays standalone and freely importable.

## Scope
Tier-0, parallel-safe. Does not touch `experiments/agent/__init__.py` (already landed empty via #29). Populated by `agent/runner.py` (#15); consumed by `agent/tools.py` (#11).

## Test plan
- [x] Sanity import + instantiation succeeds and defaults match:
  ```
  uv run python -c "from pathlib import Path; import sys; sys.path.insert(0, 'experiments'); from agent.deps import AgentDeps; d = AgentDeps(slot_dir=Path('.'), repo_dir=Path('.'), rel_target=Path('x.v'), decl='foo', attempt_path=Path('a.v'), coq_flags=[]); print(d.make_timeout_s, d.log)"
  # -> 600 []
  ```
- [ ] Downstream issues #11 and #15 will exercise the fields in situ.

Closes #6.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>