### PR TITLE
#25 summary.py: drift metrics + baseline-vs-agent comparison

### DIFF
--- a/experiments/summary.py
+++ b/experiments/summary.py
@@ -3,12 +3,17 @@ Cross-run aggregator for ExperimentResult JSONL files.
 
 Reads one or more JSONL files produced by run_experiment.py (or the eventual
 agent runner) and emits:
-  * a JSON summary with per-(mode, deletion_size) aggregate metrics, and
-  * an optional Markdown table (one table per mode).
+  * a JSON summary with per-(mode, deletion_size) aggregate metrics,
+  * a `baseline_vs_agent` section with per-deletion-size deltas, and
+  * an optional Markdown rendering with three tables (baseline, agent,
+    baseline-vs-agent).
 
-This is the first cut — see issue #13. Drift-and-cross-mode comparisons live
-in the follow-up (#25). Depends only on stdlib + fields already defined in
-experiments/metrics.py (schema extended in #4).
+The drift columns (mean_vo_bytes_ratio, mean_compile_time_ratio,
+mean_n_assumptions_diff, mean_proof_{chars,lines}_ratio,
+mean_tactic_count_ratio) directly answer the "more/less <perf characteristic>
+than the original human data" question. Pearson r per drift metric vs
+deletion_size lives under `drift_faithfulness` as a per-mode honesty check
+against memorization. See issues #13 and #25.
 
 Usage:
     python3 summary.py --inputs <glob> [--out summary.json] [--markdown summary.md]
@@ -87,6 +92,53 @@ def _nested(rec: dict[str, Any], *path: str) -> Any:
     return cur
 
 
+# Drift metrics we want to report on each per-(mode, deletion_size) row plus
+# under drift_faithfulness. Each entry is (output_key, kind, llm_field,
+# human_field). Kind is "ratio" (per-record llm/human then mean the ratios,
+# skip when either side is missing or denominator is 0) or "diff" (per-record
+# llm − human then mean the diffs, skip when either side is missing).
+_DRIFT_FIELDS: list[tuple[str, str, str, str]] = [
+    ("mean_vo_bytes_ratio",      "ratio", "vo_bytes",      "vo_bytes"),
+    ("mean_compile_time_ratio",  "ratio", "compile_time_s", "compile_time_s"),
+    ("mean_n_assumptions_diff",  "diff",  "n_assumptions", "n_assumptions"),
+    ("mean_proof_chars_ratio",   "ratio", "proof_chars",   "proof_chars"),
+    ("mean_proof_lines_ratio",   "ratio", "proof_lines",   "proof_lines"),
+    ("mean_tactic_count_ratio",  "ratio", "tactic_count",  "tactic_count"),
+]
+
+
+def _drift_value(
+    rs: list[dict[str, Any]],
+    kind: str,
+    llm_field: str,
+    human_field: str,
+) -> float | None:
+    """Compute the per-group drift statistic across a list of records.
+
+    For "ratio": skip a record if either side is missing/None or denominator
+    is 0; otherwise append llm/human and return the mean of the ratios.
+    For "diff": skip a record if either side is missing/None; otherwise append
+    llm − human and return the mean.
+    """
+    vals: list[float] = []
+    for r in rs:
+        llm = _nested(r, "llm_metrics", llm_field)
+        human = _nested(r, "human_metrics", human_field)
+        if llm is None or human is None:
+            continue
+        llm_f = float(llm)
+        human_f = float(human)
+        if kind == "ratio":
+            if human_f == 0:
+                continue
+            vals.append(llm_f / human_f)
+        elif kind == "diff":
+            vals.append(llm_f - human_f)
+        else:  # pragma: no cover - defensive
+            raise ValueError(f"unknown drift kind: {kind!r}")
+    return _mean(vals)
+
+
 # ── Aggregation ───────────────────────────────────────────────────────────────
 
 def aggregate(records: list[dict[str, Any]]) -> dict[str, Any]:
@@ -116,8 +168,8 @@ def aggregate(records: list[dict[str, Any]]) -> dict[str, Any]:
             for r in rs if r.get("normalized_edit_distance") is not None
         ]
 
-        # Compile / VO metrics come from llm_metrics; human ratio compares LLM
-        # vs ground-truth human vo_bytes to flag suspiciously-small artifacts.
+        # Compile / VO metrics come from llm_metrics; the human_ratio column
+        # kept for backward compatibility with issue #13's output shape.
         vo_bytes_vals: list[float] = []
         vo_ratio_vals: list[float] = []
         compile_time_vals: list[float] = []
@@ -136,7 +188,7 @@ def aggregate(records: list[dict[str, Any]]) -> dict[str, Any]:
             if nassum is not None:
                 n_assumptions_vals.append(float(nassum))
 
-        group_summaries.append({
+        row: dict[str, Any] = {
             "mode": mode,
             "deletion_size": dsize,
             "n_total": n_total,
@@ -149,39 +201,132 @@ def aggregate(records: list[dict[str, Any]]) -> dict[str, Any]:
             "mean_vo_bytes_human_ratio": _mean(vo_ratio_vals),
             "mean_compile_time_s": _mean(compile_time_vals),
             "mean_n_assumptions": _mean(n_assumptions_vals),
-        })
+        }
+
+        # Drift metrics: per-record llm-vs-human ratio/diff, then mean.
+        for out_key, kind, llm_field, human_field in _DRIFT_FIELDS:
+            row[out_key] = _drift_value(rs, kind, llm_field, human_field)
+
+        # Agent-only column; None for baseline rows so downstream consumers
+        # don't have to guard against KeyError.
+        if mode == "agent":
+            n_turns = [
+                float(r["agent_n_turns"]) for r in rs
+                if r.get("agent_n_turns") is not None
+            ]
+            row["mean_agent_n_turns"] = _mean(n_turns)
+        else:
+            row["mean_agent_n_turns"] = None
+
+        group_summaries.append(row)
 
     # Per-mode Pearson r between deletion_size and pass_rate.
-    faithfulness: dict[str, float | None] = {}
     by_mode: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for g in group_summaries:
         by_mode[g["mode"]].append(g)
+
+    faithfulness: dict[str, float | None] = {}
     for mode, gs in by_mode.items():
         xs = [float(g["deletion_size"]) for g in gs if g["n_total"] > 0]
         ys = [float(g["pass_rate"]) for g in gs if g["n_total"] > 0]
         faithfulness[mode] = _pearson_r(xs, ys)
 
+    # Per-metric Pearson r across deletion sizes, per mode. For each drift
+    # metric (plus pass_rate and normalized_edit_distance, which are the two
+    # headline non-drift signals) we emit {metric: {mode: r|None}}.
+    drift_metric_keys: list[str] = [k for k, _, _, _ in _DRIFT_FIELDS]
+    drift_metric_keys.extend(["pass_rate", "mean_normalized_edit_distance"])
+    drift_faithfulness: dict[str, dict[str, float | None]] = {}
+    for metric in drift_metric_keys:
+        drift_faithfulness[metric] = {}
+        for mode, gs in by_mode.items():
+            pairs: list[tuple[float, float]] = [
+                (float(g["deletion_size"]), float(g[metric]))
+                for g in gs if g.get(metric) is not None and g["n_total"] > 0
+            ]
+            if len(pairs) >= 3:
+                xs = [p[0] for p in pairs]
+                ys = [p[1] for p in pairs]
+                drift_faithfulness[metric][mode] = _pearson_r(xs, ys)
+            else:
+                drift_faithfulness[metric][mode] = None
+
+    # Baseline-vs-agent per deletion_size: only emit rows where BOTH modes
+    # have at least one result at that deletion_size.
+    baseline_by_dsize = {g["deletion_size"]: g for g in by_mode.get("baseline", [])}
+    agent_by_dsize    = {g["deletion_size"]: g for g in by_mode.get("agent", [])}
+    shared_dsizes = sorted(set(baseline_by_dsize) & set(agent_by_dsize))
+    baseline_vs_agent: list[dict[str, Any]] = []
+    for dsize in shared_dsizes:
+        b = baseline_by_dsize[dsize]
+        a = agent_by_dsize[dsize]
+        if b["n_total"] == 0 or a["n_total"] == 0:
+            continue
+        baseline_vs_agent.append({
+            "deletion_size": dsize,
+            "baseline_n_total": b["n_total"],
+            "agent_n_total":    a["n_total"],
+            "delta_pass_rate":  round(a["pass_rate"] - b["pass_rate"], 4),
+            "delta_normalized_edit_distance": _delta(
+                a.get("mean_normalized_edit_distance"),
+                b.get("mean_normalized_edit_distance"),
+            ),
+            "delta_mean_agent_n_turns": a.get("mean_agent_n_turns"),
+        })
+
     return {
         "n_total_runs": len(records),
         "groups": group_summaries,
         "faithfulness_by_mode": faithfulness,
+        "drift_faithfulness": drift_faithfulness,
+        "baseline_vs_agent": baseline_vs_agent,
     }
+
+
+def _delta(a: float | None, b: float | None) -> float | None:
+    if a is None or b is None:
+        return None
+    return round(a - b, 4)
 
 
 # ── Rendering ─────────────────────────────────────────────────────────────────
 
-_COLUMNS: list[tuple[str, str]] = [
-    ("deletion_size",                "deletion_size"),
-    ("n_total",                      "n_total"),
-    ("n_pass",                       "n_pass"),
-    ("pass_rate",                    "pass_rate"),
-    ("mean_inference_time_s",        "mean_inference_time_s"),
-    ("mean_output_tokens",           "mean_output_tokens"),
+# Columns shared by both baseline and agent tables.
+_BASE_COLUMNS: list[tuple[str, str]] = [
+    ("deletion_size",                 "deletion_size"),
+    ("n_total",                       "n_total"),
+    ("n_pass",                        "n_pass"),
+    ("pass_rate",                     "pass_rate"),
+    ("mean_inference_time_s",         "mean_inference_time_s"),
+    ("mean_output_tokens",            "mean_output_tokens"),
     ("mean_normalized_edit_distance", "mean_norm_edit_dist"),
-    ("mean_vo_bytes",                "mean_vo_bytes"),
-    ("mean_vo_bytes_human_ratio",    "mean_vo_ratio"),
-    ("mean_compile_time_s",          "mean_compile_s"),
-    ("mean_n_assumptions",           "mean_n_assumptions"),
+    ("mean_vo_bytes",                 "mean_vo_bytes"),
+    ("mean_vo_bytes_human_ratio",     "mean_vo_ratio"),
+    ("mean_compile_time_s",           "mean_compile_s"),
+    ("mean_n_assumptions",            "mean_n_assumptions"),
+    ("mean_vo_bytes_ratio",           "vo_bytes_ratio"),
+    ("mean_compile_time_ratio",       "compile_time_ratio"),
+    ("mean_n_assumptions_diff",       "n_assumptions_diff"),
+    ("mean_proof_chars_ratio",        "proof_chars_ratio"),
+    ("mean_proof_lines_ratio",        "proof_lines_ratio"),
+    ("mean_tactic_count_ratio",       "tactic_count_ratio"),
+]
+
+# Backward-compat alias for tests / external callers that imported _COLUMNS.
+_COLUMNS: list[tuple[str, str]] = _BASE_COLUMNS
+
+# Agent table adds the turn-count column.
+_AGENT_COLUMNS: list[tuple[str, str]] = _BASE_COLUMNS + [
+    ("mean_agent_n_turns", "mean_agent_n_turns"),
+]
+
+_CMP_COLUMNS: list[tuple[str, str]] = [
+    ("deletion_size",                    "deletion_size"),
+    ("baseline_n_total",                 "baseline_n"),
+    ("agent_n_total",                    "agent_n"),
+    ("delta_pass_rate",                  "Δpass_rate"),
+    ("delta_normalized_edit_distance",   "Δnorm_edit_dist"),
+    ("delta_mean_agent_n_turns",         "Δmean_agent_n_turns"),
 ]
 
 
@@ -193,8 +338,35 @@ def _fmt_cell(v: Any) -> str:
     return str(v)
 
 
+def _render_mode_table(
+    out: list[str],
+    mode: str,
+    rows: list[dict[str, Any]],
+    columns: list[tuple[str, str]],
+    faithfulness_r: float | None,
+) -> None:
+    out.append(f"## mode = `{mode}`")
+    out.append("")
+    headers = [label for _, label in columns]
+    out.append("| " + " | ".join(headers) + " |")
+    out.append("|" + "|".join(["---"] * len(headers)) + "|")
+    for g in sorted(rows, key=lambda x: x["deletion_size"]):
+        row = [_fmt_cell(g.get(key)) for key, _ in columns]
+        out.append("| " + " | ".join(row) + " |")
+    out.append("")
+    out.append(
+        "Faithfulness correlation (Pearson r, deletion_size vs pass_rate): "
+        f"**{_fmt_cell(faithfulness_r)}**"
+    )
+    out.append("")
+
+
 def render_markdown(summary: dict[str, Any]) -> str:
-    """Render one Markdown table per mode plus a Pearson r block."""
+    """Render three Markdown tables: baseline, agent, baseline-vs-agent.
+
+    Also includes a drift-faithfulness block listing Pearson r per metric per
+    mode.
+    """
     groups_by_mode: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for g in summary["groups"]:
         groups_by_mode[g["mode"]].append(g)
@@ -205,18 +377,65 @@ def render_markdown(summary: dict[str, Any]) -> str:
     out.append(f"Total runs: **{summary['n_total_runs']}**")
     out.append("")
 
-    for mode in sorted(groups_by_mode):
-        out.append(f"## mode = `{mode}`")
-        out.append("")
-        headers = [label for _, label in _COLUMNS]
+    # Baseline table (if present).
+    if "baseline" in groups_by_mode:
+        _render_mode_table(
+            out,
+            "baseline",
+            groups_by_mode["baseline"],
+            _BASE_COLUMNS,
+            summary["faithfulness_by_mode"].get("baseline"),
+        )
+
+    # Agent table (if present). Rendered even when baseline is absent.
+    if "agent" in groups_by_mode:
+        _render_mode_table(
+            out,
+            "agent",
+            groups_by_mode["agent"],
+            _AGENT_COLUMNS,
+            summary["faithfulness_by_mode"].get("agent"),
+        )
+
+    # Any other modes (future-proofing) render with base columns.
+    for mode in sorted(m for m in groups_by_mode if m not in ("baseline", "agent")):
+        _render_mode_table(
+            out,
+            mode,
+            groups_by_mode[mode],
+            _BASE_COLUMNS,
+            summary["faithfulness_by_mode"].get(mode),
+        )
+
+    # Baseline-vs-agent comparison table.
+    out.append("## baseline vs agent")
+    out.append("")
+    cmp_rows = summary.get("baseline_vs_agent") or []
+    if cmp_rows:
+        headers = [label for _, label in _CMP_COLUMNS]
         out.append("| " + " | ".join(headers) + " |")
         out.append("|" + "|".join(["---"] * len(headers)) + "|")
-        for g in sorted(groups_by_mode[mode], key=lambda x: x["deletion_size"]):
-            row = [_fmt_cell(g[key]) for key, _ in _COLUMNS]
-            out.append("| " + " | ".join(row) + " |")
-        r = summary["faithfulness_by_mode"].get(mode)
+        for row in sorted(cmp_rows, key=lambda x: x["deletion_size"]):
+            cells = [_fmt_cell(row.get(key)) for key, _ in _CMP_COLUMNS]
+            out.append("| " + " | ".join(cells) + " |")
+    else:
+        out.append("_No shared deletion sizes between baseline and agent runs._")
+    out.append("")
+
+    # Per-metric drift faithfulness (Pearson r vs deletion_size, per mode).
+    drift_faith = summary.get("drift_faithfulness") or {}
+    if drift_faith:
+        out.append("## drift faithfulness (Pearson r vs deletion_size)")
         out.append("")
-        out.append(f"Faithfulness correlation (Pearson r, deletion_size vs pass_rate): **{_fmt_cell(r)}**")
+        modes = sorted({m for per_mode in drift_faith.values() for m in per_mode})
+        headers = ["metric"] + modes
+        out.append("| " + " | ".join(headers) + " |")
+        out.append("|" + "|".join(["---"] * len(headers)) + "|")
+        for metric in sorted(drift_faith):
+            cells = [metric] + [
+                _fmt_cell(drift_faith[metric].get(mode)) for mode in modes
+            ]
+            out.append("| " + " | ".join(cells) + " |")
         out.append("")
 
     return "\n".join(out).rstrip() + "\n"
@@ -229,7 +448,8 @@ def _parser() -> argparse.ArgumentParser:
         prog="summary.py",
         description=(
             "Aggregate ExperimentResult JSONL files into a per-(mode, deletion_size) "
-            "summary with Pearson-r faithfulness score."
+            "summary with drift metrics, baseline-vs-agent comparison, and Pearson-r "
+            "faithfulness scores."
         ),
     )
     p.add_argument(

--- a/experiments/test_summary.py
+++ b/experiments/test_summary.py
@@ -192,3 +192,245 @@ def test_summary_help() -> None:
     assert "--inputs" in result.stdout
     assert "--out" in result.stdout
     assert "--markdown" in result.stdout
+
+
+# ── Drift + baseline-vs-agent fixture (issue #25) ─────────────────────────────
+#
+# Fixture geometry: 2 SHAs × 3 deletion sizes (3, 7, 15) × 2 modes
+# (baseline, agent) = 12 rows, all with matching llm + human ProofMetrics so
+# every ratio and diff is well-defined. Values are deliberately spread so
+# baseline and agent differ at every deletion_size.
+
+def _proof_metrics(
+    *, vo_bytes: int, compile_time_s: float, n_assumptions: int,
+    proof_chars: int, proof_lines: int, tactic_count: int,
+) -> dict:
+    return {
+        "tactic_count": tactic_count,
+        "automation_ratio": 0.3,
+        "unique_tactic_types": 2,
+        "max_bullet_depth": 0,
+        "proof_chars": proof_chars,
+        "proof_lines": proof_lines,
+        "ends_with_admitted": False,
+        "vo_bytes": vo_bytes,
+        "compile_time_s": compile_time_s,
+        "n_assumptions": n_assumptions,
+    }
+
+
+def _fixture_row(
+    *, sha: str, dsize: int, mode: str, verdict: str,
+    llm: dict, human: dict, agent_n_turns: int | None = None,
+    normalized_edit_distance: float = 0.25,
+) -> dict:
+    row = {
+        "challenge_id": f"{sha}-d{dsize}-{mode}",
+        "declaration":  f"decl_{sha}_{dsize}",
+        "deletion_size": dsize,
+        "condition": "B",
+        "verdict": verdict,
+        "inference_time_s": 1.0,
+        "output_tokens": 100,
+        "mode": mode,
+        "llm_metrics": llm,
+        "human_metrics": human,
+        "normalized_edit_distance": normalized_edit_distance,
+    }
+    if agent_n_turns is not None:
+        row["agent_n_turns"] = agent_n_turns
+    return row
+
+
+def _write_full_fixture(path: Path) -> None:
+    """2 SHAs × 3 deletion_sizes × 2 modes fixture with varied drift signals."""
+    rows: list[dict] = []
+    shas = ["sha1", "sha2"]
+    dsizes = [3, 7, 15]
+
+    # Baseline: llm = human exactly (ratios = 1.0, diffs = 0) at dsize=3,
+    # then progressively drifts wider as deletion_size grows (ratios > 1,
+    # diffs > 0). Pass rate also degrades across deletion sizes.
+    baseline_pass_by_d = {3: True, 7: True, 15: False}
+    # (vo_ratio, compile_ratio, n_assum_diff, pchars_ratio, plines_ratio, tac_ratio)
+    baseline_drift = {
+        3:  (1.0, 1.0, 0, 1.0, 1.0, 1.0),
+        7:  (1.2, 1.5, 1, 1.1, 1.1, 1.25),
+        15: (1.5, 2.0, 2, 1.2, 1.5, 1.5),
+    }
+    # Agent: mostly passes, tighter drift (closer to 1.0) and more n_turns
+    # at larger deletion sizes.
+    agent_pass_by_d = {3: True, 7: True, 15: True}
+    agent_drift = {
+        3:  (1.1, 1.1, 0, 1.05, 1.0, 1.0),
+        7:  (1.0, 1.2, 0, 1.0,  1.0, 1.1),
+        15: (1.2, 1.5, 1, 1.1,  1.2, 1.25),
+    }
+    agent_turns_by_d = {3: 2, 7: 4, 15: 6}
+
+    for sha in shas:
+        for dsize in dsizes:
+            # Baseline row.
+            vor, ctr, nad, pcr, plr, tcr = baseline_drift[dsize]
+            human = _proof_metrics(
+                vo_bytes=1000, compile_time_s=1.0, n_assumptions=0,
+                proof_chars=100, proof_lines=10, tactic_count=4,
+            )
+            llm = _proof_metrics(
+                vo_bytes=int(round(1000 * vor)),
+                compile_time_s=1.0 * ctr,
+                n_assumptions=0 + nad,
+                proof_chars=int(round(100 * pcr)),
+                proof_lines=int(round(10 * plr)),
+                tactic_count=int(round(4 * tcr)),
+            )
+            rows.append(_fixture_row(
+                sha=sha, dsize=dsize, mode="baseline",
+                verdict="PASS" if baseline_pass_by_d[dsize] else "FAIL",
+                llm=llm, human=human,
+            ))
+
+            # Agent row.
+            vor, ctr, nad, pcr, plr, tcr = agent_drift[dsize]
+            human_a = _proof_metrics(
+                vo_bytes=1000, compile_time_s=1.0, n_assumptions=0,
+                proof_chars=100, proof_lines=10, tactic_count=4,
+            )
+            llm_a = _proof_metrics(
+                vo_bytes=int(round(1000 * vor)),
+                compile_time_s=1.0 * ctr,
+                n_assumptions=0 + nad,
+                proof_chars=int(round(100 * pcr)),
+                proof_lines=int(round(10 * plr)),
+                tactic_count=int(round(4 * tcr)),
+            )
+            rows.append(_fixture_row(
+                sha=sha, dsize=dsize, mode="agent",
+                verdict="PASS" if agent_pass_by_d[dsize] else "FAIL",
+                llm=llm_a, human=human_a,
+                agent_n_turns=agent_turns_by_d[dsize],
+                normalized_edit_distance=0.1,
+            ))
+
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+
+def test_summary_drift_and_cross_mode(tmp_path: Path) -> None:
+    tmpfile = tmp_path / "runs.jsonl"
+    _write_full_fixture(tmpfile)
+
+    out_json = tmp_path / "summary.json"
+    out_md = tmp_path / "summary.md"
+
+    result = subprocess.run(
+        [
+            sys.executable, str(HERE / "summary.py"),
+            "--inputs", str(tmpfile),
+            "--out", str(out_json),
+            "--markdown", str(out_md),
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 0, f"summary.py failed: {result.stderr}"
+
+    summary = json.loads(out_json.read_text())
+
+    # Six (mode, deletion_size) groups (2 modes × 3 sizes), 12 total runs.
+    assert summary["n_total_runs"] == 12
+    groups = {(g["mode"], g["deletion_size"]): g for g in summary["groups"]}
+    assert len(groups) == 6
+
+    # ── Baseline drift metrics (averaged across 2 SHAs per deletion_size).
+    b3 = groups[("baseline", 3)]
+    assert abs(b3["mean_vo_bytes_ratio"] - 1.0) < 1e-6
+    assert abs(b3["mean_compile_time_ratio"] - 1.0) < 1e-6
+    assert abs(b3["mean_n_assumptions_diff"] - 0.0) < 1e-6
+    assert abs(b3["mean_proof_chars_ratio"] - 1.0) < 1e-6
+    assert abs(b3["mean_proof_lines_ratio"] - 1.0) < 1e-6
+    assert abs(b3["mean_tactic_count_ratio"] - 1.0) < 1e-6
+    # Baseline rows never populate agent turns.
+    assert b3["mean_agent_n_turns"] is None
+
+    b7 = groups[("baseline", 7)]
+    assert abs(b7["mean_vo_bytes_ratio"] - 1.2) < 1e-6
+    assert abs(b7["mean_compile_time_ratio"] - 1.5) < 1e-6
+    assert abs(b7["mean_n_assumptions_diff"] - 1.0) < 1e-6
+    # proof_chars: 110/100 for each SHA at dsize=7, mean = 1.1
+    assert abs(b7["mean_proof_chars_ratio"] - 1.1) < 1e-6
+    # tactic_count: round(4*1.25)=5, 5/4 = 1.25
+    assert abs(b7["mean_tactic_count_ratio"] - 1.25) < 1e-6
+
+    b15 = groups[("baseline", 15)]
+    assert abs(b15["mean_vo_bytes_ratio"] - 1.5) < 1e-6
+    assert abs(b15["mean_compile_time_ratio"] - 2.0) < 1e-6
+    assert abs(b15["mean_n_assumptions_diff"] - 2.0) < 1e-6
+
+    # ── Agent drift metrics + agent_n_turns populated.
+    a3 = groups[("agent", 3)]
+    assert abs(a3["mean_vo_bytes_ratio"] - 1.1) < 1e-6
+    assert a3["mean_agent_n_turns"] is not None
+    assert abs(a3["mean_agent_n_turns"] - 2.0) < 1e-6
+    a7 = groups[("agent", 7)]
+    assert abs(a7["mean_agent_n_turns"] - 4.0) < 1e-6
+    a15 = groups[("agent", 15)]
+    assert abs(a15["mean_agent_n_turns"] - 6.0) < 1e-6
+
+    # ── Pass rates: baseline {1.0, 1.0, 0.0}, agent {1.0, 1.0, 1.0}.
+    assert groups[("baseline", 3)]["pass_rate"] == 1.0
+    assert groups[("baseline", 7)]["pass_rate"] == 1.0
+    assert groups[("baseline", 15)]["pass_rate"] == 0.0
+    assert groups[("agent", 3)]["pass_rate"] == 1.0
+    assert groups[("agent", 7)]["pass_rate"] == 1.0
+    assert groups[("agent", 15)]["pass_rate"] == 1.0
+
+    # ── baseline_vs_agent: one row per shared deletion_size.
+    cmp_rows = summary["baseline_vs_agent"]
+    assert [r["deletion_size"] for r in cmp_rows] == [3, 7, 15]
+    cmp_by_d = {r["deletion_size"]: r for r in cmp_rows}
+    # dsize=15: agent passes all, baseline fails all → Δpass_rate = 1.0.
+    assert abs(cmp_by_d[15]["delta_pass_rate"] - 1.0) < 1e-6
+    assert abs(cmp_by_d[3]["delta_pass_rate"] - 0.0) < 1e-6
+    # Δnorm_edit_dist: agent 0.1 − baseline 0.25 = -0.15.
+    assert abs(cmp_by_d[3]["delta_normalized_edit_distance"] - (-0.15)) < 1e-6
+    # Δmean_agent_n_turns reports the agent-side turn count directly.
+    assert abs(cmp_by_d[7]["delta_mean_agent_n_turns"] - 4.0) < 1e-6
+
+    # ── drift_faithfulness: per-metric Pearson r vs deletion_size, per mode.
+    drift_faith = summary["drift_faithfulness"]
+    # Keys we required on each row are present.
+    for metric in (
+        "mean_vo_bytes_ratio", "mean_compile_time_ratio",
+        "mean_n_assumptions_diff", "mean_proof_chars_ratio",
+        "mean_proof_lines_ratio", "mean_tactic_count_ratio",
+        "pass_rate", "mean_normalized_edit_distance",
+    ):
+        assert metric in drift_faith, f"missing {metric} in drift_faithfulness"
+        assert "baseline" in drift_faith[metric]
+        assert "agent" in drift_faith[metric]
+
+    # Baseline vo_bytes ratio rises monotonically with deletion_size → r ~ +1.
+    r_vo_baseline = drift_faith["mean_vo_bytes_ratio"]["baseline"]
+    assert r_vo_baseline is not None
+    assert math.isfinite(r_vo_baseline)
+    assert r_vo_baseline > 0.9, f"expected strong positive r, got {r_vo_baseline}"
+
+    # Baseline pass_rate drops with deletion_size → r < 0.
+    r_pass_baseline = drift_faith["pass_rate"]["baseline"]
+    assert r_pass_baseline is not None
+    assert r_pass_baseline < 0
+
+    # ── Markdown: three tables + drift-faithfulness block.
+    md = out_md.read_text()
+    assert "mode = `baseline`" in md
+    assert "mode = `agent`" in md
+    assert "baseline vs agent" in md
+    # Drift columns surfaced in the baseline / agent tables.
+    assert "vo_bytes_ratio" in md
+    assert "n_assumptions_diff" in md
+    # Agent-only column present at least in the agent table.
+    assert "mean_agent_n_turns" in md
+    # Three distinct header bars → three tables rendered.
+    assert md.count("| deletion_size |") >= 2
+    assert "Δpass_rate" in md
+    # Drift faithfulness block.
+    assert "drift faithfulness" in md


### PR DESCRIPTION
## Summary
- Adds drift columns to every per-(mode, deletion_size) row: `mean_vo_bytes_ratio`, `mean_compile_time_ratio`, `mean_n_assumptions_diff`, `mean_proof_chars_ratio`, `mean_proof_lines_ratio`, `mean_tactic_count_ratio`, plus `mean_agent_n_turns` on agent rows (None on baseline rows).
- Adds a top-level `baseline_vs_agent` section with per-deletion_size Δpass_rate, Δnormalized_edit_distance, Δmean_agent_n_turns — only for deletion sizes where both modes have data.
- Adds a top-level `drift_faithfulness` block: per-metric Pearson r vs deletion_size, per mode, same shape as the existing `faithfulness_by_mode` (`{metric: {mode: float|None}}`). Reuses the existing `_pearson_r` helper.
- Markdown rendering now emits three tables — baseline, agent, baseline-vs-agent — plus the drift-faithfulness block. Existing baseline columns preserved.
- Ratios are per-record `llm/human` then meaned (skipping records where either side is missing or the denominator is zero); diffs are per-record `llm − human` then meaned.

## Test plan
- [x] `uv run python -c "import summary"` — no errors.
- [x] `uv run python summary.py --help` — renders.
- [x] `uv run pytest test_summary.py -v` — 4 passed (3 existing + 1 new `test_summary_drift_and_cross_mode` with a 2 SHAs × 3 deletion sizes × 2 modes fixture asserting every new ratio/diff/delta/Pearson sign).
- [x] `uv run pytest -v` — 48 passed (was 47 on master; one new test added).

Closes #25.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)