### PR TITLE
#19 orchestrate/run-commit.sh: per-SHA docker compose run launcher

### DIFF
--- a/experiments/orchestrate/run-commit.sh
+++ b/experiments/orchestrate/run-commit.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# experiments/orchestrate/run-commit.sh
+#
+# Per-SHA launcher for the fiat-crypto proof-evaluation pipeline (epic #27 /
+# issue #19). Wraps `docker compose run --rm` against a single service in a
+# compose.yml emitted by gen-compose.py (#23).
+#
+# Usage:
+#   ./run-commit.sh <sha> <run_id> [--compose-file <path>] [--dry-run]
+#
+# Defaults:
+#   --compose-file experiments/results/<run_id>/compose.yml
+#     (matches what gen-compose.py writes by default; the issue body says
+#     results-aggregate/<run_id>/compose.yml but gen-compose.py writes to
+#     experiments/results/<run_id>/compose.yml — we follow the generator.)
+#
+# Behavior:
+#   1. Computes sha_prefix = first 8 chars of <sha>.
+#   2. Asserts <compose-file> exists and contains a `cmt-<sha_prefix>:`
+#      service; fails with a helpful error otherwise.
+#   3. Runs
+#        docker compose -f <compose-file> run --rm \
+#          --name fc-run-<sha_prefix>-<run_id> \
+#          cmt-<sha_prefix>
+#      and propagates the container exit code.
+#   4. On container failure, leaves the named volume `results-<sha_prefix>`
+#      intact (the compose file declares it with a stable `name:`; we do NOT
+#      issue `docker volume rm` anywhere).
+#   5. On container success, inspects the volume via a one-shot alpine
+#      container and prints
+#        DONE <sha> agent_n=X baseline_n=Y
+#      where X/Y are line counts of /results/<run_id>/{agent,baseline}.jsonl
+#      inside the volume (0 if the file is missing — e.g. mode=baseline-only).
+#
+# --dry-run: logs the docker compose invocation instead of executing, exits 0.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXPERIMENTS_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${EXPERIMENTS_ROOT}/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Defaults / globals
+# ---------------------------------------------------------------------------
+SHA=""
+RUN_ID=""
+COMPOSE_FILE=""
+DRY_RUN=0
+
+# Image used to introspect the named volume post-run. Kept small & hermetic.
+SUMMARY_IMAGE="${RUN_COMMIT_SUMMARY_IMAGE:-alpine:3.19}"
+
+# ---------------------------------------------------------------------------
+# Logging helpers (stderr; matches build-images.sh convention)
+# ---------------------------------------------------------------------------
+log()  { printf '[run-commit] %s\n' "$*" >&2; }
+warn() { printf '[run-commit] WARN: %s\n' "$*" >&2; }
+die()  { printf '[run-commit] ERROR: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: run-commit.sh <sha> <run_id> [OPTIONS]
+
+Arguments:
+  <sha>                   Fiat-crypto commit SHA (full or >=8 chars). The
+                          first 8 chars form the sha-prefix used for the
+                          compose service name (cmt-<sha-prefix>), container
+                          name (fc-run-<sha-prefix>-<run_id>), and volume
+                          name (results-<sha-prefix>).
+  <run_id>                Run identifier. Used in the compose file path
+                          (experiments/results/<run_id>/compose.yml by
+                          default), the container name, and — inside the
+                          container — the results subdirectory.
+
+Options:
+  --compose-file <path>   Path to the compose file to run against.
+                          Default: experiments/results/<run_id>/compose.yml
+                          (resolved relative to the repo root).
+  --dry-run               Log the `docker compose run ...` command that would
+                          be issued, without executing it or the post-run
+                          summary step. Exits 0 after pre-flight checks.
+  -h, --help              Show this help and exit.
+
+Environment:
+  RUN_COMMIT_SUMMARY_IMAGE  Image used to read the named volume for the DONE
+                            summary. Default: alpine:3.19.
+
+Exit codes:
+  0  container ran to completion (or --dry-run succeeded)
+  1  container ran but exited non-zero (bubbled up from docker compose run)
+  2  usage / pre-flight error (missing arg, compose file not found, service
+     not declared in compose file)
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+parse_args() {
+  local -a positionals=()
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --dry-run)
+        DRY_RUN=1
+        shift
+        ;;
+      --compose-file)
+        [ "$#" -ge 2 ] || { usage >&2; die "--compose-file requires a path argument"; }
+        COMPOSE_FILE="$2"
+        shift 2
+        ;;
+      --)
+        shift
+        while [ "$#" -gt 0 ]; do
+          positionals+=("$1")
+          shift
+        done
+        ;;
+      -*)
+        usage >&2
+        die "unknown option: $1"
+        ;;
+      *)
+        positionals+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  if [ "${#positionals[@]}" -ne 2 ]; then
+    usage >&2
+    die "expected exactly 2 positional arguments (<sha> <run_id>); got ${#positionals[@]}"
+  fi
+
+  SHA="${positionals[0]}"
+  RUN_ID="${positionals[1]}"
+
+  if [ -z "${SHA}" ]; then
+    die "<sha> must be non-empty"
+  fi
+  if [ "${#SHA}" -lt 8 ]; then
+    die "<sha> must be at least 8 characters (got ${#SHA}: ${SHA})"
+  fi
+  if [ -z "${RUN_ID}" ]; then
+    die "<run_id> must be non-empty"
+  fi
+  # run_id becomes a path fragment and a container name suffix; restrict it
+  # to a conservative charset to avoid both filesystem and docker name woes.
+  case "${RUN_ID}" in
+    *[!A-Za-z0-9._-]*)
+      die "<run_id> may only contain [A-Za-z0-9._-]; got '${RUN_ID}'"
+      ;;
+  esac
+
+  if [ -z "${COMPOSE_FILE}" ]; then
+    COMPOSE_FILE="${REPO_ROOT}/experiments/results/${RUN_ID}/compose.yml"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight: verify compose file exists and declares the target service.
+# ---------------------------------------------------------------------------
+# $1: compose file path
+# $2: expected service name (cmt-<sha_prefix>)
+assert_compose_has_service() {
+  local compose_file="$1"
+  local service="$2"
+
+  if [ ! -f "${compose_file}" ]; then
+    die "compose file not found: ${compose_file}
+(hint: run experiments/orchestrate/gen-compose.py --run-id <id> --mode <m> --shas <shas> first,
+ or pass --compose-file <path> explicitly)"
+  fi
+
+  # gen-compose.py emits service keys as `  <name>:` at two-space indent under
+  # `services:`. Match that exact prefix to avoid collisions with volume keys
+  # (e.g. `  results-abc12345:`), which live under `volumes:` with the same
+  # indent but a different name.
+  if ! grep -Eq "^[[:space:]]{2}${service}:[[:space:]]*(#.*)?\$" "${compose_file}"; then
+    die "compose file ${compose_file} does not declare a '${service}:' service
+(hint: confirm the SHA prefix matches one that gen-compose.py was invoked with;
+ first 8 chars of the <sha> arg form the service name)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Volume introspection: read JSONL line counts for the DONE summary.
+# ---------------------------------------------------------------------------
+# $1: volume name (results-<sha_prefix>)
+# $2: run id
+#
+# Echoes two lines on stdout:
+#   agent_n=<N>
+#   baseline_n=<M>
+# Missing files produce a 0 count rather than an error — in mode=baseline
+# (resp. mode=agent), only one of the two JSONL files exists, which is fine.
+read_volume_counts() {
+  local volume="$1"
+  local run_id="$2"
+
+  # Heredoc inside the alpine container. `wc -l` on a non-existent file is
+  # silenced; fallback prints `<name>_n=0`.
+  local script
+  script=$(cat <<'INNER'
+run_id="$1"
+for mode in agent baseline; do
+  f="/r/${run_id}/${mode}.jsonl"
+  if [ -f "$f" ]; then
+    n=$(wc -l < "$f" | tr -d ' ')
+  else
+    n=0
+  fi
+  printf '%s_n=%s\n' "$mode" "$n"
+done
+INNER
+  )
+
+  # `docker run --rm` leaves no container; the volume itself is read-only
+  # here (we don't write), so nothing can accidentally be mutated.
+  docker run --rm \
+    -v "${volume}:/r:ro" \
+    "${SUMMARY_IMAGE}" \
+    sh -c "${script}" -- "${run_id}"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+  parse_args "$@"
+
+  local sha_prefix="${SHA:0:8}"
+  # Lowercase the prefix — gen-compose.py lowercases too, so user-supplied
+  # uppercase hex still matches the emitted service.
+  sha_prefix="$(printf '%s' "${sha_prefix}" | tr '[:upper:]' '[:lower:]')"
+
+  local service="cmt-${sha_prefix}"
+  local container_name="fc-run-${sha_prefix}-${RUN_ID}"
+  local volume="results-${sha_prefix}"
+
+  assert_compose_has_service "${COMPOSE_FILE}" "${service}"
+
+  # The exact command we (would) execute. Printed to stderr for both dry-run
+  # and live runs so operators can see what happened in the logs.
+  local -a docker_cmd=(
+    docker compose
+    -f "${COMPOSE_FILE}"
+    run --rm
+    --name "${container_name}"
+    "${service}"
+  )
+
+  if [ "${DRY_RUN}" -eq 1 ]; then
+    log "DRY-RUN: ${docker_cmd[*]}"
+    return 0
+  fi
+
+  # Require docker only when we're actually going to run it; --dry-run is
+  # deliberately usable in environments without docker installed.
+  if ! command -v docker >/dev/null 2>&1; then
+    die "docker is required but not found on PATH"
+  fi
+
+  log "running: ${docker_cmd[*]}"
+  set +e
+  "${docker_cmd[@]}"
+  local rc=$?
+  set -e
+
+  if [ "${rc}" -ne 0 ]; then
+    # Intentionally do NOT `docker volume rm` — partial results survive by
+    # spec so operators can inspect /results/<run_id>/ after a failure.
+    warn "container ${container_name} exited with code ${rc}; volume ${volume} left intact"
+    exit "${rc}"
+  fi
+
+  # Success path: summarize what landed in the volume.
+  local counts agent_n baseline_n
+  if ! counts="$(read_volume_counts "${volume}" "${RUN_ID}" 2>/dev/null)"; then
+    warn "failed to introspect volume ${volume} for summary; reporting zeroes"
+    counts=$'agent_n=0\nbaseline_n=0'
+  fi
+
+  agent_n="$(printf '%s\n' "${counts}" | awk -F= '$1=="agent_n"{print $2; exit}')"
+  baseline_n="$(printf '%s\n' "${counts}" | awk -F= '$1=="baseline_n"{print $2; exit}')"
+  agent_n="${agent_n:-0}"
+  baseline_n="${baseline_n:-0}"
+
+  printf 'DONE %s agent_n=%s baseline_n=%s\n' "${SHA}" "${agent_n}" "${baseline_n}"
+}
+
+main "$@"

--- a/experiments/orchestrate/test_run_commit.sh
+++ b/experiments/orchestrate/test_run_commit.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# experiments/orchestrate/test_run_commit.sh
+#
+# Bats-less smoke test for run-commit.sh (issue #19). Intentionally does NOT
+# require docker to be installed — --dry-run plus grep-based pre-flight
+# checks give us full coverage of the script's argument-handling surface.
+#
+# Tests:
+#   1. `bash -n` syntax check.
+#   2. `--help` renders usage (shows both positional arg names + the
+#      --compose-file / --dry-run options).
+#   3. Happy dry-run: synthetic compose.yml with a single cmt-abc12345 service;
+#      asserts the logged docker command references the expected service and
+#      container name.
+#   4. Service-missing error: same compose.yml but a SHA whose prefix doesn't
+#      match anything in it; asserts non-zero exit and a helpful message.
+#   5. Compose-file-missing error: path that doesn't exist; asserts non-zero
+#      exit and a helpful message.
+#   6. Missing-argument error: running with only one positional; asserts
+#      non-zero exit and usage hint.
+#
+# Exit 0 on success, nonzero on first failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_SCRIPT="${SCRIPT_DIR}/run-commit.sh"
+
+fail() { printf '[test_run_commit] FAIL: %s\n' "$*" >&2; exit 1; }
+pass() { printf '[test_run_commit] PASS: %s\n' "$*" >&2; }
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/fc-run-commit-test.XXXXXX")"
+trap 'rm -rf -- "${TMP_DIR}"' EXIT
+
+# ---------------------------------------------------------------------------
+# Test 1 — bash -n syntax check
+# ---------------------------------------------------------------------------
+if ! bash -n "${RUN_SCRIPT}"; then
+  fail "bash -n on run-commit.sh returned nonzero"
+fi
+pass "bash -n run-commit.sh"
+
+# ---------------------------------------------------------------------------
+# Test 2 — --help renders usage with expected tokens
+# ---------------------------------------------------------------------------
+help_out="$("${RUN_SCRIPT}" --help 2>&1)"
+for token in '<sha>' '<run_id>' '--compose-file' '--dry-run'; do
+  case "${help_out}" in
+    *"${token}"*) ;;
+    *) fail "--help output missing '${token}':\n${help_out}" ;;
+  esac
+done
+pass "--help lists positional args and options"
+
+# ---------------------------------------------------------------------------
+# Synthetic compose.yml — one cmt-abc12345 service, one matching volume.
+# Hand-written to mirror the shape gen-compose.py emits (two-space indent
+# under `services:` and `volumes:`), without pulling in the generator.
+# ---------------------------------------------------------------------------
+COMPOSE_FILE="${TMP_DIR}/compose.yml"
+cat > "${COMPOSE_FILE}" <<'YAML'
+name: proof-eval-testrun
+
+services:
+  cmt-abc12345:
+    image: fc-commit:abc12345
+    container_name: fc-run-abc12345-test-run
+    volumes:
+      - "results-abc12345:/results"
+    command:
+      - "bash"
+      - "-lc"
+      - "echo hello"
+
+volumes:
+  results-abc12345:
+    name: results-abc12345
+YAML
+
+# ---------------------------------------------------------------------------
+# Test 3 — happy dry-run references service + container name
+# ---------------------------------------------------------------------------
+DRY_OUT="$("${RUN_SCRIPT}" abc12345deadbeef test-run --compose-file "${COMPOSE_FILE}" --dry-run 2>&1)" \
+  || fail "expected dry-run to exit 0, got nonzero; output:\n${DRY_OUT}"
+
+for token in 'cmt-abc12345' 'fc-run-abc12345-test-run' 'docker compose' 'run --rm'; do
+  case "${DRY_OUT}" in
+    *"${token}"*) ;;
+    *) fail "dry-run output missing '${token}':\n${DRY_OUT}" ;;
+  esac
+done
+
+# Compose file path should be echoed somewhere (in the `-f <path>` arg).
+case "${DRY_OUT}" in
+  *"${COMPOSE_FILE}"*) ;;
+  *) fail "dry-run output missing compose file path '${COMPOSE_FILE}':\n${DRY_OUT}" ;;
+esac
+pass "dry-run against synthetic compose.yml references cmt-abc12345 and fc-run-abc12345-test-run"
+
+# ---------------------------------------------------------------------------
+# Test 4 — service-missing error path
+# ---------------------------------------------------------------------------
+set +e
+MISSING_OUT="$("${RUN_SCRIPT}" unknownsha99999 test-run --compose-file "${COMPOSE_FILE}" 2>&1)"
+MISSING_RC=$?
+set -e
+
+if [ "${MISSING_RC}" -eq 0 ]; then
+  fail "expected non-zero exit when service not in compose; output:\n${MISSING_OUT}"
+fi
+
+# "unknownsha99999" => prefix "unknownsh" (first 8 chars: "unknowns") — lowercased.
+# We just check the error mentions the missing service AND the compose file.
+case "${MISSING_OUT}" in
+  *'cmt-unknowns'*) ;;
+  *) fail "expected error to name the missing service; got:\n${MISSING_OUT}" ;;
+esac
+case "${MISSING_OUT}" in
+  *'does not declare'*|*'compose file'*)
+    ;;
+  *) fail "expected error to explain the compose file problem; got:\n${MISSING_OUT}" ;;
+esac
+pass "unknown-service exits non-zero with clear message"
+
+# ---------------------------------------------------------------------------
+# Test 5 — compose-file-missing error path
+# ---------------------------------------------------------------------------
+set +e
+NOFILE_OUT="$("${RUN_SCRIPT}" abc12345deadbeef test-run --compose-file "${TMP_DIR}/does-not-exist.yml" 2>&1)"
+NOFILE_RC=$?
+set -e
+
+if [ "${NOFILE_RC}" -eq 0 ]; then
+  fail "expected non-zero exit when compose file missing; output:\n${NOFILE_OUT}"
+fi
+case "${NOFILE_OUT}" in
+  *'not found'*) ;;
+  *) fail "expected 'not found' in missing-compose-file error; got:\n${NOFILE_OUT}" ;;
+esac
+pass "missing compose file exits non-zero with clear message"
+
+# ---------------------------------------------------------------------------
+# Test 6 — missing positional argument
+# ---------------------------------------------------------------------------
+set +e
+BADARGS_OUT="$("${RUN_SCRIPT}" abc12345deadbeef --compose-file "${COMPOSE_FILE}" --dry-run 2>&1)"
+BADARGS_RC=$?
+set -e
+
+if [ "${BADARGS_RC}" -eq 0 ]; then
+  fail "expected non-zero exit when <run_id> missing; output:\n${BADARGS_OUT}"
+fi
+case "${BADARGS_OUT}" in
+  *'positional'*|*'Usage:'*) ;;
+  *) fail "expected usage hint when <run_id> missing; got:\n${BADARGS_OUT}" ;;
+esac
+pass "missing <run_id> exits non-zero with usage hint"
+
+printf '[test_run_commit] all tests passed\n' >&2


