### PR TITLE
fix(profile): harden regex compilation with field-level errors

### DIFF
--- a/scaffold/src/scaffold/profile.py
+++ b/scaffold/src/scaffold/profile.py
@@ -20,7 +20,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 # Default order in which message-based commit classes are tried (highest wins).
 # Mirrors the legacy classify_commit decision tree. proof_optimise is excluded:
@@ -34,6 +34,17 @@ DEFAULT_CLASSIFICATION_PRIORITY: list[str] = [
     "refactor",
     "fix",
 ]
+
+
+def _check_regex(pattern: str, field_name: str, flags: int = 0) -> str:
+    """Try to compile *pattern*; raise ``ValueError`` with *field_name* context on failure."""
+    try:
+        re.compile(pattern, flags)
+    except re.error as e:
+        raise ValueError(
+            f"invalid regex in {field_name}: {e.msg} in pattern {pattern!r}"
+        ) from e
+    return pattern
 
 
 class HoleMarker(BaseModel):
@@ -50,6 +61,11 @@ class HoleMarker(BaseModel):
     kind: str = Field(
         description="Label for this hole kind, e.g. 'sorry' or 'admitted'."
     )
+
+    @field_validator("regex")
+    @classmethod
+    def _validate_regex(cls, v: str) -> str:
+        return _check_regex(v, "hole_markers.regex")
 
 
 class Provenance(BaseModel):
@@ -156,6 +172,35 @@ class RepoProfile(BaseModel):
     )
     provenance: Provenance = Field(default_factory=Provenance)
 
+    @field_validator("declaration_patterns")
+    @classmethod
+    def _validate_declaration_patterns(cls, v: list[str]) -> list[str]:
+        for i, p in enumerate(v):
+            _check_regex(p, f"declaration_patterns[{i}]", re.MULTILINE)
+        return v
+
+    @field_validator("commit_signals")
+    @classmethod
+    def _validate_commit_signals(cls, v: dict[str, list[str]]) -> dict[str, list[str]]:
+        for name, sigs in v.items():
+            for i, s in enumerate(sigs):
+                _check_regex(s, f"commit_signals.{name}[{i}]", re.IGNORECASE)
+        return v
+
+    @field_validator("proof_context_regex")
+    @classmethod
+    def _validate_proof_context_regex(cls, v: str) -> str:
+        if v:
+            _check_regex(v, "proof_context_regex", re.IGNORECASE)
+        return v
+
+    @field_validator("proof_style_signals")
+    @classmethod
+    def _validate_proof_style_signals(cls, v: dict[str, str]) -> dict[str, str]:
+        for name, rx in v.items():
+            _check_regex(rx, f"proof_style_signals.{name}", re.MULTILINE)
+        return v
+
     def compiled(self) -> CompiledProfile:
         """Pre-compile every regex once; the engine uses this hot-path view."""
         return CompiledProfile.from_profile(self)
@@ -190,20 +235,43 @@ class CompiledProfile:
 
     @classmethod
     def from_profile(cls, profile: RepoProfile) -> CompiledProfile:
