### PR TITLE
#4 metrics.py: add vo_bytes, compile_time_s, assumptions, and agent fields

### DIFF
--- a/experiments/metrics.py
+++ b/experiments/metrics.py
@@ -24,6 +24,22 @@ class ProofMetrics(BaseModel):
     proof_chars: int = Field(description="Character length of the proof body")
     proof_lines: int = Field(description="Line count of the proof body")
     ends_with_admitted: bool = Field(description="True if the proof terminates with Admitted.")
+    vo_bytes: int | None = Field(
+        default=None,
+        description="Size in bytes of the compiled .vo artifact produced by coqc, if available."
+    )
+    compile_time_s: float | None = Field(
+        default=None,
+        description="Wall-clock seconds taken by coqc to compile the proof, if measured."
+    )
+    assumptions: list[str] | None = Field(
+        default=None,
+        description="Axioms/assumptions the closed proof depends on (e.g. from `Print Assumptions`)."
+    )
+    n_assumptions: int | None = Field(
+        default=None,
+        description="Derived count of entries in `assumptions`; populated by helpers, not the model."
+    )
 
 
 # ── Per-run result ────────────────────────────────────────────────────────────
@@ -47,6 +63,28 @@ class ExperimentResult(BaseModel):
     )
     inference_time_s: float = Field(description="Wall-clock seconds for Claude API call")
     output_tokens: int = Field(description="Output tokens returned by Claude")
+
+    # Mode + agent-loop bookkeeping
+    mode: Literal["baseline", "agent"] = Field(
+        default="baseline",
+        description="'baseline' = single-shot completion; 'agent' = multi-turn agent loop."
+    )
+    agent_n_turns: int | None = Field(
+        default=None,
+        description="Number of agent turns taken; None for baseline runs."
+    )
+    agent_give_up_reason: str | None = Field(
+        default=None,
+        description="Reason the agent stopped (e.g. 'max_turns', 'compile_success', 'no_progress')."
+    )
+    agent_total_input_tokens: int | None = Field(
+        default=None,
+        description="Sum of input tokens across all agent turns; None for baseline runs."
+    )
+    agent_total_output_tokens: int | None = Field(
+        default=None,
+        description="Sum of output tokens across all agent turns; None for baseline runs."
+    )
 
     # Proof quality
     human_metrics: ProofMetrics | None = Field(
@@ -91,6 +129,10 @@ class DeletionConditionSummary(BaseModel):
     mean_output_tokens: float
     mean_tactic_edit_distance: float | None = None
     mean_normalized_edit_distance: float | None = None
+    mean_vo_bytes: float | None = None
+    mean_compile_time_s: float | None = None
+    mean_n_assumptions: float | None = None
+    mean_agent_n_turns: float | None = None
 
 
 class ExperimentSummary(BaseModel):
@@ -101,12 +143,15 @@ class ExperimentSummary(BaseModel):
     n_total_runs: int
     conditions: list[DeletionConditionSummary]
 
-    # Faithfulness score: Pearson r between deletion_size and pass_rate
-    # (should be strongly negative for a faithful eval)
-    faithfulness_correlation: float | None = Field(
-        default=None,
+    # Faithfulness score: Pearson r between deletion_size and pass_rate,
+    # computed separately for each mode ("baseline", "agent").
+    # Negative = harder deletions → lower pass rate (expected for faithful eval).
+    # Near zero or positive = possible memorization / non-monotonic degradation.
+    faithfulness_by_mode: dict[str, float | None] = Field(
+        default_factory=dict,
         description=(
-            "Pearson r between deletion_size and pass_rate across B conditions. "
+            "Pearson r between deletion_size and pass_rate across B conditions, "
+            "keyed by mode ('baseline', 'agent'). "
             "Negative = harder deletions → lower pass rate (expected for faithful eval). "
             "Near zero or positive = possible memorization / non-monotonic degradation."
         )


### PR DESCRIPTION
## Summary
- `ProofMetrics` gains `vo_bytes`, `compile_time_s`, `assumptions`, `n_assumptions` (all `Optional` with `None` defaults, self-documented via `Field(description=...)`)
- `ExperimentResult` gains `mode: Literal["baseline", "agent"] = "baseline"` plus `agent_n_turns`, `agent_give_up_reason`, `agent_total_input_tokens`, `agent_total_output_tokens` for agent-loop bookkeeping
- `DeletionConditionSummary` gains matching `mean_vo_bytes`, `mean_compile_time_s`, `mean_n_assumptions`, `mean_agent_n_turns` aggregates
- `ExperimentSummary.faithfulness_correlation: float | None` is restructured to `faithfulness_by_mode: dict[str, float | None] = Field(default_factory=dict)` so the Pearson r can be reported per mode; the "near zero = possible memorization" note is preserved
- Every new field is Optional with a sensible default, so existing `experiment-results.jsonl` records load unchanged

## Test plan
- [x] `uv run --with pydantic python -c "from metrics import ExperimentResult; r = ExperimentResult.model_validate({'challenge_id':'x','declaration':'y','deletion_size':3,'condition':'B','verdict':'PASS','inference_time_s':1.0,'output_tokens':10}); print('OK', r.mode, r.agent_n_turns)"` prints `OK baseline None`
- [x] Existing `experiments/experiment-results.jsonl` records load via `ExperimentResult.model_validate_json` without errors
- [x] `ProofMetrics`, `DeletionConditionSummary`, and `ExperimentSummary` all construct with only their original required fields

Closes #4.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>