### PR DESCRIPTION
## Summary
- Adds `experiments/orchestrate/run-commit.sh`: Tier-4 per-SHA launcher that `docker compose run --rm`s a single `cmt-<sha-prefix>` service from a gen-compose-produced compose file, propagates exit codes on failure (leaving the named `results-<sha-prefix>` volume intact), and prints `DONE <sha> agent_n=X baseline_n=Y` on success by introspecting the volume with a one-shot alpine container.
- Adds `experiments/orchestrate/test_run_commit.sh`: hermetic bash smoke test (no docker / no network) covering `bash -n`, `--help`, a happy `--dry-run` against a synthetic minimal compose.yml, and three error paths (service absent, compose file absent, missing `<run_id>`).

## Reconciliation note
The issue body says the default `--compose-file` is `results-aggregate/<run_id>/compose.yml`, but `gen-compose.py` (PR #50) actually writes to `experiments/results/<run_id>/compose.yml` by default. This PR uses the latter as the default so `./run-commit.sh <sha> <run_id>` composes directly with the upstream generator with no extra flags. Documented inline in the script header.

## Design details
- `sha_prefix = first 8 chars(lower(<sha>))` — matches `gen-compose.py`'s `_sha_prefix` helper so user-supplied uppercase hex still resolves the right service.
- Pre-flight uses `grep -E "^[[:space:]]{2}${service}:"` to assert the service key exists at the exact indent gen-compose.py emits; this avoids collisions with the `results-<prefix>:` volume key that lives under a different top-level stanza.
- `--dry-run` mirrors `build-images.sh` style and logs the full `docker compose run ...` invocation it would issue, without requiring docker on PATH. That keeps the smoke test runnable in any CI sandbox.
- Summary image is `alpine:3.19` by default, overridable via `RUN_COMMIT_SUMMARY_IMAGE`. Volume is mounted read-only (`:ro`) for the summary read.
- No `docker volume rm` anywhere — per spec, per-SHA volumes survive container failure so operators can inspect partial results.

## Test plan
- [x] `bash -n experiments/orchestrate/run-commit.sh`
- [x] `bash experiments/orchestrate/test_run_commit.sh` (all 6 cases pass)
- [x] `./experiments/orchestrate/run-commit.sh --help` renders usage
- [x] Dry-run against a synthetic compose.yml logs `docker compose -f <path> run --rm --name fc-run-abc12345-test-run cmt-abc12345` and exits 0
- [x] Non-existent compose file → non-zero exit with a `not found` message
- [x] Valid compose file, wrong SHA prefix → non-zero exit naming the missing `cmt-<prefix>` service
- [x] Missing `<run_id>` → non-zero exit with usage hint

Closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)