-        hole_res = [(re.compile(h.regex), h.kind) for h in profile.hole_markers]
-        declaration_res = [
-            re.compile(p, re.MULTILINE) for p in profile.declaration_patterns
-        ]
-        commit_signal_res = {
-            name: re.compile("|".join(sigs), re.IGNORECASE)
-            for name, sigs in profile.commit_signals.items()
-            if sigs
-        }
-        proof_context_re = (
-            re.compile(profile.proof_context_regex, re.IGNORECASE)
-            if profile.proof_context_regex
-            else None
-        )
+        # Defense-in-depth: wrap each section so a bad regex names the field.
+        # The pydantic validators on RepoProfile catch most issues at
+        # deserialization time; these try/excepts guard against profiles built
+        # programmatically without going through model_validate().
+        try:
+            hole_res = [(re.compile(h.regex), h.kind) for h in profile.hole_markers]
+        except re.error as e:
+            raise ValueError(f"invalid regex in hole_markers: {e}") from e
+        try:
+            declaration_res = [
+                re.compile(p, re.MULTILINE) for p in profile.declaration_patterns
+            ]
+        except re.error as e:
+            raise ValueError(f"invalid regex in declaration_patterns: {e}") from e
+
+        # Validate individual commit signals before joining with "|".
+        commit_signal_res: dict[str, re.Pattern[str]] = {}
+        for name, sigs in profile.commit_signals.items():
+            if not sigs:
+                continue
+            for i, sig in enumerate(sigs):
+                try:
+                    re.compile(sig, re.IGNORECASE)
+                except re.error as e:
+                    raise ValueError(
+                        f"invalid regex in commit_signals.{name}[{i}]: {e}"
+                    ) from e
+            commit_signal_res[name] = re.compile("|".join(sigs), re.IGNORECASE)
+
+        try:
+            proof_context_re = (
+                re.compile(profile.proof_context_regex, re.IGNORECASE)
+                if profile.proof_context_regex
+                else None
+            )
+        except re.error as e:
+            raise ValueError(f"invalid regex in proof_context_regex: {e}") from e
         # Boundary-aware tactic regex: a tactic at a tactic position. Group 1 = name.
         ordered_tactics = sorted(
             {t for t in profile.tactic_vocabulary if t},
@@ -215,10 +283,13 @@ class CompiledProfile:
             r"(?:^|[\s;|{(])(" + tactic_alt + r")(?:\s|[.;()\[\]{]|$)",
             re.IGNORECASE | re.MULTILINE,
         )
-        proof_style_res = {
-            name: re.compile(rx, re.MULTILINE)
-            for name, rx in profile.proof_style_signals.items()
-        }
+        try:
+            proof_style_res = {
+                name: re.compile(rx, re.MULTILINE)
+                for name, rx in profile.proof_style_signals.items()
+            }
+        except re.error as e:
+            raise ValueError(f"invalid regex in proof_style_signals: {e}") from e
         # Keyword extraction matches over the union of hole kinds + structural + tactic + domain.
         hole_kinds = [h.kind for h in profile.hole_markers]
         keyword_terms = (
@@ -230,9 +301,7 @@ class CompiledProfile:
         keyword_re = re.compile(_word_alternation(keyword_terms), re.IGNORECASE)
         # Normalize tactic_groups keys to lowercase so lookups from the
         # lowercased tactic tags (git_walker diff extraction) always match.
-        tactic_groups_lower = {
-            k.lower(): v for k, v in profile.tactic_groups.items()
-        }
+        tactic_groups_lower = {k.lower(): v for k, v in profile.tactic_groups.items()}
         return cls(
             profile=profile,
             hole_res=hole_res,

--- a/scaffold/src/scaffold/profile.py
+++ b/scaffold/src/scaffold/profile.py
@@ -239,16 +239,20 @@ class CompiledProfile:
         # The pydantic validators on RepoProfile catch most issues at
         # deserialization time; these try/excepts guard against profiles built
         # programmatically without going through model_validate().
-        try:
-            hole_res = [(re.compile(h.regex), h.kind) for h in profile.hole_markers]
-        except re.error as e:
-            raise ValueError(f"invalid regex in hole_markers: {e}") from e
-        try:
-            declaration_res = [
-                re.compile(p, re.MULTILINE) for p in profile.declaration_patterns
-            ]
-        except re.error as e:
-            raise ValueError(f"invalid regex in declaration_patterns: {e}") from e
+        hole_res: list[tuple[re.Pattern[str], str]] = []
+        for i, h in enumerate(profile.hole_markers):
+            try:
+                hole_res.append((re.compile(h.regex), h.kind))
+            except re.error as e:
+                raise ValueError(f"invalid regex in hole_markers[{i}]: {e}") from e
+        declaration_res: list[re.Pattern[str]] = []
+        for i, p in enumerate(profile.declaration_patterns):
+            try:
+                declaration_res.append(re.compile(p, re.MULTILINE))
+            except re.error as e:
+                raise ValueError(
+                    f"invalid regex in declaration_patterns[{i}]: {e}"
+                ) from e
 
         # Validate individual commit signals before joining with "|".
         commit_signal_res: dict[str, re.Pattern[str]] = {}
@@ -283,13 +287,14 @@ class CompiledProfile:
             r"(?:^|[\s;|{(])(" + tactic_alt + r")(?:\s|[.;()\[\]{]|$)",
             re.IGNORECASE | re.MULTILINE,
         )
-        try:
-            proof_style_res = {
-                name: re.compile(rx, re.MULTILINE)
-                for name, rx in profile.proof_style_signals.items()
-            }
-        except re.error as e:
-            raise ValueError(f"invalid regex in proof_style_signals: {e}") from e
+        proof_style_res: dict[str, re.Pattern[str]] = {}
+        for name, rx in profile.proof_style_signals.items():
+            try:
+                proof_style_res[name] = re.compile(rx, re.MULTILINE)
+            except re.error as e:
+                raise ValueError(
+                    f"invalid regex in proof_style_signals.{name}: {e}"
+                ) from e
         # Keyword extraction matches over the union of hole kinds + structural + tactic + domain.
         hole_kinds = [h.kind for h in profile.hole_markers]
         keyword_terms = (

--- a/scaffold/tests/test_regex_validation.py
+++ b/scaffold/tests/test_regex_validation.py
@@ -7,6 +7,7 @@ and CompiledProfile.from_profile() wraps compilation per field as defense-in-dep
 
 from __future__ import annotations
 
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -119,7 +120,7 @@ def test_compiled_profile_bad_hole_markers() -> None:
         structural_terms=[],
         domain_terms=[],
     )
-    with pytest.raises(ValueError, match="hole_markers"):
+    with pytest.raises(ValueError, match=r"hole_markers\[0\]"):
         CompiledProfile.from_profile(profile)
 
 
@@ -137,7 +138,7 @@ def test_compiled_profile_bad_declaration_patterns() -> None:
         structural_terms=[],
         domain_terms=[],
     )
