### PR TITLE
#5 shared/compile.py: make-target runner + vo_bytes + Print Assumptions

### DIFF
--- a/experiments/shared/compile.py
+++ b/experiments/shared/compile.py
@@ -1,0 +1,270 @@
+"""Synchronous helpers for compiling a single Coq file and probing its axioms.
+
+Three entry points, all stateless and safe to call concurrently (each call
+uses its own subprocess and, where applicable, its own temp probe file):
+
+* ``run_make_target`` — drives the repo's Makefile to build one ``.vo``.
+* ``vo_bytes``        — reports the size of a compiled ``.vo``.
+* ``print_assumptions`` — runs ``Print Assumptions`` for a single declaration
+  via a throwaway probe file compiled with ``coqc``.
+
+The ``_get_coq_flags`` helper is copy-pasted from ``experiments/run_experiment.py``
+(issue #14 will dedupe these once ``run_experiment.py`` is refactored).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import time
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+
+# 8 KB truncation cap for captured stdout/stderr. Kept as a module constant
+# so tests can exercise it without depending on subprocess output size.
+_TRUNC_BYTES = 8 * 1024
+
+
+class CompileResult(BaseModel):
+    """Outcome of a single ``make -C <repo_dir> <target>.vo`` invocation."""
+
+    ok: bool = Field(description="True iff exit_code == 0 AND the .vo exists post-run.")
+    exit_code: int
+    stdout: str
+    stderr: str
+    elapsed_s: float
+    target: str
+
+
+def _truncate(s: str, limit: int = _TRUNC_BYTES) -> str:
+    """Return ``s`` truncated to at most ``limit`` bytes of UTF-8.
+
+    We operate on the byte length so the ~8KB budget is a real upper bound
+    regardless of multibyte characters. The string is decoded back with
+    ``errors='replace'`` so a split codepoint does not raise.
+    """
+    data = s.encode("utf-8", errors="replace")
+    if len(data) <= limit:
+        return s
+    return data[:limit].decode("utf-8", errors="replace")
+
+
+def _get_coq_flags(repo_dir: Path) -> list[str]:
+    """Parse ``_CoqProject`` and return its ``-R``/``-Q``/``-I`` flag triples.
+
+    Copied verbatim from ``experiments/run_experiment.py`` (lines 231–240).
+    Issue #14 tracks the refactor that will let both callers share one copy.
+    """
+    cp = repo_dir / "_CoqProject"
+    if not cp.exists():
+        return []
+    flags: list[str] = []
+    for line in cp.read_text().splitlines():
+        parts = line.strip().split()
+        if parts and parts[0] in ("-R", "-Q", "-I") and len(parts) >= 3:
+            flags.extend(parts[:3])
+    return flags
+
+
+def _vo_path(repo_dir: Path, rel_target: Path) -> Path:
+    """Return the absolute ``.vo`` path corresponding to ``rel_target``.
+
+    ``rel_target`` may point at either the source (``.v``) or the compiled
+    artifact (``.vo``); we always land on the ``.vo``.
+    """
+    rel_vo = rel_target.with_suffix(".vo") if rel_target.suffix != ".vo" else rel_target
+    return (repo_dir / rel_vo).resolve()
+
+
+def run_make_target(
+    repo_dir: Path,
+    rel_target: Path,
+    *,
+    timeout: int = 600,
+) -> CompileResult:
+    """Invoke ``make -C <repo_dir> <rel_target>.vo`` and report the outcome.
+
+    ``ok`` is ``True`` iff ``make`` exited zero *and* the ``.vo`` exists on
+    disk afterwards — the latter guards against Makefiles that swallow errors
+    or produce the wrong artifact. ``stdout``/``stderr`` are truncated to
+    ~8KB each.
+    """
+    rel_vo = rel_target.with_suffix(".vo") if rel_target.suffix != ".vo" else rel_target
+    target_str = str(rel_vo)
+    vo_abs = _vo_path(repo_dir, rel_target)
+
+    start = time.monotonic()
+    try:
+        proc = subprocess.run(
+            ["make", "-C", str(repo_dir), target_str],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        stdout = proc.stdout or ""
+        stderr = proc.stderr or ""
+        exit_code = proc.returncode
+    except subprocess.TimeoutExpired as e:
+        stdout = (e.stdout.decode("utf-8", errors="replace") if isinstance(e.stdout, bytes) else (e.stdout or ""))
+        stderr = (e.stderr.decode("utf-8", errors="replace") if isinstance(e.stderr, bytes) else (e.stderr or ""))
+        stderr = (stderr + f"\n[timeout after {timeout}s]").lstrip("\n")
+        exit_code = 124  # conventional "timeout" exit code
+    except FileNotFoundError as e:
+        stdout = ""
+        stderr = f"make not found: {e}"
+        exit_code = 127
+    elapsed = time.monotonic() - start
+
+    ok = exit_code == 0 and vo_abs.exists()
+    return CompileResult(
+        ok=ok,
+        exit_code=exit_code,
+        stdout=_truncate(stdout),
+        stderr=_truncate(stderr),
+        elapsed_s=elapsed,
+        target=target_str,
+    )
+
+
+def vo_bytes(repo_dir: Path, rel_target: Path) -> int | None:
+    """Return the size in bytes of the ``.vo`` for ``rel_target``, or ``None``."""
+    vo = _vo_path(repo_dir, rel_target)
+    try:
+        return os.path.getsize(vo)
+    except OSError:
+        return None
+
+
+def _derive_module_path(repo_dir: Path, rel_target: Path, flags: list[str]) -> str | None:
+    """Map ``rel_target`` (a ``.v`` or ``.vo`` under ``repo_dir``) to a Coq module path.
+
+    Uses ``_CoqProject`` ``-R`` / ``-Q`` / ``-I`` flags: for each triple
+    ``(-R|-Q, phys_dir, logical_prefix)``, if ``rel_target`` lives under
+    ``phys_dir`` the returned module is ``<logical_prefix>.<dotted_subpath>.<stem>``.
+    An ``-I`` flag contributes no logical prefix and is ignored here.
+    Returns ``None`` if no flag covers ``rel_target``.
+    """
+    rel_v = rel_target.with_suffix(".v") if rel_target.suffix != ".v" else rel_target
+    # Normalise to a POSIX path relative to repo_dir.
+    rel_posix = Path(rel_v).as_posix().lstrip("./")
+
+    # Walk flags in order; `-R`/`-Q` entries have (flag, phys, logical).
+    i = 0
+    best: tuple[int, str] | None = None  # (match length, module path)
+    while i < len(flags):
+        tag = flags[i]
+        if tag in ("-R", "-Q") and i + 2 < len(flags):
+            phys = flags[i + 1].rstrip("/")
+            logical = flags[i + 2]
+            phys_norm = "" if phys in (".", "") else phys + "/"
+            if phys_norm == "" or rel_posix.startswith(phys_norm):
+                sub = rel_posix[len(phys_norm):]
+                sub_path = Path(sub)
+                parts = list(sub_path.parent.parts) if str(sub_path.parent) != "." else []
+                stem = sub_path.stem
+                pieces = [logical] + parts + [stem] if logical else parts + [stem]
+                module = ".".join(p for p in pieces if p)
+                score = len(phys_norm)
+                if best is None or score > best[0]:
+                    best = (score, module)
+            i += 3
+        elif tag == "-I" and i + 1 < len(flags):
+            i += 2
+        else:
+            i += 1
+
+    return best[1] if best else None
+
+
+def _parse_axioms(stdout: str) -> list[str]:
+    """Extract axiom names from ``coqc`` stdout after a ``Print Assumptions`` call.
+
+    The output begins with a line ``Axioms:`` and lists one axiom per
+    subsequent indented line. Parsing stops at a blank line or at
+    ``Closed under the global context.``.
+    """
+    axioms: list[str] = []
+    lines = stdout.splitlines()
+    in_axioms = False
+    for line in lines:
+        stripped = line.strip()
+        if not in_axioms:
+            if stripped.startswith("Axioms:"):
+                in_axioms = True
+                # "Axioms:" may be followed by an axiom on the same line.
+                rest = stripped[len("Axioms:"):].strip()
+                if rest:
+                    # Take only the bare identifier (drop any ``: type`` part).
+                    axioms.append(rest.split(":", 1)[0].strip())
+            continue
+        # inside the axiom block
+        if not stripped or stripped == "Closed under the global context.":
+            break
+        # indented lines are axiom entries; each entry begins with a name.
+        axioms.append(stripped.split(":", 1)[0].strip())
+    return [a for a in axioms if a]
+
+
+def print_assumptions(
+    repo_dir: Path,
+    rel_target: Path,
+    decl: str,
+    *,
+    timeout: int = 120,
+) -> list[str] | None:
+    """Return the axioms ``decl`` depends on, via a ``Print Assumptions`` probe.
+
+    Writes ``<stem>_probe.v`` next to the target, compiles it with ``coqc``
+    using the repo's ``_CoqProject`` flags, parses the output, and cleans up
+    the probe file (and its ``.vo``/``.vok``/``.glob`` siblings) unconditionally.
+    Returns ``None`` on any failure (missing ``coqc``, compile error, unparsable
+    output, unmappable module path, etc.).
+    """
+    rel_v = rel_target.with_suffix(".v") if rel_target.suffix != ".v" else rel_target
+    target_v = (repo_dir / rel_v).resolve()
+    if not target_v.exists():
+        return None
+
+    flags = _get_coq_flags(repo_dir)
+    module_path = _derive_module_path(repo_dir, rel_v, flags)
+    if module_path is None:
+        return None
+
+    probe = target_v.with_name(f"{target_v.stem}_probe.v")
+    probe.write_text(
+        f"Require Import {module_path}.\n"
+        f"Print Assumptions {decl}.\n"
+    )
+    # Sibling artifacts coqc may emit.
+    artifacts = [
+        probe,
+        probe.with_suffix(".vo"),
+        probe.with_suffix(".vok"),
+        probe.with_suffix(".vos"),
+        probe.with_suffix(".glob"),
+        probe.with_name(f".{probe.stem}.aux"),
+    ]
+
+    try:
+        try:
+            proc = subprocess.run(
+                ["coqc", *flags, str(probe)],
+                cwd=str(repo_dir),
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return None
+        if proc.returncode != 0:
+            return None
+        return _parse_axioms(proc.stdout or "")
+    finally:
+        for p in artifacts:
+            try:
+                p.unlink()
+            except OSError:
+                pass

--- a/experiments/tests/test_compile.py
+++ b/experiments/tests/test_compile.py
@@ -1,0 +1,105 @@
+"""Tests for experiments.shared.compile.
+
+These tests stub ``make`` with tiny Makefiles in ``tmp_path`` so they do not
+depend on fiat-crypto, Coq, or any network. They cover:
+
+* ``vo_bytes`` returning ``None`` for a missing file.
+* ``run_make_target`` reporting failure when ``make`` exits non-zero.
+* ``run_make_target`` reporting success when the Makefile produces the ``.vo``.
+* stdout/stderr truncation to ~8KB.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from shared.compile import CompileResult, run_make_target, vo_bytes
+from shared.compile import _truncate, _TRUNC_BYTES
+
+
+# ``make`` is a hard dependency for the runner tests; skip gracefully if absent.
+_HAS_MAKE = shutil.which("make") is not None
+requires_make = pytest.mark.skipif(not _HAS_MAKE, reason="`make` not on PATH")
+
+
+def test_vo_bytes_missing_returns_none(tmp_path: Path) -> None:
+    # no file at all
+    assert vo_bytes(tmp_path, Path("does/not/exist.vo")) is None
+    # directory exists but file does not
+    (tmp_path / "sub").mkdir()
+    assert vo_bytes(tmp_path, Path("sub/missing.vo")) is None
+
+
+def test_vo_bytes_reports_size(tmp_path: Path) -> None:
+    (tmp_path / "foo.vo").write_bytes(b"hello")
+    assert vo_bytes(tmp_path, Path("foo.v")) == 5   # accepts .v input
+    assert vo_bytes(tmp_path, Path("foo.vo")) == 5  # also accepts .vo input
+
+
+@requires_make
+def test_run_make_target_reports_failure(tmp_path: Path) -> None:
+    (tmp_path / "Makefile").write_text("target.vo: ; false\n")
+    result = run_make_target(tmp_path, Path("target.v"), timeout=30)
+    assert isinstance(result, CompileResult)
+    assert result.ok is False
+    assert result.exit_code != 0
+    assert result.target == "target.vo"
+    # no .vo was produced
+    assert vo_bytes(tmp_path, Path("target.v")) is None
+
+
+@requires_make
+def test_run_make_target_reports_success(tmp_path: Path) -> None:
+    (tmp_path / "Makefile").write_text("target.vo: ; touch $@\n")
+    result = run_make_target(tmp_path, Path("target.v"), timeout=30)
+    assert result.ok is True
+    assert result.exit_code == 0
+    assert result.target == "target.vo"
+    assert vo_bytes(tmp_path, Path("target.v")) == 0
+
+
+@requires_make
+def test_run_make_target_success_requires_vo_on_disk(tmp_path: Path) -> None:
+    # Makefile exits 0 but does NOT create target.vo — ok must be False.
+    (tmp_path / "Makefile").write_text("target.vo: ; true\n")
+    result = run_make_target(tmp_path, Path("target.v"), timeout=30)
+    assert result.exit_code == 0
+    assert result.ok is False
+
+
+def test_truncate_caps_at_8kb() -> None:
+    # sanity: helper truncates to the declared byte budget
+    big = "x" * (_TRUNC_BYTES + 1000)
+    out = _truncate(big)
+    assert len(out.encode("utf-8")) <= _TRUNC_BYTES
+    # and leaves short strings alone
+    assert _truncate("short") == "short"
+
+
+@requires_make
+def test_run_make_target_truncates_stdout(tmp_path: Path) -> None:
+    # Emit well over 8KB of stdout from the recipe.
+    (tmp_path / "Makefile").write_text(
+        "target.vo:\n"
+        "\t@python3 -c 'print(\"x\"*20000)'\n"
+        "\t@touch $@\n"
+    )
+    result = run_make_target(tmp_path, Path("target.v"), timeout=30)
+    assert result.ok is True
+    assert len(result.stdout.encode("utf-8")) <= _TRUNC_BYTES
+
+
+def test_compile_result_shape() -> None:
+    # Construct directly to lock the schema; tests above exercise the runner.
+    r = CompileResult(
+        ok=True, exit_code=0, stdout="a", stderr="b", elapsed_s=0.5, target="x.vo"
+    )
+    assert r.ok is True
+    assert r.exit_code == 0
+    assert r.stdout == "a"
+    assert r.stderr == "b"
+    assert r.elapsed_s == 0.5
+    assert r.target == "x.vo"


