### PR TITLE
#13 summary.py: baseline JSONL aggregator + Pearson r

### DIFF
--- a/experiments/summary.py
+++ b/experiments/summary.py
@@ -1,0 +1,277 @@
+"""
+Cross-run aggregator for ExperimentResult JSONL files.
+
+Reads one or more JSONL files produced by run_experiment.py (or the eventual
+agent runner) and emits:
+  * a JSON summary with per-(mode, deletion_size) aggregate metrics, and
+  * an optional Markdown table (one table per mode).
+
+This is the first cut — see issue #13. Drift-and-cross-mode comparisons live
+in the follow-up (#25). Depends only on stdlib + fields already defined in
+experiments/metrics.py (schema extended in #4).
+
+Usage:
+    python3 summary.py --inputs <glob> [--out summary.json] [--markdown summary.md]
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob as globlib
+import json
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+
+# ── Loading ───────────────────────────────────────────────────────────────────
+
+def _iter_records(paths: Iterable[Path]) -> Iterable[dict[str, Any]]:
+    """Yield one decoded dict per non-empty JSON line across all input files."""
+    for p in paths:
+        with p.open("r", encoding="utf-8") as fh:
+            for lineno, raw in enumerate(fh, start=1):
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError as exc:
+                    print(
+                        f"warning: skipping malformed line {p}:{lineno}: {exc}",
+                        file=sys.stderr,
+                    )
+
+
+def _expand_inputs(glob_pattern: str) -> list[Path]:
+    """Expand a shell-style glob into a sorted list of existing files."""
+    matches = sorted(
+        Path(m) for m in globlib.glob(glob_pattern, recursive=True)
+        if Path(m).is_file()
+    )
+    return matches
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _mean(xs: list[float]) -> float | None:
+    return round(statistics.mean(xs), 4) if xs else None
+
+
+def _pearson_r(xs: list[float], ys: list[float]) -> float | None:
+    """Pearson r between two equal-length sequences.
+
+    Formula copied verbatim from run_experiment.py (lines 466–470). Returns
+    None when there are fewer than 3 points or when the denominator is zero.
+    """
+    if len(xs) < 3 or len(xs) != len(ys):
+        return None
+    xm = sum(xs) / len(xs)
+    ym = sum(ys) / len(ys)
+    num   = sum((x - xm) * (y - ym) for x, y in zip(xs, ys))
+    denom = (sum((x - xm) ** 2 for x in xs) * sum((y - ym) ** 2 for y in ys)) ** 0.5
+    return round(num / denom, 4) if denom > 0 else None
+
+
+def _nested(rec: dict[str, Any], *path: str) -> Any:
+    """Safe nested-dict lookup; returns None if any key is missing or None."""
+    cur: Any = rec
+    for key in path:
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(key)
+        if cur is None:
+            return None
+    return cur
+
+
+# ── Aggregation ───────────────────────────────────────────────────────────────
+
+def aggregate(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Group records by (mode, deletion_size) and compute summary metrics."""
+    groups: dict[tuple[str, int], list[dict[str, Any]]] = defaultdict(list)
+    for rec in records:
+        mode = rec.get("mode", "baseline")
+        dsize = rec.get("deletion_size")
+        if dsize is None:
+            continue
+        groups[(mode, int(dsize))].append(rec)
+
+    group_summaries: list[dict[str, Any]] = []
+    for (mode, dsize), rs in sorted(groups.items()):
+        n_total = len(rs)
+        n_pass = sum(1 for r in rs if r.get("verdict") == "PASS")
+        pass_rate = round(n_pass / n_total, 4) if n_total else 0.0
+
+        inference_times = [
+            float(r["inference_time_s"]) for r in rs if r.get("inference_time_s") is not None
+        ]
+        output_tokens = [
+            float(r["output_tokens"]) for r in rs if r.get("output_tokens") is not None
+        ]
+        n_eds = [
+            float(r["normalized_edit_distance"])
+            for r in rs if r.get("normalized_edit_distance") is not None
+        ]
+
+        # Compile / VO metrics come from llm_metrics; human ratio compares LLM
+        # vs ground-truth human vo_bytes to flag suspiciously-small artifacts.
+        vo_bytes_vals: list[float] = []
+        vo_ratio_vals: list[float] = []
+        compile_time_vals: list[float] = []
+        n_assumptions_vals: list[float] = []
+        for r in rs:
+            vo = _nested(r, "llm_metrics", "vo_bytes")
+            if vo is not None:
+                vo_bytes_vals.append(float(vo))
+                human_vo = _nested(r, "human_metrics", "vo_bytes")
+                if human_vo is not None and float(human_vo) > 0:
+                    vo_ratio_vals.append(float(vo) / float(human_vo))
+            ctime = _nested(r, "llm_metrics", "compile_time_s")
+            if ctime is not None:
+                compile_time_vals.append(float(ctime))
+            nassum = _nested(r, "llm_metrics", "n_assumptions")
+            if nassum is not None:
+                n_assumptions_vals.append(float(nassum))
+
+        group_summaries.append({
+            "mode": mode,
+            "deletion_size": dsize,
+            "n_total": n_total,
+            "n_pass": n_pass,
+            "pass_rate": pass_rate,
+            "mean_inference_time_s": _mean(inference_times),
+            "mean_output_tokens": _mean(output_tokens),
+            "mean_normalized_edit_distance": _mean(n_eds),
+            "mean_vo_bytes": _mean(vo_bytes_vals),
+            "mean_vo_bytes_human_ratio": _mean(vo_ratio_vals),
+            "mean_compile_time_s": _mean(compile_time_vals),
+            "mean_n_assumptions": _mean(n_assumptions_vals),
+        })
+
+    # Per-mode Pearson r between deletion_size and pass_rate.
+    faithfulness: dict[str, float | None] = {}
+    by_mode: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for g in group_summaries:
+        by_mode[g["mode"]].append(g)
+    for mode, gs in by_mode.items():
+        xs = [float(g["deletion_size"]) for g in gs if g["n_total"] > 0]
+        ys = [float(g["pass_rate"]) for g in gs if g["n_total"] > 0]
+        faithfulness[mode] = _pearson_r(xs, ys)
+
+    return {
+        "n_total_runs": len(records),
+        "groups": group_summaries,
+        "faithfulness_correlation": faithfulness,
+    }
+
+
+# ── Rendering ─────────────────────────────────────────────────────────────────
+
+_COLUMNS: list[tuple[str, str]] = [
+    ("deletion_size",                "deletion_size"),
+    ("n_total",                      "n_total"),
+    ("n_pass",                       "n_pass"),
+    ("pass_rate",                    "pass_rate"),
+    ("mean_inference_time_s",        "mean_inference_time_s"),
+    ("mean_output_tokens",           "mean_output_tokens"),
+    ("mean_normalized_edit_distance", "mean_norm_edit_dist"),
+    ("mean_vo_bytes",                "mean_vo_bytes"),
+    ("mean_vo_bytes_human_ratio",    "mean_vo_ratio"),
+    ("mean_compile_time_s",          "mean_compile_s"),
+    ("mean_n_assumptions",           "mean_n_assumptions"),
+]
+
+
+def _fmt_cell(v: Any) -> str:
+    if v is None:
+        return "—"
+    if isinstance(v, float):
+        return f"{v:.4f}" if abs(v) < 1000 else f"{v:.1f}"
+    return str(v)
+
+
+def render_markdown(summary: dict[str, Any]) -> str:
+    """Render one Markdown table per mode plus a Pearson r block."""
+    groups_by_mode: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for g in summary["groups"]:
+        groups_by_mode[g["mode"]].append(g)
+
+    out: list[str] = []
+    out.append("# Experiment summary")
+    out.append("")
+    out.append(f"Total runs: **{summary['n_total_runs']}**")
+    out.append("")
+
+    for mode in sorted(groups_by_mode):
+        out.append(f"## mode = `{mode}`")
+        out.append("")
+        headers = [label for _, label in _COLUMNS]
+        out.append("| " + " | ".join(headers) + " |")
+        out.append("|" + "|".join(["---"] * len(headers)) + "|")
+        for g in sorted(groups_by_mode[mode], key=lambda x: x["deletion_size"]):
+            row = [_fmt_cell(g[key]) for key, _ in _COLUMNS]
+            out.append("| " + " | ".join(row) + " |")
+        r = summary["faithfulness_correlation"].get(mode)
+        out.append("")
+        out.append(f"Faithfulness correlation (Pearson r, deletion_size vs pass_rate): **{_fmt_cell(r)}**")
+        out.append("")
+
+    return "\n".join(out).rstrip() + "\n"
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def _parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="summary.py",
+        description=(
+            "Aggregate ExperimentResult JSONL files into a per-(mode, deletion_size) "
+            "summary with Pearson-r faithfulness score."
+        ),
+    )
+    p.add_argument(
+        "--inputs", required=True,
+        help="Glob pattern matching JSONL result files (e.g. 'results/**/*.jsonl').",
+    )
+    p.add_argument(
+        "--out", default=None,
+        help="Path to write the JSON summary (stdout if omitted).",
+    )
+    p.add_argument(
+        "--markdown", default=None,
+        help="Optional path to write a Markdown summary table.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+
+    paths = _expand_inputs(args.inputs)
+    if not paths:
+        print(
+            f"error: no input files matched glob {args.inputs!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    records = list(_iter_records(paths))
+    summary = aggregate(records)
+
+    rendered_json = json.dumps(summary, indent=2, sort_keys=True)
+    if args.out:
+        Path(args.out).write_text(rendered_json + "\n", encoding="utf-8")
+    else:
+        print(rendered_json)
+
+    if args.markdown:
+        Path(args.markdown).write_text(render_markdown(summary), encoding="utf-8")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/test_summary.py
+++ b/experiments/test_summary.py
@@ -1,0 +1,194 @@
+"""Tests for experiments/summary.py.
+
+Writes a tiny synthetic JSONL with 4 rows across 2 deletion_sizes (all
+mode="baseline") and exercises the CLI via subprocess, then asserts the JSON
+summary contains the expected groups with correct pass_rate and a finite
+Pearson r.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+
+HERE = Path(__file__).parent
+
+
+def _write_synthetic_jsonl(path: Path) -> None:
+    """3+ deletion_sizes are needed for Pearson r to be computed."""
+    rows = [
+        # deletion_size=3: 2/2 pass → pass_rate 1.0
+        {
+            "challenge_id": "c-a",
+            "declaration": "foo",
+            "deletion_size": 3,
+            "condition": "B",
+            "verdict": "PASS",
+            "inference_time_s": 1.0,
+            "output_tokens": 100,
+            "mode": "baseline",
+            "llm_metrics": {
+                "tactic_count": 5, "automation_ratio": 0.4, "unique_tactic_types": 3,
+                "max_bullet_depth": 0, "proof_chars": 50, "proof_lines": 3,
+                "ends_with_admitted": False,
+                "vo_bytes": 1000, "compile_time_s": 0.5, "n_assumptions": 0,
+            },
+            "human_metrics": {
+                "tactic_count": 5, "automation_ratio": 0.4, "unique_tactic_types": 3,
+                "max_bullet_depth": 0, "proof_chars": 50, "proof_lines": 3,
+                "ends_with_admitted": False,
+                "vo_bytes": 1000, "compile_time_s": 0.5, "n_assumptions": 0,
+            },
+            "normalized_edit_distance": 0.0,
+        },
+        {
+            "challenge_id": "c-b",
+            "declaration": "bar",
+            "deletion_size": 3,
+            "condition": "B",
+            "verdict": "PASS",
+            "inference_time_s": 2.0,
+            "output_tokens": 200,
+            "mode": "baseline",
+            "llm_metrics": {
+                "tactic_count": 4, "automation_ratio": 0.25, "unique_tactic_types": 2,
+                "max_bullet_depth": 0, "proof_chars": 40, "proof_lines": 2,
+                "ends_with_admitted": False,
+                "vo_bytes": 800, "compile_time_s": 0.4, "n_assumptions": 0,
+            },
+        },
+        # deletion_size=7: 1/2 pass → pass_rate 0.5
+        {
+            "challenge_id": "c-c",
+            "declaration": "baz",
+            "deletion_size": 7,
+            "condition": "B",
+            "verdict": "PASS",
+            "inference_time_s": 3.0,
+            "output_tokens": 300,
+            "mode": "baseline",
+            "llm_metrics": {
+                "tactic_count": 6, "automation_ratio": 0.5, "unique_tactic_types": 4,
+                "max_bullet_depth": 1, "proof_chars": 70, "proof_lines": 4,
+                "ends_with_admitted": False,
+                "vo_bytes": 1200, "compile_time_s": 0.7, "n_assumptions": 1,
+            },
+        },
+        {
+            "challenge_id": "c-d",
+            "declaration": "qux",
+            "deletion_size": 7,
+            "condition": "B",
+            "verdict": "FAIL",
+            "inference_time_s": 4.0,
+            "output_tokens": 400,
+            "mode": "baseline",
+        },
+        # deletion_size=15: 0/1 pass → pass_rate 0.0
+        {
+            "challenge_id": "c-e",
+            "declaration": "quux",
+            "deletion_size": 15,
+            "condition": "B",
+            "verdict": "FAIL",
+            "inference_time_s": 5.0,
+            "output_tokens": 500,
+            "mode": "baseline",
+        },
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+
+def test_summary_cli(tmp_path: Path) -> None:
+    tmpfile = tmp_path / "runs.jsonl"
+    _write_synthetic_jsonl(tmpfile)
+
+    out_json = tmp_path / "summary.json"
+    out_md = tmp_path / "summary.md"
+
+    result = subprocess.run(
+        [
+            sys.executable, str(HERE / "summary.py"),
+            "--inputs", str(tmpfile),
+            "--out", str(out_json),
+            "--markdown", str(out_md),
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 0, f"summary.py failed: {result.stderr}"
+
+    summary = json.loads(out_json.read_text())
+
+    # n_total_runs should be 5
+    assert summary["n_total_runs"] == 5
+
+    # Check groups: 3 (mode, deletion_size) groups expected
+    groups = {(g["mode"], g["deletion_size"]): g for g in summary["groups"]}
+    assert ("baseline", 3) in groups
+    assert ("baseline", 7) in groups
+    assert ("baseline", 15) in groups
+
+    # Pass rates
+    assert groups[("baseline", 3)]["n_total"] == 2
+    assert groups[("baseline", 3)]["n_pass"] == 2
+    assert groups[("baseline", 3)]["pass_rate"] == 1.0
+
+    assert groups[("baseline", 7)]["n_total"] == 2
+    assert groups[("baseline", 7)]["n_pass"] == 1
+    assert groups[("baseline", 7)]["pass_rate"] == 0.5
+
+    assert groups[("baseline", 15)]["n_total"] == 1
+    assert groups[("baseline", 15)]["n_pass"] == 0
+    assert groups[("baseline", 15)]["pass_rate"] == 0.0
+
+    # Extended metrics only computed where llm_metrics exist
+    g3 = groups[("baseline", 3)]
+    assert g3["mean_vo_bytes"] is not None
+    # (1000 + 800) / 2 = 900
+    assert abs(g3["mean_vo_bytes"] - 900.0) < 1e-6
+    # Only the first record has human_metrics.vo_bytes, ratio = 1000/1000 = 1.0
+    assert g3["mean_vo_bytes_human_ratio"] is not None
+    assert abs(g3["mean_vo_bytes_human_ratio"] - 1.0) < 1e-6
+    assert g3["mean_normalized_edit_distance"] == 0.0
+
+    # Pearson r: with deletion_sizes [3, 7, 15] and pass_rates [1.0, 0.5, 0.0]
+    # correlation should be strongly negative and finite.
+    faith = summary["faithfulness_correlation"]
+    assert "baseline" in faith
+    r = faith["baseline"]
+    assert r is not None
+    assert math.isfinite(r)
+    assert r < 0, f"expected negative correlation, got {r}"
+
+    # Markdown file written and contains the mode header.
+    md = out_md.read_text()
+    assert "mode = `baseline`" in md
+    assert "Faithfulness correlation" in md
+
+
+def test_summary_no_inputs(tmp_path: Path) -> None:
+    """Glob matches nothing → clean error exit code 1, no crash."""
+    result = subprocess.run(
+        [
+            sys.executable, str(HERE / "summary.py"),
+            "--inputs", str(tmp_path / "does_not_exist_*.jsonl"),
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 1
+    assert "no input files" in result.stderr.lower()
+
+
+def test_summary_help() -> None:
+    result = subprocess.run(
+        [sys.executable, str(HERE / "summary.py"), "--help"],
+        capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 0
+    assert "--inputs" in result.stdout
+    assert "--out" in result.stdout
+    assert "--markdown" in result.stdout


### PR DESCRIPTION
## Summary
- New `experiments/summary.py` CLI: `--inputs <glob> [--out summary.json] [--markdown summary.md]`.
- For each `(mode, deletion_size)` group, emits `n_total`, `n_pass`, `pass_rate`, `mean_inference_time_s`, `mean_output_tokens`, `mean_normalized_edit_distance`, `mean_vo_bytes`, `mean_vo_bytes_human_ratio`, `mean_compile_time_s`, `mean_n_assumptions`.
- Per-mode `faithfulness_correlation` Pearson r between `deletion_size` and `pass_rate` — formula copied verbatim from `run_experiment.py:466-470` per the issue.
- Markdown output is one table per mode. Depends only on stdlib.
- `mode="agent"` groups are expected to be empty in this iteration; drift/cross-mode comparisons live in follow-up #25.

## Test plan
- [x] `cd experiments && uv run pytest test_summary.py -v` (3 tests: CLI happy path, empty-glob clean-error, `--help`). All pass.
- [x] Manual: `uv run python summary.py --inputs "results/**/*.jsonl" --markdown /tmp/s.md` → exits 1 with `error: no input files matched glob 'results/**/*.jsonl'` (no crash).
- [x] Manual: ran against the existing `experiments/experiment-results.jsonl`; produced JSON + Markdown with a single `baseline` group and `—` for Pearson r (<3 deletion sizes, as expected).

Closes #13.

Generated with [Claude Code](https://claude.com/claude-code)