-    with pytest.raises(ValueError, match="declaration_patterns"):
+    with pytest.raises(ValueError, match=r"declaration_patterns\[0\]"):
         CompiledProfile.from_profile(profile)
 
 
@@ -192,14 +193,14 @@ def test_compiled_profile_bad_proof_style_signal() -> None:
         structural_terms=[],
         domain_terms=[],
     )
-    with pytest.raises(ValueError, match="proof_style_signals"):
+    with pytest.raises(ValueError, match=r"proof_style_signals\.ssreflect"):
         CompiledProfile.from_profile(profile)
 
 
 # ── test_profile tool integration ─────────────────────────────────────────
 
 
-def test_test_profile_surfaces_bad_regex(tmp_path: pytest.TempPathFactory) -> None:
+def test_test_profile_surfaces_bad_regex(tmp_path: Path) -> None:
     """The test_profile tool returns the validation error, not a crash.
 
     This verifies the claim from the issue: pydantic validators on RepoProfile

--- a/scaffold/tests/test_regex_validation.py
+++ b/scaffold/tests/test_regex_validation.py
@@ -1,0 +1,220 @@
+"""Tests for regex validation in RepoProfile / CompiledProfile.
+
+Covers the hardening from issue #61: pydantic validators on RepoProfile catch
+malformed regexes at deserialization time with actionable field-level errors,
+and CompiledProfile.from_profile() wraps compilation per field as defense-in-depth.
+"""
+
+from __future__ import annotations
+
+
+import pytest
+from pydantic import ValidationError
+
+from scaffold.profile import CompiledProfile, HoleMarker, RepoProfile
+
+# A minimal valid profile dict — tests override individual fields.
+_VALID_BASE: dict = {
+    "proof_assistant": "coq",
+    "proof_file_globs": ["*.v"],
+    "hole_markers": [{"regex": r"\bAdmitted\b", "kind": "admitted"}],
+    "declaration_patterns": [r"^\s*Theorem\s+(\w+)"],
+}
+
+
+def _profile_with(**overrides: object) -> dict:
+    """Return a copy of _VALID_BASE with fields overridden."""
+    d = dict(_VALID_BASE)
+    d.update(overrides)
+    return d
+
+
+# ── HoleMarker.regex validator ────────────────────────────────────────────
+
+
+def test_hole_marker_valid_regex() -> None:
+    hm = HoleMarker(regex=r"\bAdmitted\b", kind="admitted")
+    assert hm.regex == r"\bAdmitted\b"
+
+
+def test_hole_marker_bad_regex() -> None:
+    with pytest.raises(ValidationError, match="hole_markers.regex"):
+        HoleMarker(regex="(unclosed", kind="bad")
+
+
+# ── RepoProfile field validators ──────────────────────────────────────────
+
+
+def test_valid_profile_round_trips() -> None:
+    p = RepoProfile.model_validate(_VALID_BASE)
+    assert p.proof_assistant == "coq"
+    # compiled() should also work fine
+    cp = p.compiled()
+    assert len(cp.hole_res) == 1
+
+
+def test_bad_declaration_pattern() -> None:
+    data = _profile_with(declaration_patterns=["(unclosed"])
+    with pytest.raises(ValidationError, match="declaration_patterns"):
+        RepoProfile.model_validate(data)
+
+
+def test_bad_declaration_pattern_identifies_index() -> None:
+    data = _profile_with(declaration_patterns=[r"^\s*Theorem\s+(\w+)", "(bad"])
+    with pytest.raises(ValidationError, match=r"declaration_patterns\[1\]"):
+        RepoProfile.model_validate(data)
+
+
+def test_bad_commit_signal() -> None:
+    data = _profile_with(commit_signals={"proof_complete": [r"complete", "(broken"]})
+    with pytest.raises(ValidationError, match="commit_signals"):
+        RepoProfile.model_validate(data)
+
+
+def test_bad_commit_signal_names_class_and_index() -> None:
+    data = _profile_with(commit_signals={"infra": [r"ci", r"build"], "fix": ["(oops"]})
+    with pytest.raises(ValidationError, match=r"commit_signals\.fix\[0\]"):
+        RepoProfile.model_validate(data)
+
+
+def test_bad_proof_context_regex() -> None:
+    data = _profile_with(proof_context_regex="[unclosed")
+    with pytest.raises(ValidationError, match="proof_context_regex"):
+        RepoProfile.model_validate(data)
+
+
+def test_empty_proof_context_regex_is_ok() -> None:
+    """Empty string is the default and should not trigger validation."""
+    p = RepoProfile.model_validate(_profile_with(proof_context_regex=""))
+    assert p.proof_context_regex == ""
+
+
+def test_bad_proof_style_signal() -> None:
+    data = _profile_with(proof_style_signals={"term_mode": "(bad"})
+    with pytest.raises(ValidationError, match=r"proof_style_signals\.term_mode"):
+        RepoProfile.model_validate(data)
+
+
+def test_bad_hole_markers_in_profile() -> None:
+    data = _profile_with(hole_markers=[{"regex": "(bad", "kind": "broken"}])
+    with pytest.raises(ValidationError, match="hole_markers"):
+        RepoProfile.model_validate(data)
+
+
+# ── CompiledProfile defense-in-depth ──────────────────────────────────────
+
+
+def test_compiled_profile_bad_hole_markers() -> None:
+    """from_profile() wraps hole_markers compilation."""
+    profile = RepoProfile.model_construct(
+        proof_assistant="coq",
+        proof_file_globs=["*.v"],
+        hole_markers=[HoleMarker.model_construct(regex="(bad", kind="x")],
+        declaration_patterns=[],
+        commit_signals={},
+        proof_context_regex="",
+        tactic_vocabulary=[],
+        tactic_groups={},
+        proof_style_signals={},
+        structural_terms=[],
+        domain_terms=[],
+    )
+    with pytest.raises(ValueError, match="hole_markers"):
+        CompiledProfile.from_profile(profile)
+
+
+def test_compiled_profile_bad_declaration_patterns() -> None:
+    profile = RepoProfile.model_construct(
+        proof_assistant="coq",
+        proof_file_globs=["*.v"],
+        hole_markers=[],
+        declaration_patterns=["(bad"],
+        commit_signals={},
+        proof_context_regex="",
+        tactic_vocabulary=[],
+        tactic_groups={},
+        proof_style_signals={},
+        structural_terms=[],
+        domain_terms=[],
+    )
+    with pytest.raises(ValueError, match="declaration_patterns"):
+        CompiledProfile.from_profile(profile)
+
+
+def test_compiled_profile_bad_commit_signal() -> None:
+    """Individual signals are validated before joining with '|'."""
+    profile = RepoProfile.model_construct(
+        proof_assistant="coq",
+        proof_file_globs=["*.v"],
+        hole_markers=[],
+        declaration_patterns=[],
+        commit_signals={"fix": ["ok", "(bad"]},
+        proof_context_regex="",
+        tactic_vocabulary=[],
+        tactic_groups={},
+        proof_style_signals={},
+        structural_terms=[],
+        domain_terms=[],
+    )
+    with pytest.raises(ValueError, match=r"commit_signals\.fix\[1\]"):
+        CompiledProfile.from_profile(profile)
+
+
+def test_compiled_profile_bad_proof_context_regex() -> None:
+    profile = RepoProfile.model_construct(
+        proof_assistant="coq",
+        proof_file_globs=["*.v"],
+        hole_markers=[],
+        declaration_patterns=[],
+        commit_signals={},
+        proof_context_regex="[bad",
+        tactic_vocabulary=[],
+        tactic_groups={},
+        proof_style_signals={},
+        structural_terms=[],
+        domain_terms=[],
+    )
+    with pytest.raises(ValueError, match="proof_context_regex"):
+        CompiledProfile.from_profile(profile)
+
+
+def test_compiled_profile_bad_proof_style_signal() -> None:
+    profile = RepoProfile.model_construct(
+        proof_assistant="coq",
+        proof_file_globs=["*.v"],
+        hole_markers=[],
+        declaration_patterns=[],
+        commit_signals={},
+        proof_context_regex="",
+        tactic_vocabulary=[],
+        tactic_groups={},
+        proof_style_signals={"ssreflect": "(bad"},
+        structural_terms=[],
+        domain_terms=[],
+    )
+    with pytest.raises(ValueError, match="proof_style_signals"):
+        CompiledProfile.from_profile(profile)
+
+
+# ── test_profile tool integration ─────────────────────────────────────────
+
+
+def test_test_profile_surfaces_bad_regex(tmp_path: pytest.TempPathFactory) -> None:
+    """The test_profile tool returns the validation error, not a crash.
+
+    This verifies the claim from the issue: pydantic validators on RepoProfile
+    surface through test_profile's existing model_validate() try/except.
+    """
+    from scaffold.profiler.deps import ProfilerDeps
+    from scaffold.profiler.tools import build_tools
+
+    deps = ProfilerDeps(repo_path=tmp_path)  # type: ignore[arg-type]
+    tools = build_tools(deps)
+    test_profile = tools["test_profile"]
+
+    bad_profile = _profile_with(
+        declaration_patterns=["(broken"],
+    )
+    res = test_profile(bad_profile)
+    assert res["ok"] is False
+    assert "declaration_patterns" in res["error"]


### PR DESCRIPTION
## Summary

- Add pydantic `field_validator`s on `HoleMarker.regex` and all regex-bearing fields on `RepoProfile` (`declaration_patterns`, `commit_signals`, `proof_context_regex`, `proof_style_signals`) that pre-validate regex syntax at deserialization time with actionable error messages naming the field, index, and offending pattern
- Wrap `CompiledProfile.from_profile()` with per-field try/except as defense-in-depth for programmatically-constructed profiles (via `model_construct()`)
- Validate individual `commit_signals` entries before joining with `|`, so a broken entry like `"foo(bar"` gets caught with the exact class name and index rather than a cryptic alternation error
- 17 new tests covering validators, defense-in-depth, and `test_profile` tool integration

Closes #61

## Test plan

- [x] `uv run ruff format` — clean
- [x] `uv run ruff check --fix` — clean
- [x] `uv run ty check` — clean
- [x] `uv run pytest` — 64 tests pass (17 new in `test_regex_validation.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)