### PR DESCRIPTION
## Summary
- `experiments/shared/compile.py`: `run_make_target`, `vo_bytes`, `print_assumptions`, and a `CompileResult` pydantic model. `run_make_target` drives `make -C <repo_dir> <target>.vo` and reports `ok` only when both the exit code is zero and the `.vo` landed on disk; stdout/stderr are byte-truncated to ~8KB so multibyte characters can't blow the cap. `print_assumptions` writes `<stem>_probe.v`, derives the Coq module path from the repo's `_CoqProject` `-R`/`-Q` flags, compiles via `coqc`, parses the `Axioms:` block, and unconditionally cleans up the probe and its sibling artifacts.
- `_get_coq_flags` is copied verbatim from `run_experiment.py:231-240` per the issue's explicit note; issue #14 owns the dedupe when `run_experiment.py` is refactored.
- `experiments/tests/test_compile.py`: 8 tests, all passing. The make-dependent cases stub tiny Makefiles in `tmp_path` so they don't need fiat-crypto or Coq, and skip gracefully when `make` is not on PATH.
- `experiments/conftest.py` is already present on master (landed with PR #30), so no cherry-pick was needed.

## Test plan
- [x] `uv run --with pytest --with pydantic python -m pytest experiments/tests/test_compile.py -v` — 8 passed
- [ ] `run_make_target` will be exercised against real fiat-crypto targets in issue #12/#13 integrations
- [ ] `print_assumptions` requires a real `coqc` install to integration-test; covered once the docker image work in issue #9 lands

Closes #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)