### PR TITLE
Wire classification_priority into classify_commit

### DIFF
--- a/docs/PatternDetectorChanges.md
+++ b/docs/PatternDetectorChanges.md
@@ -146,6 +146,32 @@ stratify-tactics          ->  per-tactic subdataset files
 
 ---
 
+## v3 — Data-driven classification priority (#65)
+
+### What changed
+
+**`classification_priority` is now wired into `classify_commit`.**
+
+The `RepoProfile.classification_priority` field (added in PR #60) declared the
+order in which commit classes are checked, but `classify_commit` used a hardcoded
+if/elif chain that ignored it. The field was dead configuration.
+
+The hardcoded chain has been refactored into per-class checker functions
+(`_check_infra`, `_check_proof_complete`, etc.) dispatched via a `_CLASSIFIERS`
+dict. `classify_commit` now iterates `classification_priority` and calls each
+checker in priority order — the first match wins.
+
+**Backwards-compatibility note:** Profiles with a non-default
+`classification_priority` (e.g. `agent-recovered-f0b38f3c` for fiat-crypto) were
+previously unaffected by the field because it was ignored. Re-mining with such
+profiles will now respect the stored priority order, which could change
+classification for commits matching multiple signal banks simultaneously. In
+practice this is unlikely to affect results because signal regex sets rarely
+overlap, but it is a semantic change worth noting. If in doubt, set the profile's
+`classification_priority` to the default order.
+
+---
+
 ## Generalization work (toward repo-agnostic mining)
 
 The v0–v2 changes above were developed against fiat-crypto. The following

--- a/scaffold/src/scaffold/pattern_detector.py
+++ b/scaffold/src/scaffold/pattern_detector.py
@@ -9,12 +9,20 @@ lives here; the regexes it consults live in the profile.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
 
 from scaffold.models import CommitClass, CommitRecord
 from scaffold.profile import CompiledProfile
 
 logger = logging.getLogger(__name__)
+
+# Type alias for per-class checker functions.
+# Each takes (record, text, subject, has, has_ctx) and returns a CommitClass
+# if the check matched, or None to defer to the next priority.
+_HasFn = Callable[[str, str], bool]
+_HasCtxFn = Callable[[str], bool]
+_CheckerFn = Callable[[CommitRecord, str, str, _HasFn, _HasCtxFn], CommitClass | None]
 
 
 # ---------------------------------------------------------------------------
@@ -60,18 +68,141 @@ def assign_tactic_groups(
 # ---------------------------------------------------------------------------
 
 
+def _check_infra(
+    record: CommitRecord,
+    text: str,
+    subject: str,
+    has: _HasFn,
+    has_ctx: _HasCtxFn,
+) -> CommitClass | None:
+    """Infrastructure noise — check subject only to avoid body false positives."""
+    if has("infra", subject) and not has_ctx(subject):
+        return CommitClass.infra
+    return None
+
+
+def _check_proof_complete(
+    record: CommitRecord,
+    text: str,
+    subject: str,
+    has: _HasFn,
+    has_ctx: _HasCtxFn,
+) -> CommitClass | None:
+    """Explicit hole closure language, plus a structural heuristic."""
+    if has("proof_complete", text) and has_ctx(text):
+        return CommitClass.proof_complete
+    # Structural heuristic for body-free commits: net deletions in proof files
+    # with proof-context subject => likely a hole was removed.
+    if (
+        record.touches_proof_files
+        and record.deletions > record.insertions
+        and not record.message_body
+        and has_ctx(text)
+        and not has("infra", text)
+    ):
+        return CommitClass.proof_complete
+    return None
+
+
+def _check_spec_change(
+    record: CommitRecord,
+    text: str,
+    subject: str,
+    has: _HasFn,
+    has_ctx: _HasCtxFn,
+) -> CommitClass | None:
+    """Statement-level edits on proof files."""
+    if has("spec_change", text) and record.touches_proof_files:
+        return CommitClass.spec_change
+    return None
+
+
+def _check_proof_new(
+    record: CommitRecord,
+    text: str,
+    subject: str,
+    has: _HasFn,
+    has_ctx: _HasCtxFn,
+) -> CommitClass | None:
+    """New lemma or theorem added with a proof."""
+    if has("proof_new", text) and record.touches_proof_files:
+        return CommitClass.proof_new
+    return None
+
+
+def _check_proof_add(
+    record: CommitRecord,
+    text: str,
+    subject: str,
+    has: _HasFn,
+    has_ctx: _HasCtxFn,
+) -> CommitClass | None:
+    """Partial or incremental proof work."""
+    if has("proof_add", text) and record.touches_proof_files:
+        return CommitClass.proof_add
+    return None
+
+
+def _check_refactor(
+    record: CommitRecord,
+    text: str,
+    subject: str,
+    has: _HasFn,
+    has_ctx: _HasCtxFn,
+) -> CommitClass | None:
+    """Refactoring — reclassified to proof_add when touching proof files."""
+    if has("refactor", text):
+        if record.touches_proof_files:
+            return CommitClass.proof_add
+        return CommitClass.refactor
+    return None
+
+
+def _check_fix(
+    record: CommitRecord,
+    text: str,
+    subject: str,
+    has: _HasFn,
+    has_ctx: _HasCtxFn,
+) -> CommitClass | None:
+    """Bug fix — reclassified to proof_add when touching proof files."""
+    if has("fix", text):
+        if record.touches_proof_files:
+            return CommitClass.proof_add
+        return CommitClass.fix
+    return None
+
+
+# Map of class name → checker function.  Iterated in the order given by
+# ``RepoProfile.classification_priority`` so reordering the list changes
+# which class wins when multiple signals match.
+_CLASSIFIERS: dict[str, _CheckerFn] = {
+    "infra": _check_infra,
+    "proof_complete": _check_proof_complete,
+    "spec_change": _check_spec_change,
+    "proof_new": _check_proof_new,
+    "proof_add": _check_proof_add,
+    "refactor": _check_refactor,
+    "fix": _check_fix,
+}
+
+
 def classify_commit(record: CommitRecord, compiled: CompiledProfile) -> CommitClass:
     """Classify a CommitRecord using the profile's signal banks.
 
-    Priority order (highest wins) — structure preserved from the original
-    hand-tuned classifier; only the regexes are now profile-supplied:
+    The check order is determined by ``compiled.profile.classification_priority``
+    (highest priority first). Each entry names a commit class whose checker
+    function is called in turn; the first match wins. Default order:
+
       1. infra          — dependency bumps / CI are almost never proof-relevant
       2. proof_complete — a hole was removed / proof closed
       3. spec_change    — theorem statement was changed
       4. proof_new      — new lemma/theorem added with a proof
       5. proof_add      — partial proof work (goals still open)
       6. refactor / fix (on proof files -> proof_add; else their own class)
-      7. other
+
+    After all priority entries are exhausted, any remaining commit that touches
+    proof files is classified as ``proof_add``; everything else as ``other``.
     """
     sig = compiled.commit_signal_res
     ctx = compiled.proof_context_re
@@ -86,49 +217,15 @@ def classify_commit(record: CommitRecord, compiled: CompiledProfile) -> CommitCl
     text = f"{record.message_subject} {record.message_body}".lower()
     subject = record.message_subject.lower()
 
-    # 1. Infrastructure noise — check subject only to avoid body false positives.
-    if has("infra", subject) and not has_ctx(subject):
-        return CommitClass.infra
+    for class_name in compiled.profile.classification_priority:
+        checker = _CLASSIFIERS.get(class_name)
+        if checker is None:
+            continue
+        result = checker(record, text, subject, has, has_ctx)
+        if result is not None:
+            return result
 
-    # 2. proof_complete — explicit hole closure language.
-    if has("proof_complete", text) and has_ctx(text):
-        return CommitClass.proof_complete
-
-    # Structural heuristic for body-free commits: net deletions in proof files
-    # with proof-context subject => likely a hole was removed.
-    if (
-        record.touches_proof_files
-        and record.deletions > record.insertions
-        and not record.message_body
-        and has_ctx(text)
-        and not has("infra", text)
-    ):
-        return CommitClass.proof_complete
-
-    # 3. spec_change — statement-level edits.
-    if has("spec_change", text) and record.touches_proof_files:
-        return CommitClass.spec_change
-
-    # 4. proof_new — new lemma or theorem added.
-    if has("proof_new", text) and record.touches_proof_files:
-        return CommitClass.proof_new
-
-    # 5. proof_add — partial or incremental proof work.
-    if has("proof_add", text) and record.touches_proof_files:
-        return CommitClass.proof_add
-
-    # 6. refactor / fix touching proof files -> proof_add.
-    if record.touches_proof_files:
-        if has("refactor", text) or has("fix", text):
-            return CommitClass.proof_add
-
-    # 7. refactor / fix on non-proof files stay as their own class.
-    if has("refactor", text):
-        return CommitClass.refactor
-    if has("fix", text):
-        return CommitClass.fix
-
-    # 8. Any remaining proof-file-touching commit -> proof_add.
+    # Fallback: any remaining proof-file-touching commit -> proof_add.
     if record.touches_proof_files:
         return CommitClass.proof_add
 

--- a/scaffold/src/scaffold/pattern_detector.py
+++ b/scaffold/src/scaffold/pattern_detector.py
@@ -175,7 +175,8 @@ def _check_fix(
 
 # Map of class name → checker function.  Iterated in the order given by
 # ``RepoProfile.classification_priority`` so reordering the list changes
-# which class wins when multiple signals match.
+# which class wins when multiple signals match.  The insertion order of
+# this dict is irrelevant; only the profile's priority list matters.
 _CLASSIFIERS: dict[str, _CheckerFn] = {
     "infra": _check_infra,
     "proof_complete": _check_proof_complete,
@@ -220,6 +221,10 @@ def classify_commit(record: CommitRecord, compiled: CompiledProfile) -> CommitCl
     for class_name in compiled.profile.classification_priority:
         checker = _CLASSIFIERS.get(class_name)
         if checker is None:
+            logger.warning(
+                "Unknown class %r in classification_priority, skipping",
+                class_name,
+            )
             continue
         result = checker(record, text, subject, has, has_ctx)
         if result is not None:

--- a/scaffold/src/scaffold/profile.py
+++ b/scaffold/src/scaffold/profile.py
@@ -120,7 +120,13 @@ class RepoProfile(BaseModel):
     )
     classification_priority: list[str] = Field(
         default_factory=lambda: list(DEFAULT_CLASSIFICATION_PRIORITY),
-        description="Order in which commit classes are tried (highest priority first).",
+        description=(
+            "Order in which commit classes are tried (highest priority first). "
+            "classify_commit iterates this list and the first matching class wins. "
+            "Valid entries: infra, proof_complete, spec_change, proof_new, proof_add, "
+            "refactor, fix. proof_optimise is excluded: it is derived from diffs, "
+            "not message signals."
+        ),
     )
 
     # --- tactic / proof-style analysis --------------------------------------
@@ -230,9 +236,7 @@ class CompiledProfile:
         keyword_re = re.compile(_word_alternation(keyword_terms), re.IGNORECASE)
         # Normalize tactic_groups keys to lowercase so lookups from the
         # lowercased tactic tags (git_walker diff extraction) always match.
-        tactic_groups_lower = {
-            k.lower(): v for k, v in profile.tactic_groups.items()
-        }
+        tactic_groups_lower = {k.lower(): v for k, v in profile.tactic_groups.items()}
         return cls(
             profile=profile,
             hole_res=hole_res,

--- a/scaffold/tests/test_pattern_detector.py
+++ b/scaffold/tests/test_pattern_detector.py
@@ -139,6 +139,49 @@ class TestDefaultPriority:
         rec = _make_record(message_subject="Update readme")
         assert classify_commit(rec, compiled) == CommitClass.other
 
+    def test_refactor_and_fix_dual_match_on_proof_files(self, compiled):
+        """Commit matching both refactor and fix on proof files → proof_add."""
+        rec = _make_record(
+            message_subject="Refactor to fix proof regression",
+            touches_proof_files=True,
+        )
+        assert classify_commit(rec, compiled) == CommitClass.proof_add
+
+    def test_refactor_and_fix_dual_match_on_non_proof_files(self, compiled):
+        """Commit matching both refactor and fix on non-proof files → refactor
+        (refactor is checked before fix in default priority)."""
+        rec = _make_record(message_subject="Refactor to fix build regression")
+        assert classify_commit(rec, compiled) == CommitClass.refactor
+
+    def test_signal_in_body_not_subject(self, compiled):
+        """A signal in the message body (not subject) should still match."""
+        rec = _make_record(
+            message_subject="Misc updates",
+            message_body="This change will complete the proof obligation.",
+            touches_proof_files=True,
+        )
+        assert classify_commit(rec, compiled) == CommitClass.proof_complete
+
+    def test_proof_add_signal_on_non_proof_files(self, compiled):
+        """proof_add requires touches_proof_files; without it → other."""
+        rec = _make_record(message_subject="Progress on documentation")
+        assert classify_commit(rec, compiled) == CommitClass.other
+
+    def test_no_proof_context_regex(self):
+        """Empty proof_context_regex: infra always fires (guard is vacuous),
+        proof_complete signal never fires (context required)."""
+        profile = _make_profile(proof_context_regex="")
+        compiled = profile.compiled()
+        # Infra: no context guard to block it.
+        rec_infra = _make_record(message_subject="Bump proof deps")
+        assert classify_commit(rec_infra, compiled) == CommitClass.infra
+        # proof_complete signal: requires has_ctx which always returns False.
+        rec_pc = _make_record(
+            message_subject="Complete proof of theorem",
+            touches_proof_files=True,
+        )
+        assert classify_commit(rec_pc, compiled) != CommitClass.proof_complete
+
 
 # ── Priority reordering ──────────────────────────────────────────────────
 
@@ -214,8 +257,27 @@ class TestPriorityReordering:
         # With default priority this would be infra; now it falls through to other.
         assert classify_commit(rec, compiled) == CommitClass.other
 
-    def test_unknown_class_name_ignored(self):
-        """An unknown entry in classification_priority is silently skipped."""
+    def test_fix_before_refactor_dual_match(self):
+        """When fix has higher priority than refactor, a dual-match commit
+        on non-proof files gets fix instead of refactor."""
+        rec = _make_record(message_subject="Refactor to fix build regression")
+        default_compiled = _make_profile().compiled()
+        assert classify_commit(rec, default_compiled) == CommitClass.refactor
+        swapped = _make_profile(
+            classification_priority=[
+                "infra",
+                "proof_complete",
+                "spec_change",
+                "proof_new",
+                "proof_add",
+                "fix",
+                "refactor",
+            ],
+        ).compiled()
+        assert classify_commit(rec, swapped) == CommitClass.fix
+
+    def test_unknown_class_name_warns_and_skips(self):
+        """An unknown entry in classification_priority logs a warning and is skipped."""
         profile = _make_profile(
             classification_priority=[
                 "imaginary_class",

--- a/scaffold/tests/test_pattern_detector.py
+++ b/scaffold/tests/test_pattern_detector.py
@@ -1,0 +1,247 @@
+"""Tests for classify_commit — including data-driven classification_priority."""
+
+from __future__ import annotations
+
+import pytest
+
+from scaffold.models import CommitClass, CommitRecord
+from scaffold.pattern_detector import classify_commit
+from scaffold.profile import HoleMarker, RepoProfile
+
+
+def _make_profile(**overrides: object) -> RepoProfile:
+    """Build a Coq-ish profile with commit signals suitable for classification tests."""
+    defaults: dict[str, object] = {
+        "proof_assistant": "coq",
+        "proof_file_globs": ["*.v"],
+        "hole_markers": [HoleMarker(regex=r"\bAdmitted\b", kind="admitted")],
+        "declaration_patterns": [
+            r"^\s*(?:Theorem|Lemma)\s+(\w+)",
+        ],
+        "commit_signals": {
+            "proof_complete": [r"complete", r"close\s+proof", r"fill\b"],
+            "proof_new": [r"add\s+lemma", r"new\s+theorem"],
+            "proof_add": [r"progress", r"partial"],
+            "spec_change": [r"change\s+statement", r"modify\s+spec"],
+            "infra": [r"bump\b", r"\bci\b", r"makefile"],
+            "refactor": [r"refactor", r"cleanup"],
+            "fix": [r"\bfix\b", r"bugfix"],
+        },
+        "proof_context_regex": r"proof|lemma|theorem|coq",
+    }
+    defaults.update(overrides)
+    return RepoProfile(**defaults)  # type: ignore[arg-type]
+
+
+def _make_record(**overrides: object) -> CommitRecord:
+    """Build a minimal CommitRecord, overriding any fields."""
+    defaults: dict[str, object] = {
+        "hash": "aaa",
+        "date": "2024-01-01T00:00:00",
+        "message_subject": "",
+        "message_body": "",
+        "touches_proof_files": False,
+        "insertions": 0,
+        "deletions": 0,
+    }
+    defaults.update(overrides)
+    return CommitRecord(**defaults)  # type: ignore[arg-type]
+
+
+# ── Default-priority classification ───────────────────────────────────────
+
+
+class TestDefaultPriority:
+    """Verify each class fires with the default priority order."""
+
+    @pytest.fixture
+    def compiled(self):
+        return _make_profile().compiled()
+
+    def test_infra(self, compiled):
+        rec = _make_record(message_subject="Bump deps in CI")
+        assert classify_commit(rec, compiled) == CommitClass.infra
+
+    def test_infra_suppressed_by_proof_context(self, compiled):
+        """Infra signal in subject with proof context → not infra."""
+        rec = _make_record(message_subject="Bump proof lemma CI")
+        assert classify_commit(rec, compiled) != CommitClass.infra
+
+    def test_proof_complete_signal(self, compiled):
+        rec = _make_record(
+            message_subject="Complete proof of add_comm",
+            touches_proof_files=True,
+        )
+        assert classify_commit(rec, compiled) == CommitClass.proof_complete
+
+    def test_proof_complete_structural_heuristic(self, compiled):
+        """Body-free, net deletions on proof files with proof context."""
+        rec = _make_record(
+            message_subject="Remove admitted in theorem",
+            touches_proof_files=True,
+            deletions=10,
+            insertions=3,
+        )
+        assert classify_commit(rec, compiled) == CommitClass.proof_complete
+
+    def test_spec_change(self, compiled):
+        rec = _make_record(
+            message_subject="Change statement of foo",
+            touches_proof_files=True,
+        )
+        assert classify_commit(rec, compiled) == CommitClass.spec_change
+
+    def test_proof_new(self, compiled):
+        rec = _make_record(
+            message_subject="Add lemma for bar",
+            touches_proof_files=True,
+        )
+        assert classify_commit(rec, compiled) == CommitClass.proof_new
+
+    def test_proof_add(self, compiled):
+        rec = _make_record(
+            message_subject="Progress on proof",
+            touches_proof_files=True,
+        )
+        assert classify_commit(rec, compiled) == CommitClass.proof_add
+
+    def test_refactor_on_proof_files_becomes_proof_add(self, compiled):
+        rec = _make_record(
+            message_subject="Refactor proof structure",
+            touches_proof_files=True,
+        )
+        assert classify_commit(rec, compiled) == CommitClass.proof_add
+
+    def test_fix_on_proof_files_becomes_proof_add(self, compiled):
+        rec = _make_record(
+            message_subject="Fix proof of foo",
+            touches_proof_files=True,
+        )
+        assert classify_commit(rec, compiled) == CommitClass.proof_add
+
+    def test_refactor_on_non_proof_files(self, compiled):
+        rec = _make_record(message_subject="Refactor build scripts")
+        assert classify_commit(rec, compiled) == CommitClass.refactor
+
+    def test_fix_on_non_proof_files(self, compiled):
+        rec = _make_record(message_subject="Fix typo in readme")
+        assert classify_commit(rec, compiled) == CommitClass.fix
+
+    def test_proof_file_fallback(self, compiled):
+        """Commit touching proof files with no signal → proof_add."""
+        rec = _make_record(
+            message_subject="Minor tweaks",
+            touches_proof_files=True,
+        )
+        assert classify_commit(rec, compiled) == CommitClass.proof_add
+
+    def test_other(self, compiled):
+        rec = _make_record(message_subject="Update readme")
+        assert classify_commit(rec, compiled) == CommitClass.other
+
+
+# ── Priority reordering ──────────────────────────────────────────────────
+
+
+class TestPriorityReordering:
+    """Verify that reordering classification_priority changes results."""
+
+    def test_spec_change_before_proof_complete(self):
+        """When spec_change has higher priority than proof_complete,
+        a commit matching both signals should be classified as spec_change."""
+        profile = _make_profile(
+            classification_priority=[
+                "spec_change",
+                "proof_complete",
+                "infra",
+                "proof_new",
+                "proof_add",
+                "refactor",
+                "fix",
+            ],
+        )
+        compiled = profile.compiled()
+        # This commit message matches both proof_complete ("complete") and
+        # spec_change ("change statement").
+        rec = _make_record(
+            message_subject="Complete change statement of theorem",
+            touches_proof_files=True,
+        )
+        # With default priority, proof_complete would win.
+        default_compiled = _make_profile().compiled()
+        assert classify_commit(rec, default_compiled) == CommitClass.proof_complete
+        # With spec_change first, spec_change wins.
+        assert classify_commit(rec, compiled) == CommitClass.spec_change
+
+    def test_proof_add_before_proof_new(self):
+        """When proof_add has higher priority than proof_new, it wins."""
+        rec = _make_record(
+            message_subject="Add lemma with progress",
+            touches_proof_files=True,
+        )
+        default_compiled = _make_profile().compiled()
+        # Default: proof_new comes before proof_add, so proof_new wins.
+        assert classify_commit(rec, default_compiled) == CommitClass.proof_new
+        # Swap: proof_add before proof_new.
+        swapped = _make_profile(
+            classification_priority=[
+                "infra",
+                "proof_complete",
+                "spec_change",
+                "proof_add",
+                "proof_new",
+                "refactor",
+                "fix",
+            ],
+        ).compiled()
+        assert classify_commit(rec, swapped) == CommitClass.proof_add
+
+    def test_omitting_class_from_priority(self):
+        """A class omitted from classification_priority never fires."""
+        profile = _make_profile(
+            classification_priority=[
+                "proof_complete",
+                "spec_change",
+                "proof_new",
+                "proof_add",
+                "refactor",
+                "fix",
+                # "infra" intentionally omitted
+            ],
+        )
+        compiled = profile.compiled()
+        rec = _make_record(message_subject="Bump CI deps")
+        # With default priority this would be infra; now it falls through to other.
+        assert classify_commit(rec, compiled) == CommitClass.other
+
+    def test_unknown_class_name_ignored(self):
+        """An unknown entry in classification_priority is silently skipped."""
+        profile = _make_profile(
+            classification_priority=[
+                "imaginary_class",
+                "infra",
+                "proof_complete",
+                "spec_change",
+                "proof_new",
+                "proof_add",
+                "refactor",
+                "fix",
+            ],
+        )
+        compiled = profile.compiled()
+        rec = _make_record(message_subject="Bump CI deps")
+        assert classify_commit(rec, compiled) == CommitClass.infra
+
+    def test_empty_priority_only_fallback(self):
+        """Empty classification_priority → only the proof_add/other fallback."""
+        profile = _make_profile(classification_priority=[])
+        compiled = profile.compiled()
+        rec = _make_record(
+            message_subject="Complete proof of theorem",
+            touches_proof_files=True,
+        )
+        # No checkers run, but touches proof files → proof_add fallback.
+        assert classify_commit(rec, compiled) == CommitClass.proof_add
+
+        rec2 = _make_record(message_subject="Complete proof of theorem")
+        assert classify_commit(rec2, compiled) == CommitClass.other


### PR DESCRIPTION
## Summary

Closes #65.

- Refactors the hardcoded if/elif chain in `classify_commit` into per-class checker functions (`_check_infra`, `_check_proof_complete`, etc.) dispatched via a `_CLASSIFIERS` dict
- `classify_commit` now iterates `compiled.profile.classification_priority` and calls each checker in order — the first match wins
- Default priority order is unchanged, so all existing behavior is preserved
- Updated the `classification_priority` field description to document the valid entries and that it's now actively used
- Added 18 tests in `test_pattern_detector.py` covering every class in the default priority, the structural heuristic, refactor/fix reclassification on proof files, and priority reordering scenarios

## Test plan

- [x] All 18 new `test_pattern_detector.py` tests pass
- [x] Full test suite (65 tests) passes
- [x] `ruff format` clean
- [x] `ruff check` clean
- [x] `ty check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)