### PR TITLE
#23 orchestrate/gen-compose.py: per-run compose.yml generator

### DIFF
--- a/experiments/orchestrate/gen-compose.py
+++ b/experiments/orchestrate/gen-compose.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Generate a per-run docker compose.yml for the proof-eval pipeline.
+
+Emits one service per fiat-crypto SHA plus one named volume per SHA, so
+re-runs against the same SHA accumulate in the same on-disk volume
+(separated by ``/results/<run_id>/`` inside). Snapshotted into
+``experiments/results/<run_id>/compose.yml`` so every run is reproducible
+from the file alone.
+
+Stdlib only. We render YAML by string templating rather than pulling in
+PyYAML -- the emitted shape is small and fixed, and we validate the
+output with ``docker compose config --quiet`` afterwards.
+
+CLI
+---
+    python3 gen-compose.py \
+        --run-id <id> \
+        --mode <baseline|agent|both> \
+        --shas <sha1,sha2,...> \
+        [--out <path>] \
+        [--skip-validate]
+
+Default ``--out`` is ``experiments/results/<run_id>/compose.yml`` (relative
+to the repo root, derived from this file's location).
+
+Design notes
+------------
+- Each service's ``RUN_CONFIG_JSON`` is produced by sourcing
+  ``experiments/orchestrate/lib.sh`` and calling ``run_config_json <sha>``
+  in a subprocess. We don't re-implement the logic here; if a SHA has no
+  matching meta.json the helper returns an empty ``slots`` list, which is
+  a legitimate (if unusual) state -- we pass it through.
+- The literal string ``${ANTHROPIC_API_KEY}`` is emitted into the YAML so
+  that ``docker compose`` performs the env interpolation at launch rather
+  than us baking the value into an artifact that may be committed.
+- YAML anchors (``x-defaults: &defaults``) deduplicate the ``restart``
+  field and the host-experiments volume mount; per-service fields that
+  vary (image, container_name, environment, command) are set inline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+# The per-container command fragments. We embed them as f-strings later.
+# Inside the container, /results is the named volume, and /work is the
+# checkout baked by docker/commit.Dockerfile. The outer entry point
+# (``_command_for_mode`` below) handles mkdir/cd once; these fragments
+# only carry the per-mode runner invocation.
+_RUN_BASELINE = (
+    'uv run eval-baseline --run-id {run_id} '
+    '--out /results/{run_id}/baseline.jsonl'
+)
+_RUN_AGENT = (
+    'uv run eval-agent --run-id {run_id} '
+    '--out /results/{run_id}/agent.jsonl'
+)
+
+
+def _repo_root() -> Path:
+    """Return the repo root, derived from this file's location.
+
+    This file lives at ``<repo>/experiments/orchestrate/gen-compose.py``,
+    so the repo root is two parents up.
+    """
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def _sha_prefix(sha: str) -> str:
+    """First 8 chars of a SHA, lowercased. Short enough for container names,
+    long enough to be practically unique across a single run's targets."""
+    return sha.strip().lower()[:8]
+
+
+def _command_for_mode(mode: str, run_id: str) -> str:
+    """Build the bash -lc command string for the given mode.
+
+    ``mkdir -p /results/<run_id> && cd /work`` is the shared prelude;
+    the per-mode suffix chains one or both runners with ``&&``.
+    """
+    prelude = f"mkdir -p /results/{run_id} && cd /work"
+    if mode == "baseline":
+        runners = _RUN_BASELINE.format(run_id=run_id)
+    elif mode == "agent":
+        runners = _RUN_AGENT.format(run_id=run_id)
+    elif mode == "both":
+        runners = (
+            _RUN_BASELINE.format(run_id=run_id)
+            + " && "
+            + _RUN_AGENT.format(run_id=run_id)
+        )
+    else:
+        raise ValueError(f"unknown mode: {mode!r}")
+    return f"{prelude} && {runners}"
+
+
+def _run_config_json_for(sha: str, lib_sh: Path) -> str:
+    """Invoke ``run_config_json <sha>`` from lib.sh, return stdout (trimmed).
+
+    We compact the JSON to a single line with ``json.loads`` + ``json.dumps``
+    so it embeds cleanly in YAML without multi-line-string gymnastics.
+    """
+    if not lib_sh.is_file():
+        raise FileNotFoundError(f"lib.sh not found at {lib_sh}")
+    result = subprocess.run(
+        ["bash", "-c", f'source "{lib_sh}" && run_config_json "{sha}"'],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"run_config_json({sha!r}) failed with exit code "
+            f"{result.returncode}: {result.stderr.strip()}"
+        )
+    raw = result.stdout.strip()
+    if not raw:
+        raise RuntimeError(
+            f"run_config_json({sha!r}) produced no output "
+            f"(is the SHA present in any meta.json?)"
+        )
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"run_config_json({sha!r}) produced invalid JSON: {exc}"
+        ) from exc
+    return json.dumps(parsed, separators=(",", ":"))
+
+
+def _yaml_escape_double(s: str) -> str:
+    """Escape a string so it can be placed inside a YAML double-quoted scalar.
+
+    YAML double-quoted strings recognise the usual JSON-style escapes. The
+    two characters we need to guard against are backslash and the closing
+    double quote; newlines get ``\\n``.
+    """
+    return (
+        s.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+    )
+
+
+def _emit_compose_yaml(
+    *,
+    run_id: str,
+    mode: str,
+    shas: list[str],
+    repo_root: Path,
+    lib_sh: Path,
+) -> str:
+    """Build the full compose.yml text as a string."""
+    host_experiments = str(repo_root / "experiments")
+
+    lines: list[str] = []
+    lines.append(f"name: proof-eval-{run_id}")
+    lines.append("")
+
+    # Anchored defaults: fields every service inherits unchanged. We keep
+    # this tiny -- anything service-specific (env, command, image, ...)
+    # stays inline so it's obvious at a glance what varies per-SHA.
+    lines.append("x-defaults: &defaults")
+    lines.append('  restart: "no"')
+    lines.append("")
+
+    lines.append("services:")
+    for sha in shas:
+        prefix = _sha_prefix(sha)
+        run_config_json = _run_config_json_for(sha, lib_sh)
+        command = _command_for_mode(mode, run_id)
+
+        lines.append(f"  cmt-{prefix}:")
+        lines.append("    <<: *defaults")
+        lines.append(f"    image: fc-commit:{prefix}")
+        lines.append(f"    container_name: fc-run-{prefix}-{run_id}")
+        lines.append("    environment:")
+        # The literal ${ANTHROPIC_API_KEY} string: compose resolves at
+        # launch. Single-quoted so YAML doesn't try to interpret the $.
+        lines.append("      ANTHROPIC_API_KEY: '${ANTHROPIC_API_KEY}'")
+        # RUN_CONFIG_JSON is a JSON object; we double-quote it as a YAML
+        # scalar and escape inner double-quotes.
+        lines.append(
+            f'      RUN_CONFIG_JSON: "{_yaml_escape_double(run_config_json)}"'
+        )
+        lines.append(f'      RUN_ID: "{run_id}"')
+        lines.append(f'      MODE: "{mode}"')
+        lines.append("    volumes:")
+        lines.append(f'      - "results-{prefix}:/results"')
+        lines.append(
+            f'      - "{host_experiments}:/work/host-experiments:ro"'
+        )
+        lines.append("    command:")
+        lines.append('      - "bash"')
+        lines.append('      - "-lc"')
+        lines.append(f'      - "{_yaml_escape_double(command)}"')
+    lines.append("")
+
+    lines.append("volumes:")
+    for sha in shas:
+        prefix = _sha_prefix(sha)
+        lines.append(f"  results-{prefix}:")
+        lines.append(f"    name: results-{prefix}")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a per-run docker compose.yml for the proof-eval pipeline.",
+    )
+    parser.add_argument(
+        "--run-id",
+        required=True,
+        help="Stable identifier for this evaluation run (used in compose project name, container names, and result paths).",
+    )
+    parser.add_argument(
+        "--mode",
+        required=True,
+        choices=("baseline", "agent", "both"),
+        help="Which evaluator(s) to run per commit.",
+    )
+    parser.add_argument(
+        "--shas",
+        required=True,
+        help="Comma-separated list of fiat-crypto SHAs to emit services for.",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Output path. Defaults to experiments/results/<run_id>/compose.yml (repo-relative).",
+    )
+    parser.add_argument(
+        "--skip-validate",
+        action="store_true",
+        help="Skip the final `docker compose config --quiet` validation step.",
+    )
+    return parser.parse_args(argv)
+
+
+def _validate_with_compose(out_path: Path) -> int:
+    """Run ``docker compose -f <out> config --quiet``. Returns exit code."""
+    try:
+        result = subprocess.run(
+            ["docker", "compose", "-f", str(out_path), "config", "--quiet"],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        # No docker on PATH -- tell the caller how to bypass next time.
+        print(
+            f"docker not found on PATH; wrote {out_path} but skipped validation. "
+            f"Pass --skip-validate to silence.",
+            file=sys.stderr,
+        )
+        return 0
+    if result.returncode != 0:
+        print(
+            f"docker compose validation FAILED for {out_path}:",
+            file=sys.stderr,
+        )
+        if result.stdout:
+            print(result.stdout, file=sys.stderr)
+        if result.stderr:
+            print(result.stderr, file=sys.stderr)
+    return result.returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    shas = [s.strip() for s in args.shas.split(",") if s.strip()]
+    if not shas:
+        print("--shas produced an empty list", file=sys.stderr)
+        return 2
+
+    repo_root = _repo_root()
+    lib_sh = repo_root / "experiments" / "orchestrate" / "lib.sh"
+
+    if args.out is None:
+        out_path = repo_root / "experiments" / "results" / args.run_id / "compose.yml"
+    else:
+        out_path = Path(args.out).resolve()
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        content = _emit_compose_yaml(
+            run_id=args.run_id,
+            mode=args.mode,
+            shas=shas,
+            repo_root=repo_root,
+            lib_sh=lib_sh,
+        )
+    except (RuntimeError, FileNotFoundError, ValueError) as exc:
+        print(f"gen-compose: {exc}", file=sys.stderr)
+        return 1
+
+    out_path.write_text(content, encoding="utf-8")
+    print(f"wrote {out_path}")
+
+    if args.skip_validate:
+        return 0
+
+    rc = _validate_with_compose(out_path)
+    if rc != 0:
+        print(
+            f"gen-compose: compose file at {out_path} is invalid (see above).",
+            file=sys.stderr,
+        )
+        return rc
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/tests/test_gen_compose.py
+++ b/experiments/tests/test_gen_compose.py
@@ -1,0 +1,275 @@
+"""Tests for experiments.orchestrate.gen-compose.
+
+Exercise the CLI end-to-end with synthetic SHAs: write a compose.yml
+to a tmp path, assert its shape, and (if ``docker compose`` is in PATH)
+validate with ``docker compose config --quiet``.
+
+The gen-compose.py script has a hyphen in its name, so it isn't
+importable as a module via ``import``. We run it as a subprocess -- the
+CLI is the supported entry point.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+GEN_COMPOSE = REPO_ROOT / "experiments" / "orchestrate" / "gen-compose.py"
+
+# A pair of real fiat-crypto SHAs whose meta.json lives under
+# experiments/admitted-proofs/ (01-of_prefancy_identZ_correct &&
+# 02-pull_cast_genericize_op). Using real SHAs means run_config_json
+# returns non-empty slot lists, so we also assert on that shape.
+SHA_A = "b9f28afec4f3dc3340a8693cdf450721af67d13b"
+SHA_B = "07e016ed52f68205f851f3686c64018a0c7a262b"
+
+
+def _run_cli(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Invoke gen-compose.py as a subprocess. Returns the completed proc."""
+    return subprocess.run(
+        [sys.executable, str(GEN_COMPOSE), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT / "experiments"),
+    )
+
+
+def test_cli_help_renders() -> None:
+    result = _run_cli(["--help"])
+    assert result.returncode == 0, result.stderr
+    assert "--run-id" in result.stdout
+    assert "--mode" in result.stdout
+    assert "--shas" in result.stdout
+    assert "--out" in result.stdout
+    assert "--skip-validate" in result.stdout
+
+
+def test_cli_generates_expected_shape(tmp_path: Path) -> None:
+    out = tmp_path / "compose.yml"
+    result = _run_cli(
+        [
+            "--run-id",
+            "unit001",
+            "--mode",
+            "both",
+            "--shas",
+            f"{SHA_A},{SHA_B}",
+            "--out",
+            str(out),
+            "--skip-validate",
+        ]
+    )
+    assert result.returncode == 0, (
+        f"gen-compose failed.\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert out.exists(), "gen-compose did not produce the output file"
+    text = out.read_text(encoding="utf-8")
+
+    # Project name.
+    assert "name: proof-eval-unit001" in text
+
+    # One service per SHA, keyed by the 8-char prefix.
+    assert "cmt-b9f28afe:" in text
+    assert "cmt-07e016ed:" in text
+
+    # Image tag matches the Dockerfile's convention.
+    assert "image: fc-commit:b9f28afe" in text
+    assert "image: fc-commit:07e016ed" in text
+
+    # Container name embeds both prefix and run_id.
+    assert "container_name: fc-run-b9f28afe-unit001" in text
+    assert "container_name: fc-run-07e016ed-unit001" in text
+
+    # The literal ${ANTHROPIC_API_KEY} string must be present so compose
+    # does the interpolation at launch (NOT us at generation time).
+    assert "${ANTHROPIC_API_KEY}" in text
+
+    # Top-level volumes section with explicit `name:` for each SHA
+    # (this is what makes re-runs accumulate into stable on-disk volumes).
+    assert re.search(
+        r"^volumes:\s*\n(?:.*\n)*?  results-b9f28afe:\s*\n    name: results-b9f28afe",
+        text,
+        re.MULTILINE,
+    ), "missing or malformed results-b9f28afe volume entry"
+    assert re.search(
+        r"  results-07e016ed:\s*\n    name: results-07e016ed",
+        text,
+    ), "missing or malformed results-07e016ed volume entry"
+
+    # YAML anchors present for dedup.
+    assert "x-defaults: &defaults" in text
+    assert "<<: *defaults" in text
+
+    # Service-level volume mounts: the named volume and the read-only
+    # host-experiments bind mount.
+    assert '"results-b9f28afe:/results"' in text
+    assert '"results-07e016ed:/results"' in text
+    assert ":/work/host-experiments:ro" in text
+
+    # Mode + run_id env vars are set on every service.
+    assert 'MODE: "both"' in text
+    assert 'RUN_ID: "unit001"' in text
+
+    # RUN_CONFIG_JSON is a compact JSON object embedding the commit and
+    # slot list. Pull it back out and verify the structure.
+    m = re.search(r'RUN_CONFIG_JSON: "(.*)"', text)
+    assert m is not None, "RUN_CONFIG_JSON not found in output"
+    # The captured group is YAML-escaped (\\" and \\\\). Unescape
+    # minimally: this test only relies on the backslash-quote -> quote
+    # transformation since we generated the file.
+    payload_raw = m.group(1).replace('\\"', '"').replace("\\\\", "\\")
+    parsed = json.loads(payload_raw)
+    assert parsed["commit"] == SHA_A
+    assert isinstance(parsed["slots"], list)
+
+    # restart: "no" via the anchor.
+    assert 'restart: "no"' in text
+
+    # Command dispatch for mode=both runs baseline then agent.
+    assert "eval-baseline --run-id unit001" in text
+    assert "eval-agent --run-id unit001" in text
+    assert "/results/unit001/baseline.jsonl" in text
+    assert "/results/unit001/agent.jsonl" in text
+
+
+def test_cli_mode_baseline_omits_agent(tmp_path: Path) -> None:
+    out = tmp_path / "compose.yml"
+    result = _run_cli(
+        [
+            "--run-id",
+            "base",
+            "--mode",
+            "baseline",
+            "--shas",
+            SHA_A,
+            "--out",
+            str(out),
+            "--skip-validate",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    text = out.read_text(encoding="utf-8")
+    assert "eval-baseline" in text
+    assert "eval-agent" not in text
+    assert 'MODE: "baseline"' in text
+
+
+def test_cli_mode_agent_omits_baseline(tmp_path: Path) -> None:
+    out = tmp_path / "compose.yml"
+    result = _run_cli(
+        [
+            "--run-id",
+            "agt",
+            "--mode",
+            "agent",
+            "--shas",
+            SHA_A,
+            "--out",
+            str(out),
+            "--skip-validate",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    text = out.read_text(encoding="utf-8")
+    assert "eval-agent" in text
+    assert "eval-baseline" not in text
+    assert 'MODE: "agent"' in text
+
+
+def test_cli_default_out_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When --out is omitted, the default lands under experiments/results/<run_id>/."""
+    run_id = "default-out-testxyz"
+    expected = (
+        REPO_ROOT / "experiments" / "results" / run_id / "compose.yml"
+    )
+    # Clean any stale artifact.
+    if expected.exists():
+        expected.unlink()
+    if expected.parent.exists():
+        try:
+            expected.parent.rmdir()
+        except OSError:
+            pass
+
+    try:
+        result = _run_cli(
+            [
+                "--run-id",
+                run_id,
+                "--mode",
+                "baseline",
+                "--shas",
+                SHA_A,
+                "--skip-validate",
+            ]
+        )
+        assert result.returncode == 0, result.stderr
+        assert expected.exists(), f"default output not written at {expected}"
+    finally:
+        if expected.exists():
+            expected.unlink()
+        if expected.parent.exists():
+            try:
+                expected.parent.rmdir()
+            except OSError:
+                pass
+
+
+def test_cli_rejects_invalid_mode(tmp_path: Path) -> None:
+    out = tmp_path / "compose.yml"
+    result = _run_cli(
+        [
+            "--run-id",
+            "x",
+            "--mode",
+            "bogus",
+            "--shas",
+            SHA_A,
+            "--out",
+            str(out),
+            "--skip-validate",
+        ]
+    )
+    assert result.returncode != 0
+    assert "invalid choice" in result.stderr
+
+
+@pytest.mark.skipif(
+    shutil.which("docker") is None,
+    reason="docker not in PATH; cannot validate compose.yml",
+)
+def test_cli_validates_with_docker_compose(tmp_path: Path) -> None:
+    out = tmp_path / "compose.yml"
+    # NO --skip-validate: exercise the validation pathway.
+    result = _run_cli(
+        [
+            "--run-id",
+            "validated",
+            "--mode",
+            "both",
+            "--shas",
+            f"{SHA_A},{SHA_B}",
+            "--out",
+            str(out),
+        ]
+    )
+    # If docker is present but `docker compose` isn't (e.g. podman-docker
+    # shim), skip rather than fail.
+    probe = subprocess.run(
+        ["docker", "compose", "version"], capture_output=True, text=True
+    )
+    if probe.returncode != 0:
+        pytest.skip("`docker compose` subcommand unavailable")
+    assert result.returncode == 0, (
+        f"gen-compose + validation failed.\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert out.exists()


### PR DESCRIPTION
## Summary
- New `experiments/orchestrate/gen-compose.py`: stdlib-only generator that emits a docker compose.yml with one `cmt-<prefix>` service and one `results-<prefix>` named volume per fiat-crypto SHA.
- Each service's `RUN_CONFIG_JSON` is sourced from `experiments/orchestrate/lib.sh`'s `run_config_json` via subprocess, so slot enumeration stays canonical.
- Literal `${ANTHROPIC_API_KEY}` is emitted into the YAML (compose interpolates at launch, never baked into the artifact); named volumes carry explicit `name:` so re-runs accumulate across invocations.
- YAML anchors (`x-defaults: &defaults`) dedupe the shared `restart: "no"`; per-SHA fields stay inline for diff clarity.
- `--skip-validate` flag bypasses the final `docker compose config --quiet` step for environments without docker.

## Test plan
- [x] `uv run python orchestrate/gen-compose.py --help` renders the CLI.
- [x] `tests/test_gen_compose.py` (7 tests): shape assertions (services/volumes/anchors/literal env-var string/runner dispatch per mode), default `--out` path, invalid-mode rejection, and docker-gated validation test that auto-skips when `docker compose` is unavailable.
- [x] Full suite: `uv run pytest -v` -> 44 passed.
- [x] Manual end-to-end: `--run-id test123 --mode both --shas abc123def,789abcde` -> two services + two named volumes + `docker compose config --quiet` exits 0.

Closes #23.

Generated with [Claude Code](https://claude.com/claude-code)