### PR TITLE
fix: replace hand-rolled .env parsers with python-dotenv

### DIFF
--- a/scaffold/pyproject.toml
+++ b/scaffold/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "typer>=0.24.0",
     "anthropic>=0.52.0",
     "pydantic-ai>=1.76.0",
+    "python-dotenv>=1.2.2",
     "rich>=14.3.2",
     "pydantic-ai-harness[code-mode]>=0.3.0",
     "logfire>=4.31.0",

--- a/scaffold/src/quali/study.py
+++ b/scaffold/src/quali/study.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import cast
 
@@ -58,30 +57,19 @@ evidence supports.\
 """
 
 
-def _find_dotenv() -> Path | None:
-    """Walk up from CWD looking for a .env file."""
-    cur = Path.cwd()
-    while True:
-        candidate = cur / ".env"
-        if candidate.is_file():
-            return candidate
-        parent = cur.parent
-        if parent == cur:
-            return None
-        cur = parent
-
-
 def load_env(path: Path | None = None) -> None:
-    """Load a .env file. If no path given, searches up from CWD."""
-    if path is None:
-        path = _find_dotenv()
-    if path is None or not path.exists():
-        return
-    for line in path.read_text().splitlines():
-        line = line.strip()
-        if line and not line.startswith("#") and "=" in line:
-            key, _, value = line.partition("=")
-            os.environ.setdefault(key.strip(), value.strip())
+    """Load a .env file. If no path given, searches up from CWD.
+
+    Existing env vars win (python-dotenv's default ``override=False``).
+    """
+    from dotenv import find_dotenv, load_dotenv
+
+    if path is not None:
+        load_dotenv(path)
+    else:
+        dotenv_path = find_dotenv(usecwd=True)
+        if dotenv_path:
+            load_dotenv(dotenv_path)
 
 
 def load_commit_index(grouped_path: Path) -> dict[str, dict]:

--- a/scaffold/src/scaffold/profiler/runner.py
+++ b/scaffold/src/scaffold/profiler/runner.py
@@ -17,7 +17,6 @@ on failure it survives and is recoverable via ``scaffold materialize``.
 from __future__ import annotations
 
 import logging
-import os
 import shutil
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -31,29 +30,19 @@ from .deps import ProfilerDeps
 logger = logging.getLogger(__name__)
 
 
-def _load_dotenv(start: Path | None = None) -> Path | None:
-    """Load the nearest ``.env`` (walking up from ``start``/CWD) into ``os.environ``.
+def _load_dotenv() -> None:
+    """Load the nearest ``.env`` (walking up from CWD) into ``os.environ``.
 
     pydantic-ai reads ``ANTHROPIC_API_KEY`` from the environment, but this repo
     keeps the key in a ``.env`` at the monorepo root (one dir above ``scaffold``).
-    Mirrors quali's ``load_env``: existing env vars win (``setdefault``), values
-    have surrounding quotes stripped. Returns the file loaded, or None.
+    Existing env vars win (python-dotenv's default ``override=False``).
     """
-    cur = (start or Path.cwd()).resolve()
-    while True:
-        candidate = cur / ".env"
-        if candidate.is_file():
-            for line in candidate.read_text().splitlines():
-                line = line.strip()
-                if not line or line.startswith("#") or "=" not in line:
-                    continue
-                key, _, value = line.partition("=")
-                os.environ.setdefault(key.strip(), value.strip().strip("'\""))
-            logger.info("Loaded environment from %s", candidate)
-            return candidate
-        if cur.parent == cur:
-            return None
-        cur = cur.parent
+    from dotenv import find_dotenv, load_dotenv
+
+    dotenv_path = find_dotenv(usecwd=True)
+    if dotenv_path:
+        load_dotenv(dotenv_path)
+        logger.info("Loaded environment from %s", dotenv_path)
 
 
 @dataclass

--- a/scaffold/uv.lock
+++ b/scaffold/uv.lock
@@ -2088,6 +2088,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-ai" },
     { name = "pydantic-ai-harness", extra = ["code-mode"] },
+    { name = "python-dotenv" },
     { name = "rich" },
     { name = "typer" },
 ]
@@ -2107,6 +2108,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-ai", specifier = ">=1.76.0" },
     { name = "pydantic-ai-harness", extras = ["code-mode"], specifier = ">=0.3.0" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "rich", specifier = ">=14.3.2" },
     { name = "typer", specifier = ">=0.24.0" },
 ]


### PR DESCRIPTION
## Summary

Closes #63.

- Replace the hand-rolled `_load_dotenv()` in `scaffold/src/scaffold/profiler/runner.py` and `load_env()`/`_find_dotenv()` in `scaffold/src/quali/study.py` with `python-dotenv`'s `find_dotenv(usecwd=True)` + `load_dotenv()`
- Add `python-dotenv>=1.2.2` as a direct dependency in `scaffold/pyproject.toml` (was already a transitive dep)
- Remove unused `os` imports from both modules
- Preserves "existing env vars win" semantics via python-dotenv's default `override=False`

## Test plan

- [x] All 47 existing tests pass
- [x] ruff format clean
- [x] ruff check clean
- [ ] Manual: verify `ANTHROPIC_API_KEY` is still picked up from monorepo root `.env` when running `scaffold profile` or `quali`

🤖 Generated with [Claude Code](https://claude.com/claude-code)