### PR TITLE
#8 orchestrate/detect_coq_version.py: per-SHA Coq version detector

### DIFF
--- a/experiments/orchestrate/detect_coq_version.py
+++ b/experiments/orchestrate/detect_coq_version.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Per-SHA Coq version detector for fiat-crypto.
+
+For any fiat-crypto SHA, return the best Coq version tag to base the
+per-commit Docker image on (a tag suitable for ``coqorg/coq:<TAG>`` on
+Docker Hub, e.g. ``8.20.0``, ``8.18.0``, ``dev``).
+
+Detection precedence (each step reads a file at the given SHA via
+``git -C <repo> show <sha>:<path>``):
+
+1. ``.github/workflows/coq-docker.yml`` -- parse the first non-``dev``
+   ``DOCKER_COQ_VERSION`` from the matrix; if only ``dev`` entries are
+   present, return ``dev``.
+2. ``.github/workflows/coq-opam-package.yml`` -- parse the first matrix
+   ``coq-version`` (e.g. ``8.20.0``).
+3. ``.github/workflows/coq-debian.yml`` -- return ``dev`` (the Dockerfile
+   will fall back to a Debian-based image).
+4. ``.travis.yml`` -- parse the FIRST non-``master`` matrix entry. If it
+   has ``COQ_PACKAGE="coq-X.Y.Z"``, return ``X.Y.Z``; otherwise if it has
+   ``COQ_PACKAGE="coq"`` + ``COQ_VERSION="vX.Y"``, return ``X.Y``.
+5. If none matched, exit with code 2 and stderr ``unknown``.
+
+This module uses only the Python standard library (no PyYAML, no
+third-party regex).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from typing import Callable, Optional
+
+
+WORKFLOW_DOCKER = ".github/workflows/coq-docker.yml"
+WORKFLOW_OPAM = ".github/workflows/coq-opam-package.yml"
+WORKFLOW_DEBIAN = ".github/workflows/coq-debian.yml"
+TRAVIS = ".travis.yml"
+
+# Paths queried, in precedence order, by ``detect_from_contents``.
+_PATHS = (WORKFLOW_DOCKER, WORKFLOW_OPAM, WORKFLOW_DEBIAN, TRAVIS)
+
+
+def _parse_docker(content: str) -> Optional[str]:
+    """Return first non-``dev`` ``DOCKER_COQ_VERSION`` or ``dev`` if all are dev."""
+    matches = re.findall(r'DOCKER_COQ_VERSION\s*:\s*["\']?([^"\',}\s]+)', content)
+    if not matches:
+        return None
+    for v in matches:
+        if v != "dev":
+            return v
+    return "dev"
+
+
+def _parse_opam(content: str) -> Optional[str]:
+    """Return the first matrix ``coq-version`` entry, skipping ``dev``/``master``."""
+    # Find the matrix block's ``coq-version`` array, e.g.:
+    #   coq-version: ['dev', '8.20.0']
+    m = re.search(
+        r"coq-version\s*:\s*\[([^\]]*)\]",
+        content,
+    )
+    if m:
+        items = re.findall(r"['\"]([^'\"]+)['\"]", m.group(1))
+        for v in items:
+            if v not in ("dev", "master"):
+                return v
+        if items:
+            return items[0]
+    # Fallback: YAML list style
+    #   coq-version:
+    #     - 'dev'
+    #     - '8.20.0'
+    m = re.search(
+        r"coq-version\s*:\s*\n((?:\s*-\s*['\"][^'\"]+['\"]\s*\n?)+)",
+        content,
+    )
+    if m:
+        items = re.findall(r"-\s*['\"]([^'\"]+)['\"]", m.group(1))
+        for v in items:
+            if v not in ("dev", "master"):
+                return v
+        if items:
+            return items[0]
+    return None
+
+
+def _parse_debian(content: str) -> Optional[str]:
+    """If the debian workflow is present at all, signal ``dev`` fallback."""
+    if content.strip():
+        return "dev"
+    return None
+
+
+def _parse_travis(content: str) -> Optional[str]:
+    """Return the first non-``master`` matrix entry's Coq version hint.
+
+    Walks ``env:`` lines of the ``jobs:`` matrix. Accepts either
+    ``COQ_PACKAGE="coq-X.Y.Z"`` (returns ``X.Y.Z``) or
+    ``COQ_PACKAGE="coq"`` + ``COQ_VERSION="vX.Y"`` (returns ``X.Y``).
+    """
+    # Match any line carrying both COQ_VERSION and COQ_PACKAGE env assignments.
+    line_re = re.compile(
+        r'COQ_VERSION\s*=\s*"([^"]+)".*?COQ_PACKAGE\s*=\s*"([^"]+)"'
+    )
+    for line in content.splitlines():
+        m = line_re.search(line)
+        if not m:
+            continue
+        coq_version = m.group(1)
+        coq_package = m.group(2)
+        if coq_version == "master":
+            continue
+        # Prefer explicit X.Y.Z from the package name.
+        pkg_m = re.fullmatch(r"coq-(\d+\.\d+(?:\.\d+)?)", coq_package)
+        if pkg_m:
+            return pkg_m.group(1)
+        # Fall back to COQ_VERSION="vX.Y" hint.
+        ver_m = re.fullmatch(r"v?(\d+\.\d+(?:\.\d+)?)", coq_version)
+        if ver_m:
+            return ver_m.group(1)
+    return None
+
+
+# Per-path parser dispatch, used by ``detect_from_contents``.
+_PARSERS: dict[str, Callable[[str], Optional[str]]] = {
+    WORKFLOW_DOCKER: _parse_docker,
+    WORKFLOW_OPAM: _parse_opam,
+    WORKFLOW_DEBIAN: _parse_debian,
+    TRAVIS: _parse_travis,
+}
+
+
+def detect_from_contents(files: dict[str, str]) -> Optional[str]:
+    """Apply detection precedence over a dict of ``{path: content}``.
+
+    Keys absent from ``files`` are treated as missing (skipped silently).
+    Returns the detected version string (e.g. ``8.20.0`` or ``dev``), or
+    ``None`` if no step yielded a result.
+    """
+    for path in _PATHS:
+        content = files.get(path)
+        if content is None:
+            continue
+        result = _PARSERS[path](content)
+        if result is not None:
+            return result
+    return None
+
+
+def _git_show(repo: str, sha: str, path: str) -> Optional[str]:
+    """Return the contents of ``<sha>:<path>`` in ``repo``, or ``None`` if missing."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", repo, "show", f"{sha}:{path}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def detect(repo: str, sha: str) -> Optional[str]:
+    """Detect the Coq version for ``sha`` in the git repo at ``repo``."""
+    files: dict[str, str] = {}
+    for path in _PATHS:
+        content = _git_show(repo, sha, path)
+        if content is not None:
+            files[path] = content
+    return detect_from_contents(files)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(
+            f"usage: {argv[0]} <fiat_crypto_repo_path> <sha>",
+            file=sys.stderr,
+        )
+        return 2
+    repo, sha = argv[1], argv[2]
+    result = detect(repo, sha)
+    if result is None:
+        print("unknown", file=sys.stderr)
+        return 2
+    print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/experiments/tests/test_detect_coq_version.py
+++ b/experiments/tests/test_detect_coq_version.py
@@ -1,0 +1,217 @@
+"""Tests for experiments.orchestrate.detect_coq_version.
+
+These exercise ``detect_from_contents`` -- the pure core of the detector --
+with short inline workflow / travis fixtures so we can skip subprocess
+mocking and PyYAML. Real-SHA validation happens in CI / by hand.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orchestrate.detect_coq_version import (
+    WORKFLOW_DEBIAN,
+    WORKFLOW_DOCKER,
+    WORKFLOW_OPAM,
+    TRAVIS,
+    detect_from_contents,
+)
+
+
+DOCKER_WITH_EXPLICIT_VERSION = """\
+name: CI (Coq, docker)
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+        - env: { COQ_VERSION: "8.18", DOCKER_COQ_VERSION: "8.18.0", DOCKER_OCAML_VERSION: "default" }
+          os: 'ubuntu-latest'
+"""
+
+
+DOCKER_ONLY_DEV = """\
+name: CI (Coq, docker, dev)
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+        - env: { COQ_VERSION: "master", DOCKER_COQ_VERSION: "dev", DOCKER_OCAML_VERSION: "default" }
+          os: 'ubuntu-latest'
+  validate:
+    strategy:
+      matrix:
+        include:
+        - env: { COQ_VERSION: "master", DOCKER_COQ_VERSION: "dev", DOCKER_OCAML_VERSION: "default" }
+          os: 'ubuntu-latest'
+"""
+
+
+DOCKER_DEV_THEN_STABLE = """\
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+        - env: { DOCKER_COQ_VERSION: "dev" }
+        - env: { DOCKER_COQ_VERSION: "8.20.0" }
+"""
+
+
+OPAM_INLINE = """\
+jobs:
+  install:
+    strategy:
+      matrix:
+        coq-version: ['dev', '8.20.0']
+        os: [{name: 'Ubuntu'}]
+"""
+
+
+OPAM_BLOCK = """\
+jobs:
+  install:
+    strategy:
+      matrix:
+        coq-version:
+          - 'dev'
+          - '8.19.1'
+"""
+
+
+DEBIAN_MIN = """\
+name: CI (Coq, Debian)
+jobs:
+  build:
+    runs-on: 'ubuntu-22.04'
+"""
+
+
+TRAVIS_FIRST_NONMASTER_EXPLICIT = """\
+jobs:
+  include:
+    - stage: early
+      env: COQ_VERSION="master" COQ_PACKAGE="coq"       PPA="ppa:jgross-h/coq-master-daily"
+    - stage: selected
+      env: COQ_VERSION="8.8.2"  COQ_PACKAGE="coq-8.8.2" PPA="ppa:jgross-h/many-coq-versions"
+    - stage: selected
+      env: COQ_VERSION="8.7.2"  COQ_PACKAGE="coq-8.7.2" PPA="ppa:jgross-h/many-coq-versions"
+"""
+
+
+TRAVIS_FIRST_NONMASTER_HINT_ONLY = """\
+jobs:
+  include:
+    - stage: early
+      env: COQ_VERSION="master" COQ_PACKAGE="coq"   PPA="ppa:jgross-h/coq-master-daily"
+    - stage: early
+      env: COQ_VERSION="v8.9"   COQ_PACKAGE="coq"   PPA="ppa:jgross-h/coq-8.9-daily"
+    - stage: selected
+      env: COQ_VERSION="8.8.2"  COQ_PACKAGE="coq-8.8.2" PPA="ppa:jgross-h/many-coq-versions"
+"""
+
+
+# ----------------------------------------------------------------------
+# docker workflow (precedence step 1)
+# ----------------------------------------------------------------------
+
+
+def test_docker_matrix_explicit_version_returns_it() -> None:
+    files = {WORKFLOW_DOCKER: DOCKER_WITH_EXPLICIT_VERSION}
+    assert detect_from_contents(files) == "8.18.0"
+
+
+def test_docker_matrix_only_dev_returns_dev() -> None:
+    files = {WORKFLOW_DOCKER: DOCKER_ONLY_DEV}
+    assert detect_from_contents(files) == "dev"
+
+
+def test_docker_matrix_prefers_first_non_dev() -> None:
+    files = {WORKFLOW_DOCKER: DOCKER_DEV_THEN_STABLE}
+    assert detect_from_contents(files) == "8.20.0"
+
+
+# ----------------------------------------------------------------------
+# opam-package workflow (precedence step 2)
+# ----------------------------------------------------------------------
+
+
+def test_opam_inline_matrix_picks_first_non_dev() -> None:
+    files = {WORKFLOW_OPAM: OPAM_INLINE}
+    assert detect_from_contents(files) == "8.20.0"
+
+
+def test_opam_block_style_matrix_picks_first_non_dev() -> None:
+    files = {WORKFLOW_OPAM: OPAM_BLOCK}
+    assert detect_from_contents(files) == "8.19.1"
+
+
+# ----------------------------------------------------------------------
+# debian workflow (precedence step 3)
+# ----------------------------------------------------------------------
+
+
+def test_debian_workflow_returns_dev_fallback() -> None:
+    files = {WORKFLOW_DEBIAN: DEBIAN_MIN}
+    assert detect_from_contents(files) == "dev"
+
+
+# ----------------------------------------------------------------------
+# travis.yml (precedence step 4)
+# ----------------------------------------------------------------------
+
+
+def test_travis_first_nonmaster_explicit_package() -> None:
+    files = {TRAVIS: TRAVIS_FIRST_NONMASTER_EXPLICIT}
+    assert detect_from_contents(files) == "8.8.2"
+
+
+def test_travis_first_nonmaster_hint_only() -> None:
+    files = {TRAVIS: TRAVIS_FIRST_NONMASTER_HINT_ONLY}
+    # First non-master entry is COQ_PACKAGE="coq" + COQ_VERSION="v8.9";
+    # detector returns the X.Y hint.
+    assert detect_from_contents(files) == "8.9"
+
+
+# ----------------------------------------------------------------------
+# precedence ordering
+# ----------------------------------------------------------------------
+
+
+def test_docker_takes_precedence_over_travis() -> None:
+    files = {
+        WORKFLOW_DOCKER: DOCKER_WITH_EXPLICIT_VERSION,
+        TRAVIS: TRAVIS_FIRST_NONMASTER_EXPLICIT,
+    }
+    assert detect_from_contents(files) == "8.18.0"
+
+
+def test_opam_takes_precedence_over_debian() -> None:
+    files = {
+        WORKFLOW_OPAM: OPAM_INLINE,
+        WORKFLOW_DEBIAN: DEBIAN_MIN,
+    }
+    assert detect_from_contents(files) == "8.20.0"
+
+
+def test_only_travis_available_skips_missing_workflows() -> None:
+    # Scenario (c) from the task: no .github/workflows/ files, only .travis.yml.
+    files = {TRAVIS: TRAVIS_FIRST_NONMASTER_EXPLICIT}
+    assert detect_from_contents(files) == "8.8.2"
+
+
+def test_no_files_returns_none() -> None:
+    assert detect_from_contents({}) is None
+
+
+@pytest.fixture
+def fiat_crypto_old_sha_files() -> dict[str, str]:
+    """Fixture representing a pre-.github/workflows/ fiat-crypto SHA."""
+    return {TRAVIS: TRAVIS_FIRST_NONMASTER_EXPLICIT}
+
+
+def test_fixture_old_sha_returns_travis_version(
+    fiat_crypto_old_sha_files: dict[str, str],
+) -> None:
+    assert detect_from_contents(fiat_crypto_old_sha_files) == "8.8.2"


