### PR TITLE
#17 run_agent_experiment.py: typer CLI for agent pipeline

### DIFF
--- a/experiments/run_agent_experiment.py
+++ b/experiments/run_agent_experiment.py
@@ -1,0 +1,395 @@
+"""Typer CLI wrapper around ``agent/runner.py``.
+
+This is the user-facing counterpart of ``run_experiment.py``. It mirrors that
+file's structure — same slot discovery, same results-dir resolution, same
+summary print-out — but the per-slot work is delegated to ``agent.runner.run_one``
+rather than the single-shot Anthropic call.
+
+Two modes of slot discovery:
+
+1. If ``RUN_CONFIG_JSON`` is set (the per-container orchestrator case), the
+   JSON is parsed and its ``slots`` list is used verbatim. This is the path
+   taken inside the per-SHA containers spun up by ``orchestrate/lib.sh``.
+2. Otherwise, slots are discovered by walking ``admitted-proofs/`` (condition A)
+   and ``experiments3/`` (condition B) under the experiments directory, the
+   same way ``run_experiment.py`` does.
+
+In both cases results are appended one-per-line to ``<results_dir>/agent.jsonl``
+with ``mode="agent"``, matching the baseline's schema.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import traceback
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import typer
+from dotenv import load_dotenv
+
+# Walk up from the script's directory to find .env, same as run_experiment.py.
+_script_dir = Path(__file__).resolve().parent
+for _p in (_script_dir, *_script_dir.parents):
+    if (_p / ".env").exists():
+        load_dotenv(_p / ".env")
+        break
+
+sys.path.insert(0, str(_script_dir))
+
+from agent.runner import run_one
+from metrics import (
+    DeletionConditionSummary,
+    ExperimentResult,
+    ExperimentSummary,
+)
+
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+BASE = Path(__file__).parent
+EXP_A = BASE / "admitted-proofs"
+EXP_B = BASE / "experiments3"
+FIAT_CRYPTO_DIR = Path(os.environ.get("FIAT_CRYPTO_DIR", "/data/fiat-crypto"))
+
+
+def _resolve_results_dir(explicit: str | None) -> Path:
+    """Return the per-run results directory.
+
+    If ``explicit`` is set, it is honoured verbatim. Otherwise, inside a
+    container (detected via ``/.dockerenv`` or ``RUNNING_IN_DOCKER``) this
+    resolves to ``/results/${RUN_ID}``; out of container it lands under
+    ``experiments/results/${RUN_ID}``. ``RUN_ID`` defaults to a timestamp so
+    ad-hoc local runs still get their own directory.
+    """
+    if explicit:
+        return Path(explicit)
+    run_id = os.environ.get("RUN_ID") or time.strftime("%Y%m%d-%H%M%S")
+    in_container = Path("/.dockerenv").exists() or bool(os.environ.get("RUNNING_IN_DOCKER"))
+    root = Path("/results") if in_container else (BASE / "results")
+    return root / run_id
+
+
+# ── Slot discovery ────────────────────────────────────────────────────────────
+
+class _Slot:
+    """Lightweight record describing one (slot × deletion_size) unit of work."""
+
+    __slots__ = ("slot_dir", "condition", "deletion_size", "challenge_file")
+
+    def __init__(
+        self,
+        slot_dir: Path,
+        condition: str,
+        deletion_size: int,
+        challenge_file: str,
+    ) -> None:
+        self.slot_dir = slot_dir
+        self.condition = condition
+        self.deletion_size = deletion_size
+        self.challenge_file = challenge_file
+
+
+def _slots_from_run_config(raw_config: str) -> tuple[list[_Slot], str | None, int | None, Path | None]:
+    """Parse ``RUN_CONFIG_JSON`` into ``(slots, model, max_turns, repo_dir)``.
+
+    The shape matches ``agent/runner.py:main``'s expectations. Any of
+    ``model``, ``max_turns``, ``repo_dir`` may be absent, in which case
+    ``None`` is returned and the CLI-level defaults take over.
+    """
+    config = json.loads(raw_config)
+    raw_slots: list[dict[str, Any]] = config.get("slots") or []
+    slots: list[_Slot] = []
+    for entry in raw_slots:
+        if "slot_dir" in entry:
+            slot_dir = Path(entry["slot_dir"])
+        else:
+            condition = entry["condition"]
+            slot_name = entry["slot"]
+            sub = "admitted-proofs" if condition == "A" else "experiments3"
+            slot_dir = BASE / sub / slot_name
+        condition = entry["condition"]
+        deletion_size = int(entry.get("deletion_size", -1))
+        challenge_file = entry.get("challenge_file") or (
+            "challenge.v" if deletion_size == -1 else f"challenge{deletion_size}.v"
+        )
+        slots.append(_Slot(slot_dir, condition, deletion_size, challenge_file))
+    cfg_model = config.get("model")
+    cfg_max_turns = config.get("max_turns")
+    cfg_repo_dir = config.get("repo_dir")
+    return (
+        slots,
+        cfg_model if isinstance(cfg_model, str) else None,
+        int(cfg_max_turns) if cfg_max_turns is not None else None,
+        Path(cfg_repo_dir) if cfg_repo_dir else None,
+    )
+
+
+def _discover_slots(
+    max_challenges: int | None,
+    deletion_sizes: list[int],
+    skip_a: bool,
+    skip_b: bool,
+    only: str | None,
+) -> list[_Slot]:
+    """Walk the on-disk ``admitted-proofs/`` and ``experiments3/`` dirs.
+
+    Applies the ``--max-challenges`` cap per (condition, deletion_size) slice
+    and the ``--only`` substring filter, mirroring ``run_experiment.run_condition``.
+    """
+    slots: list[_Slot] = []
+
+    if not skip_b and EXP_B.exists():
+        for n in deletion_sizes:
+            count = 0
+            for slot in sorted(EXP_B.iterdir()):
+                if not slot.is_dir():
+                    continue
+                if only and only not in slot.name:
+                    continue
+                chal = slot / f"challenge{n}.v"
+                meta = slot / "meta.json"
+                if not chal.exists() or not meta.exists():
+                    continue
+                if max_challenges is not None and count >= max_challenges:
+                    break
+                slots.append(_Slot(slot, "B", n, f"challenge{n}.v"))
+                count += 1
+
+    if not skip_a and EXP_A.exists():
+        count = 0
+        for slot in sorted(EXP_A.iterdir()):
+            if not slot.is_dir():
+                continue
+            if only and only not in slot.name:
+                continue
+            chal = slot / "challenge.v"
+            meta = slot / "meta.json"
+            if not chal.exists() or not meta.exists():
+                continue
+            if max_challenges is not None and count >= max_challenges:
+                break
+            slots.append(_Slot(slot, "A", -1, "challenge.v"))
+            count += 1
+
+    return slots
+
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+def _summarise(results: list[ExperimentResult], model: str) -> ExperimentSummary:
+    """Aggregate per-row results into an ``ExperimentSummary``.
+
+    Byte-compatible with ``run_experiment._summarise`` but emits the Pearson r
+    under the ``"agent"`` key in ``faithfulness_by_mode`` (baseline's runner
+    emits under ``"baseline"``).
+    """
+    by_cond: dict[tuple[str, int], list[ExperimentResult]] = defaultdict(list)
+    for r in results:
+        by_cond[(r.condition, r.deletion_size)].append(r)
+
+    conditions: list[DeletionConditionSummary] = []
+    for (cond, dsize), rs in sorted(by_cond.items()):
+        n_pass = sum(1 for r in rs if r.verdict == "PASS")
+        n_fail = sum(1 for r in rs if r.verdict == "FAIL")
+        n_err = sum(1 for r in rs if r.verdict in ("TIMEOUT", "ERROR"))
+        n_total = len(rs)
+        pass_rate = round(n_pass / n_total, 4) if n_total else 0.0
+        teds = [r.normalized_edit_distance for r in rs if r.normalized_edit_distance is not None]
+        turns = [r.agent_n_turns for r in rs if r.agent_n_turns is not None]
+        conditions.append(DeletionConditionSummary(
+            deletion_size=dsize,
+            condition=cond,  # type: ignore[arg-type]
+            n_challenges=n_total,
+            n_pass=n_pass,
+            n_fail=n_fail,
+            n_error_or_timeout=n_err,
+            pass_rate=pass_rate,
+            mean_inference_time_s=round(statistics.mean(r.inference_time_s for r in rs), 2),
+            mean_output_tokens=round(statistics.mean(r.output_tokens for r in rs), 1),
+            mean_tactic_edit_distance=round(statistics.mean(
+                r.tactic_edit_distance for r in rs if r.tactic_edit_distance is not None
+            ), 2) if any(r.tactic_edit_distance is not None for r in rs) else None,
+            mean_normalized_edit_distance=round(statistics.mean(teds), 4) if teds else None,
+            mean_agent_n_turns=round(statistics.mean(turns), 2) if turns else None,
+        ))
+
+    faith_by_mode: dict[str, float | None] = {}
+    b_conds = [c for c in conditions if c.condition == "B" and c.n_challenges > 0]
+    faith_r: float | None = None
+    if len(b_conds) >= 3:
+        xs = [float(c.deletion_size) for c in b_conds]
+        ys = [c.pass_rate for c in b_conds]
+        xm = sum(xs) / len(xs)
+        ym = sum(ys) / len(ys)
+        num = sum((x - xm) * (y - ym) for x, y in zip(xs, ys))
+        denom = (sum((x - xm) ** 2 for x in xs) * sum((y - ym) ** 2 for y in ys)) ** 0.5
+        faith_r = round(num / denom, 4) if denom > 0 else None
+    faith_by_mode["agent"] = faith_r
+
+    return ExperimentSummary(
+        model=model,
+        date=time.strftime("%Y-%m-%d %H:%M:%S"),
+        n_total_runs=len(results),
+        conditions=conditions,
+        faithfulness_by_mode=faith_by_mode,
+    )
+
+
+def _log_error(results_dir: Path, slot: _Slot, exc: BaseException) -> None:
+    """Append a per-slot traceback to ``<results_dir>/run.log``."""
+    logfile = results_dir / "run.log"
+    logfile.parent.mkdir(parents=True, exist_ok=True)
+    with logfile.open("a") as fh:
+        fh.write(
+            f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] slot={slot.slot_dir} "
+            f"condition={slot.condition} deletion_size={slot.deletion_size} failed\n"
+        )
+        fh.write("".join(traceback.format_exception(type(exc), exc, exc.__traceback__)))
+        fh.write("\n")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def _main(
+    max_challenges: int = typer.Option(
+        3, "--max-challenges", "-n",
+        help="Max challenges per condition/deletion-size (0 = all).",
+    ),
+    deletion_sizes: str = typer.Option(
+        "3,5,7,10,15",
+        "--deletion-sizes",
+        help="Comma-separated Condition B deletion sizes to run.",
+    ),
+    skip_a: bool = typer.Option(False, "--skip-a", help="Skip full-proof condition."),
+    skip_b: bool = typer.Option(False, "--skip-b", help="Skip partial-deletion conditions."),
+    only: str = typer.Option("", "--only", help="Only run challenges whose dir name contains this substring."),
+    model: str = typer.Option(
+        "anthropic:claude-sonnet-4-6",
+        "--model",
+        help="Model identifier passed to pydantic-ai (e.g. 'anthropic:claude-sonnet-4-6').",
+    ),
+    max_turns: int = typer.Option(
+        20, "--max-turns",
+        help="Maximum pydantic-ai request budget per slot.",
+    ),
+    results_dir: str = typer.Option(
+        "", "--results-dir",
+        help="Directory for agent.jsonl output; defaults to /results/${RUN_ID} in-container "
+             "or experiments/results/${RUN_ID} otherwise.",
+    ),
+) -> None:
+    limit = max_challenges if max_challenges > 0 else None
+    only_filter = only or None
+    b_sizes = [int(s.strip()) for s in deletion_sizes.split(",") if s.strip()]
+
+    out_dir = _resolve_results_dir(results_dir or None)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "agent.jsonl"
+
+    # Slot discovery: RUN_CONFIG_JSON short-circuits filesystem walking.
+    raw_config = os.environ.get("RUN_CONFIG_JSON")
+    cfg_repo_dir: Path | None = None
+    if raw_config:
+        slots, cfg_model, cfg_max_turns, cfg_repo_dir = _slots_from_run_config(raw_config)
+        if cfg_model:
+            model = cfg_model
+        if cfg_max_turns is not None:
+            max_turns = cfg_max_turns
+    else:
+        slots = _discover_slots(limit, b_sizes, skip_a, skip_b, only_filter)
+
+    repo_dir = cfg_repo_dir or FIAT_CRYPTO_DIR
+
+    print("=" * 64)
+    print("AGENT PROOF EXPERIMENT — pydantic-ai ReAct loop")
+    print(f"Model         : {model}")
+    print(f"Max turns     : {max_turns}")
+    print(f"Max challenges: {limit or 'all'}")
+    print(f"B sizes       : {b_sizes}")
+    print(f"Results       : {out_path}")
+    print(f"Repo dir      : {repo_dir}")
+    print(f"N slots       : {len(slots)}")
+    print(f"Source        : {'RUN_CONFIG_JSON' if raw_config else 'filesystem discovery'}")
+    print(f"Date          : {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    print("=" * 64, flush=True)
+
+    all_results: list[ExperimentResult] = []
+
+    with out_path.open("a") as fh:
+        for slot in slots:
+            print(
+                f"\n[{slot.condition}{'' if slot.deletion_size < 0 else slot.deletion_size}] "
+                f"{slot.slot_dir.name} (deletion={slot.deletion_size})",
+                flush=True,
+            )
+            try:
+                result = run_one(
+                    slot_dir=slot.slot_dir,
+                    condition=slot.condition,
+                    deletion_size=slot.deletion_size,
+                    challenge_file=slot.challenge_file,
+                    repo_dir=repo_dir,
+                    model=model,
+                    max_turns=max_turns,
+                )
+            except Exception as e:  # noqa: BLE001 - per-slot isolation
+                _log_error(out_dir, slot, e)
+                print(f"  ERROR: {type(e).__name__}: {e}", flush=True)
+                continue
+            fh.write(result.model_dump_json() + "\n")
+            fh.flush()
+            all_results.append(result)
+            print(
+                f"  verdict={result.verdict} turns={result.agent_n_turns} "
+                f"time={result.inference_time_s}s tokens={result.output_tokens}",
+                flush=True,
+            )
+
+    # Summary
+    summary = _summarise(all_results, model)
+
+    print("\n" + "=" * 64)
+    print("SUMMARY")
+    print("=" * 64)
+    for c in summary.conditions:
+        print(
+            f"Condition {c.condition} (deletion={c.deletion_size}): "
+            f"{c.n_pass}/{c.n_challenges} PASS  "
+            f"[pass_rate={c.pass_rate:.0%}  "
+            f"mean_time={c.mean_inference_time_s}s  "
+            f"mean_tokens={c.mean_output_tokens:.0f}  "
+            f"mean_turns={c.mean_agent_n_turns}  "
+            f"mean_ned={c.mean_normalized_edit_distance}]"
+        )
+
+    agent_r = summary.faithfulness_by_mode.get("agent")
+    if agent_r is not None:
+        print(
+            f"\nFaithfulness (Pearson r, deletion_size vs pass_rate): {agent_r:+.4f}"
+        )
+        interp = (
+            "← strongly negative: eval is faithful (harder = worse)"
+            if agent_r < -0.5 else
+            "← weak correlation: possible memorization or insufficient data"
+        )
+        print(f"  {interp}")
+
+    summary_path = out_dir / "agent-summary.json"
+    summary_path.write_text(summary.model_dump_json(indent=2))
+    print(f"\nResults    → {out_path}  ({len(all_results)} records)")
+    print(f"Summary    → {summary_path}")
+
+
+def main() -> None:
+    """Console-script entry point (wired to ``eval-agent`` in pyproject.toml)."""
+    typer.run(_main)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/tests/test_run_agent_experiment.py
+++ b/experiments/tests/test_run_agent_experiment.py
@@ -1,0 +1,252 @@
+"""Tests for ``experiments/run_agent_experiment.py``.
+
+The CLI is pure glue — slot discovery + file plumbing — so these tests stub
+``agent.runner.run_one`` with a canned ``ExperimentResult`` and assert that:
+
+* The CLI renders its options (``--help``).
+* Filesystem discovery finds the synthetic slot and writes a JSONL row.
+* ``RUN_CONFIG_JSON`` short-circuits discovery (a sentinel on-disk slot that
+  the filesystem walker *would* pick up is NOT used when the env var is set).
+
+No network and no Coq toolchain touched.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+import run_agent_experiment
+from metrics import ExperimentResult
+
+
+def _build_cli_app() -> typer.Typer:
+    """Wrap ``_main`` as a Typer app so CliRunner can drive it."""
+    app = typer.Typer()
+    app.command()(run_agent_experiment._main)
+    return app
+
+
+def _canned_result(slot_name: str, deletion_size: int, condition: str = "B") -> ExperimentResult:
+    """Build a minimal ``mode="agent"`` row the CLI can serialize."""
+    return ExperimentResult(
+        challenge_id=slot_name,
+        declaration="Foo.bar",
+        deletion_size=deletion_size,
+        condition=condition,  # type: ignore[arg-type]
+        verdict="PASS",
+        inference_time_s=1.23,
+        output_tokens=42,
+        mode="agent",
+        agent_n_turns=3,
+        agent_give_up_reason="compile_success",
+        agent_total_input_tokens=100,
+        agent_total_output_tokens=42,
+    )
+
+
+def _write_slot(slot_dir: Path, deletion_size: int, condition: str = "B") -> None:
+    """Materialize the minimum file layout the walker looks for."""
+    slot_dir.mkdir(parents=True, exist_ok=True)
+    (slot_dir / "meta.json").write_text(json.dumps({
+        "declaration": "Foo.bar",
+        "file_path": "src/Foo.v",
+        "commit_hash": "deadbeefdeadbeef",
+    }))
+    challenge_name = "challenge.v" if deletion_size == -1 else f"challenge{deletion_size}.v"
+    (slot_dir / challenge_name).write_text("Lemma bar : True. Proof. Admitted.\n")
+
+
+@pytest.fixture()
+def cli_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Point EXP_A/EXP_B at ``tmp_path`` so filesystem discovery is hermetic."""
+    exp_a = tmp_path / "admitted-proofs"
+    exp_b = tmp_path / "experiments3"
+    exp_a.mkdir()
+    exp_b.mkdir()
+    monkeypatch.setattr(run_agent_experiment, "EXP_A", exp_a)
+    monkeypatch.setattr(run_agent_experiment, "EXP_B", exp_b)
+    # Make sure no stray RUN_CONFIG_JSON leaks in from the host shell.
+    monkeypatch.delenv("RUN_CONFIG_JSON", raising=False)
+    return exp_a, exp_b
+
+
+def test_help_renders() -> None:
+    """`eval-agent --help` renders every documented option."""
+    runner = CliRunner()
+    result = runner.invoke(_build_cli_app(), ["--help"])
+    assert result.exit_code == 0
+    out = result.output
+    for flag in (
+        "--max-challenges",
+        "--deletion-sizes",
+        "--skip-a",
+        "--skip-b",
+        "--only",
+        "--model",
+        "--max-turns",
+        "--results-dir",
+    ):
+        assert flag in out, f"missing flag in --help output: {flag}"
+
+
+def test_discovers_slots_and_writes_jsonl(
+    cli_env: tuple[Path, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Filesystem discovery → run_one stub → two JSONL lines with mode=agent."""
+    exp_a, exp_b = cli_env
+
+    # Two slots under Condition B, deletion_size=3 (the first size in the default list).
+    slot_a = exp_b / "01-alpha"
+    slot_b = exp_b / "02-beta"
+    _write_slot(slot_a, 3, condition="B")
+    _write_slot(slot_b, 3, condition="B")
+
+    calls: list[dict] = []
+
+    def fake_run_one(
+        slot_dir,
+        condition,
+        deletion_size,
+        challenge_file,
+        repo_dir,
+        model,
+        max_turns,
+    ) -> ExperimentResult:
+        calls.append({
+            "slot_dir": Path(slot_dir),
+            "condition": condition,
+            "deletion_size": deletion_size,
+            "challenge_file": challenge_file,
+            "model": model,
+            "max_turns": max_turns,
+        })
+        return _canned_result(Path(slot_dir).name, deletion_size, condition)
+
+    monkeypatch.setattr(run_agent_experiment, "run_one", fake_run_one)
+
+    results_dir = tmp_path / "results"
+    runner = CliRunner()
+    result = runner.invoke(
+        _build_cli_app(),
+        [
+            "--deletion-sizes", "3",
+            "--skip-a",
+            "--max-challenges", "5",
+            "--results-dir", str(results_dir),
+            "--model", "test:dummy",
+            "--max-turns", "7",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    # Both slots got dispatched once each.
+    assert len(calls) == 2
+    assert {c["slot_dir"].name for c in calls} == {slot_a.name, slot_b.name}
+    # CLI options flowed through to run_one.
+    assert all(c["model"] == "test:dummy" for c in calls)
+    assert all(c["max_turns"] == 7 for c in calls)
+    assert all(c["condition"] == "B" and c["deletion_size"] == 3 for c in calls)
+
+    jsonl = results_dir / "agent.jsonl"
+    assert jsonl.exists(), "agent.jsonl must be written"
+    lines = [ln for ln in jsonl.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 2
+    for ln in lines:
+        row = json.loads(ln)
+        assert row["mode"] == "agent"
+        assert row["verdict"] == "PASS"
+
+
+def test_run_config_json_short_circuits_discovery(
+    cli_env: tuple[Path, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When RUN_CONFIG_JSON is set, the CLI uses its slots verbatim, ignoring the on-disk walker."""
+    exp_a, exp_b = cli_env
+
+    # This "decoy" slot WOULD be picked up by filesystem discovery — asserting
+    # it isn't touched proves the short-circuit worked.
+    decoy = exp_b / "99-decoy"
+    _write_slot(decoy, 3, condition="B")
+
+    # The synthetic slot we *do* want to run lives outside EXP_A/EXP_B so it
+    # could only reach run_one through RUN_CONFIG_JSON.
+    synth = tmp_path / "synthetic-slot"
+    _write_slot(synth, -1, condition="A")
+
+    calls: list[dict] = []
+
+    def fake_run_one(
+        slot_dir,
+        condition,
+        deletion_size,
+        challenge_file,
+        repo_dir,
+        model,
+        max_turns,
+    ) -> ExperimentResult:
+        calls.append({
+            "slot_dir": Path(slot_dir),
+            "condition": condition,
+            "deletion_size": deletion_size,
+            "model": model,
+            "max_turns": max_turns,
+            "repo_dir": Path(repo_dir),
+        })
+        return _canned_result(Path(slot_dir).name, deletion_size, condition)
+
+    monkeypatch.setattr(run_agent_experiment, "run_one", fake_run_one)
+
+    config = {
+        "run_id": "rcj-test",
+        "model": "config:model",
+        "max_turns": 9,
+        "repo_dir": str(tmp_path / "fake-repo"),
+        "slots": [
+            {
+                "slot_dir": str(synth),
+                "condition": "A",
+                "deletion_size": -1,
+                "challenge_file": "challenge.v",
+            },
+        ],
+    }
+    monkeypatch.setenv("RUN_CONFIG_JSON", json.dumps(config))
+
+    results_dir = tmp_path / "results-rcj"
+    runner = CliRunner()
+    # Pass CLI flags that RUN_CONFIG_JSON should override (model, max_turns).
+    result = runner.invoke(
+        _build_cli_app(),
+        [
+            "--results-dir", str(results_dir),
+            "--model", "cli:ignored",
+            "--max-turns", "2",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    # Exactly one call, and it's the synthetic slot — NOT the decoy.
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["slot_dir"] == synth
+    assert call["slot_dir"].name != decoy.name
+    # Config values won over CLI flags.
+    assert call["model"] == "config:model"
+    assert call["max_turns"] == 9
+    assert call["repo_dir"] == tmp_path / "fake-repo"
+
+    jsonl = results_dir / "agent.jsonl"
+    lines = [ln for ln in jsonl.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 1
+    row = json.loads(lines[0])
+    assert row["mode"] == "agent"
+    assert row["challenge_id"] == synth.name


### PR DESCRIPTION
## Summary
- New `experiments/run_agent_experiment.py`: typer CLI wrapping `agent/runner.run_one`, mirroring `run_experiment.py`'s structure (slot discovery, results-dir resolution, summary print-out).
- Supports two slot-discovery paths: `RUN_CONFIG_JSON` env var (per-container orchestrator) takes precedence; otherwise walks `admitted-proofs/` + `experiments3/` the same way as the baseline runner.
- Writes one `ExperimentResult` per line to `${results_dir}/agent.jsonl` with `mode="agent"`, plus an `agent-summary.json` with per-condition pass-rates and the agent-mode Pearson faithfulness score.
- `eval-agent = "run_agent_experiment:main"` was already registered in `experiments/pyproject.toml` by issue #22, so no pyproject change is needed.

## Test plan
- [x] `cd experiments && uv run python -c "import run_agent_experiment"` — no ImportError.
- [x] `cd experiments && uv run eval-agent --help` — renders all eight options.
- [x] New `experiments/tests/test_run_agent_experiment.py` (3 tests): `--help` rendering; monkeypatched `run_one` over two synthetic slots produces two JSONL lines with `mode="agent"`; `RUN_CONFIG_JSON` short-circuits filesystem discovery and overrides CLI model/max_turns.
- [x] `cd experiments && uv run pytest -v` — 40 passed (37 pre-existing + 3 new).

Closes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)