### PR DESCRIPTION
## Summary

Closes #8. Stdlib-only Python CLI that, given a fiat-crypto repo path and a SHA, prints the best Coq version tag to base the per-commit Docker image on (suitable for `coqorg/coq:<TAG>` on Docker Hub -- e.g. `8.20.0`, `8.18.0`, `dev`).

## Detection precedence

Each step reads the file at the given SHA via `git -C <repo> show <sha>:<path>`; a missing file falls through to the next step.

1. `.github/workflows/coq-docker.yml` -- first non-`dev` `DOCKER_COQ_VERSION` from the matrix; if all entries are `dev`, return `dev`.
2. `.github/workflows/coq-opam-package.yml` -- first matrix `coq-version` entry that isn't `dev`/`master`.
3. `.github/workflows/coq-debian.yml` -- present => return `dev` (the Dockerfile is expected to fall back to a debian-based image).
4. `.travis.yml` -- first non-`master` matrix entry's `COQ_PACKAGE="coq-X.Y.Z"` (returns `X.Y.Z`) or `COQ_PACKAGE="coq"` + `COQ_VERSION="vX.Y"` hint (returns `X.Y`).
5. Nothing matched -- exit code 2 with stderr `unknown`.

Core logic is factored into `detect_from_contents(files: dict[str, str]) -> str | None` so tests exercise it directly with inline string fixtures -- no subprocess mocking, no PyYAML.

## Reality check (real fiat-crypto SHAs)

- `b9f28afec4f3dc3340a8693cdf450721af67d13b` (predates `.github/workflows/`) -> `8.9`. This SHA's first non-master `.travis.yml` matrix entry is `COQ_VERSION="v8.9" COQ_PACKAGE="coq"`, which per the spec yields the `X.Y` hint `8.9`. (The first entry with an explicit `coq-X.Y.Z` package name in this file is `8.8.2` at a later stage.)
- HEAD of `data/fiat-crypto` -> `dev`. The current `coq-docker.yml` only lists `DOCKER_COQ_VERSION: "dev"`, so step 1 correctly returns `dev`.
- Invalid SHA -> exit 2, stderr `unknown`.

## Test plan

- [x] `uv run --with pytest python -m pytest experiments/tests/test_detect_coq_version.py -v` -- 13 passed.
- [x] Covers each precedence step, dev-only matrix, precedence ordering (docker > travis, opam > debian), missing-files-return-None, and the issue-specified scenarios (docker with explicit version, docker with only dev, travis fallback).
- [x] CLI smoke-tested end-to-end against three real fiat-crypto SHAs (HEAD / old commit / invalid).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>