### PR TITLE
Extend miner to formulate proof_optimise, proof_add, and spec_change challenges

### DIFF
--- a/scaffold/src/scaffold/cli.py
+++ b/scaffold/src/scaffold/cli.py
@@ -75,6 +75,65 @@ def mine(
 
 
 @app.command()
+def mine_enriched(
+    enriched_path: Path = typer.Argument(
+        ..., help="Path to enriched commits JSONL (with commit_class set)"
+    ),
+    repo_path: Path = typer.Argument(..., help="Path to the source git repo"),
+    profile: Path = _PROFILE_OPT,
+    output: Path = typer.Option("output.jsonl", "--output", "-o"),
+    classes: list[str] = typer.Option(
+        None,
+        "--class",
+        "-c",
+        help=(
+            "Commit classes to mine (repeatable). Default: all supported "
+            "(proof_optimise, proof_add, proof_new, spec_change, proof_complete)."
+        ),
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v"),
+) -> None:
+    """Mine challenges from pre-classified enriched commit records.
+
+    Takes an enriched JSONL (output of enrich-commits / diff-enrich) and
+    produces challenges for proof_optimise, proof_add, and spec_change
+    commits in addition to the existing proof_complete hole-filling.
+    """
+    _setup_logging(verbose)
+
+    from scaffold.analyzers import ProfileAnalyzer
+    from scaffold.git_walker import mine_from_enriched
+    from scaffold.output import read_commit_records, write_mining_result
+
+    compiled = _load_compiled(profile)
+    analyzer = ProfileAnalyzer(compiled)
+    records = read_commit_records(enriched_path)
+
+    target_classes = set(classes) if classes else None
+    result = mine_from_enriched(
+        repo_path,
+        repo_path.name,
+        analyzer,
+        records,
+        classes=target_classes,
+    )
+
+    write_mining_result(result, output)
+
+    # Print per-class breakdown.
+    from collections import Counter
+
+    type_counts: Counter[str] = Counter(
+        c.challenge_type.value for c in result.challenges
+    )
+    typer.echo(f"\nWrote {result.total_challenges} challenges to {output}")
+    typer.echo(f"  from {result.total_commits_scanned} enriched records")
+    typer.echo("\nChallenge type breakdown:")
+    for ct, n in sorted(type_counts.items(), key=lambda x: -x[1]):
+        typer.echo(f"  {ct:<18} {n:>6}")
+
+
+@app.command()
 def mine_all(
     data_dir: Path = typer.Option("./data", "--data-dir", "-d"),
     output_dir: Path = typer.Option("./artifacts", "--output-dir", "-o"),

--- a/scaffold/src/scaffold/git_walker.py
+++ b/scaffold/src/scaffold/git_walker.py
@@ -7,12 +7,19 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
 from scaffold.analyzers import ProfileAnalyzer
-from scaffold.models import CommitRecord, EvalChallenge, MiningResult
+from scaffold.models import (
+    ChallengeType,
+    CommitClass,
+    CommitRecord,
+    EvalChallenge,
+    MiningResult,
+)
 from scaffold.profile import CompiledProfile
 
 logger = logging.getLogger(__name__)
@@ -306,6 +313,402 @@ def mine_commit(
         )
 
     return challenges
+
+
+# ---------------------------------------------------------------------------
+# Declaration-aware parsing (for spec_change splicing)
+# ---------------------------------------------------------------------------
+
+# Coq proof-start and proof-end patterns.
+_PROOF_START_RE = re.compile(r"^\s*Proof\b", re.MULTILINE)
+_PROOF_END_RE = re.compile(r"^\s*(?:Qed|Defined|Admitted|Abort)\s*\.", re.MULTILINE)
+# Coq declaration keyword that introduces a named theorem/lemma.
+_COQ_DECL_RE = re.compile(
+    r"^\s*(?:Theorem|Lemma|Proposition|Corollary|Fact|Remark|Example"
+    r"|Definition|Fixpoint|Program)\s+(\w+)",
+    re.MULTILINE,
+)
+
+
+@dataclass
+class DeclSpan:
+    """A parsed declaration span with its statement and proof body."""
+
+    name: str
+    # Line offsets (0-based) in the source file.
+    decl_start: int  # first line of the declaration
+    proof_start: int | None  # line of ``Proof.`` (None if no explicit Proof)
+    proof_end: int  # line of ``Qed.``/``Defined.``/``Admitted.``
+    # Extracted text slices.
+    statement: str  # from decl keyword up to (but not including) Proof.
+    proof_body: str  # from Proof. through Qed./Defined.
+
+
+def parse_decl_spans(
+    content: str, declaration_res: list[re.Pattern[str]]
+) -> list[DeclSpan]:
+    """Parse top-level declaration spans from Coq-like source content.
+
+    Returns a list of ``DeclSpan`` objects sorted by position. Each span
+    covers the declaration statement (up to ``Proof.``) and the proof body
+    (``Proof.`` through the terminator ``Qed.``/``Defined.``/``Admitted.``).
+
+    Falls back to ``_COQ_DECL_RE`` if *declaration_res* is empty.
+    """
+    decl_patterns = declaration_res or [_COQ_DECL_RE]
+    lines = content.splitlines()
+
+    # Find all declaration start positions: (line_idx, name).
+    decl_starts: list[tuple[int, str]] = []
+    for i, line in enumerate(lines):
+        for pat in decl_patterns:
+            m = pat.search(line)
+            if m:
+                decl_starts.append((i, m.group(1)))
+                break  # one match per line is enough
+
+    if not decl_starts:
+        return []
+
+    spans: list[DeclSpan] = []
+    for idx, (decl_line, name) in enumerate(decl_starts):
+        # Search range: from this decl to the next decl (or EOF).
+        end_bound = (
+            decl_starts[idx + 1][0] if idx + 1 < len(decl_starts) else len(lines)
+        )
+        region = "\n".join(lines[decl_line:end_bound])
+
+        # Find ``Proof.`` within the region.
+        pm = _PROOF_START_RE.search(region)
+        if pm:
+            # Count newlines up to the match to get relative line offset.
+            proof_line_rel = region[: pm.start()].count("\n")
+            proof_line_abs = decl_line + proof_line_rel
+            statement = "\n".join(lines[decl_line:proof_line_abs])
+        else:
+            proof_line_abs = None
+            # No explicit Proof. — statement is the declaration line itself.
+            statement = lines[decl_line]
+
+        # Find the proof terminator.
+        search_start = (proof_line_abs - decl_line) if proof_line_abs is not None else 0
+        # Search after the Proof. line (or from the decl line).
+        tail = "\n".join(lines[decl_line + search_start : end_bound])
+        em = _PROOF_END_RE.search(tail)
+        if em:
+            end_line_rel = tail[: em.start()].count("\n")
+            end_line_abs = decl_line + search_start + end_line_rel
+        else:
+            # No terminator found — skip this declaration.
+            continue
+
+        body_start = proof_line_abs if proof_line_abs is not None else decl_line
+        proof_body = "\n".join(lines[body_start : end_line_abs + 1])
+
+        spans.append(
+            DeclSpan(
+                name=name,
+                decl_start=decl_line,
+                proof_start=proof_line_abs,
+                proof_end=end_line_abs,
+                statement=statement,
+                proof_body=proof_body,
+            )
+        )
+
+    return spans
+
+
+def splice_spec_change(
+    parent_content: str,
+    child_content: str,
+    declaration_res: list[re.Pattern[str]],
+) -> tuple[str, list[str]] | None:
+    """Create a spec_change challenge by splicing new statement + old proof.
+
+    Returns ``(spliced_content, changed_decl_names)`` or ``None`` if no
+    statement changed between parent and child.
+    """
+    parent_spans = parse_decl_spans(parent_content, declaration_res)
+    child_spans = parse_decl_spans(child_content, declaration_res)
+
+    parent_by_name = {s.name: s for s in parent_spans}
+    child_by_name = {s.name: s for s in child_spans}
+
+    changed_names: list[str] = []
+    for name, child_span in child_by_name.items():
+        parent_span = parent_by_name.get(name)
+        if parent_span is None:
+            continue
+        # Statement changed but same declaration exists in both.
+        if child_span.statement.strip() != parent_span.statement.strip():
+            changed_names.append(name)
+
+    if not changed_names:
+        return None
+
+    # Build spliced content: start with child content, then for each changed
+    # declaration, replace the child's proof body with the parent's proof body.
+    child_lines = child_content.splitlines()
+    # Work backwards so line indices stay valid.
+    replacements: list[tuple[int, int, str]] = []
+    for name in changed_names:
+        child_span = child_by_name[name]
+        parent_span = parent_by_name[name]
+        if child_span.proof_start is None or parent_span.proof_start is None:
+            continue
+        # Replace from child's Proof. line through Qed. with parent's proof body.
+        replacements.append(
+            (child_span.proof_start, child_span.proof_end, parent_span.proof_body)
+        )
+
+    if not replacements:
+        return None
+
+    # Sort by start line descending so replacements don't shift indices.
+    replacements.sort(key=lambda r: r[0], reverse=True)
+    result_lines = list(child_lines)
+    for start, end, body in replacements:
+        result_lines[start : end + 1] = body.splitlines()
+
+    return "\n".join(result_lines), changed_names
+
+
+# ---------------------------------------------------------------------------
+# New challenge formulations (proof_optimise, proof_add, spec_change)
+# ---------------------------------------------------------------------------
+
+
+def mine_proof_optimise_commit(
+    repo_path: str | Path,
+    record: CommitRecord,
+    analyzer: ProfileAnalyzer,
+    repo_name: str,
+) -> list[EvalChallenge]:
+    """Mine a proof_optimise commit: challenge is the longer proof, solution is shorter."""
+    parent = record.parent_hashes[0] if record.parent_hashes else ""
+    if not parent or not record.proof_files_changed:
+        return []
+
+    challenges: list[EvalChallenge] = []
+    for fpath in record.proof_files_changed:
+        parent_content = get_file_at_commit(repo_path, parent, fpath)
+        child_content = get_file_at_commit(repo_path, record.hash, fpath)
+        if parent_content is None or child_content is None:
+            continue
+
+        diff = get_diff_text(repo_path, parent, record.hash, fpath)
+        instructions = (
+            f"Simplify or optimize the proof(s) in {fpath}. "
+            f"Produce a shorter or cleaner version that still compiles."
+        )
+
+        challenges.append(
+            EvalChallenge(
+                task_id=_make_task_id(repo_name, record.hash, fpath),
+                repo=repo_name,
+                proof_assistant=analyzer.proof_assistant,
+                commit_hash=record.hash,
+                parent_hash=parent,
+                commit_message=record.message_subject,
+                file_path=fpath,
+                challenge_type=ChallengeType.proof_optimise,
+                challenge_file_content=parent_content,
+                solution_file_content=child_content,
+                diff=diff,
+                instructions=instructions,
+            )
+        )
+
+    return challenges
+
+
+def mine_proof_add_commit(
+    repo_path: str | Path,
+    record: CommitRecord,
+    analyzer: ProfileAnalyzer,
+    repo_name: str,
+) -> list[EvalChallenge]:
+    """Mine a proof_add commit: challenge is the file before, solution has proof added."""
+    parent = record.parent_hashes[0] if record.parent_hashes else ""
+    if not parent or not record.proof_files_changed:
+        return []
+
+    challenges: list[EvalChallenge] = []
+    for fpath in record.proof_files_changed:
+        parent_content = get_file_at_commit(repo_path, parent, fpath)
+        child_content = get_file_at_commit(repo_path, record.hash, fpath)
+
+        if child_content is None:
+            continue
+
+        diff = get_diff_text(repo_path, parent, record.hash, fpath)
+
+        if parent_content is None:
+            # New file added — challenge is to write the proof from scratch.
+            instructions = f"Write the proof content for the declarations in {fpath}."
+            challenge_content = ""
+        else:
+            instructions = (
+                f"Write or extend the proof(s) in {fpath}. "
+                f"Complete any unfinished proofs or add missing proof content."
+            )
+            challenge_content = parent_content
+
+        challenges.append(
+            EvalChallenge(
+                task_id=_make_task_id(repo_name, record.hash, fpath),
+                repo=repo_name,
+                proof_assistant=analyzer.proof_assistant,
+                commit_hash=record.hash,
+                parent_hash=parent,
+                commit_message=record.message_subject,
+                file_path=fpath,
+                challenge_type=ChallengeType.proof_add,
+                challenge_file_content=challenge_content,
+                solution_file_content=child_content,
+                diff=diff,
+                instructions=instructions,
+            )
+        )
+
+    return challenges
+
+
+def mine_spec_change_commit(
+    repo_path: str | Path,
+    record: CommitRecord,
+    analyzer: ProfileAnalyzer,
+    repo_name: str,
+) -> list[EvalChallenge]:
+    """Mine a spec_change commit: splice new statement + old proof as challenge."""
+    parent = record.parent_hashes[0] if record.parent_hashes else ""
+    if not parent or not record.proof_files_changed:
+        return []
+
+    compiled = analyzer._c
+    challenges: list[EvalChallenge] = []
+
+    for fpath in record.proof_files_changed:
+        parent_content = get_file_at_commit(repo_path, parent, fpath)
+        child_content = get_file_at_commit(repo_path, record.hash, fpath)
+        if parent_content is None or child_content is None:
+            continue
+
+        result = splice_spec_change(
+            parent_content, child_content, compiled.declaration_res
+        )
+        if result is None:
+            continue
+
+        spliced_content, changed_names = result
+        diff = get_diff_text(repo_path, parent, record.hash, fpath)
+        decl_list = ", ".join(f"`{n}`" for n in changed_names)
+
+        instructions = (
+            f"The statement of {decl_list} in {fpath} was modified. "
+            f"Adapt the proof to the new statement."
+        )
+
+        challenges.append(
+            EvalChallenge(
+                task_id=_make_task_id(repo_name, record.hash, fpath),
+                repo=repo_name,
+                proof_assistant=analyzer.proof_assistant,
+                commit_hash=record.hash,
+                parent_hash=parent,
+                commit_message=record.message_subject,
+                file_path=fpath,
+                challenge_type=ChallengeType.spec_change,
+                challenge_file_content=spliced_content,
+                solution_file_content=child_content,
+                diff=diff,
+                instructions=instructions,
+            )
+        )
+
+    return challenges
+
+
+# ---------------------------------------------------------------------------
+# Enriched mining — dispatch by commit class
+# ---------------------------------------------------------------------------
+
+# Map from CommitClass to the miner function that handles it.
+_CLASS_MINERS = {
+    CommitClass.proof_optimise: mine_proof_optimise_commit,
+    CommitClass.proof_add: mine_proof_add_commit,
+    CommitClass.proof_new: mine_proof_add_commit,  # same formulation as proof_add
+    CommitClass.spec_change: mine_spec_change_commit,
+}
+
+
+def mine_from_enriched(
+    repo_path: str | Path,
+    repo_name: str,
+    analyzer: ProfileAnalyzer,
+    records: list[CommitRecord],
+    classes: set[str] | None = None,
+) -> MiningResult:
+    """Mine challenges from pre-classified enriched commit records.
+
+    Args:
+        repo_path: Path to the git repo.
+        repo_name: Human-readable repo name.
+        analyzer: Profile-driven proof analyzer.
+        records: Enriched CommitRecords (with commit_class set).
+        classes: Optional set of commit class names to mine. If None, mines
+            all supported classes (proof_optimise, proof_add, proof_new,
+            spec_change). Pass ``{"proof_complete"}`` to include hole-filling
+            via the existing ``mine_commit`` path.
+    """
+    target_classes = classes or {c.value for c in _CLASS_MINERS}
+    all_challenges: list[EvalChallenge] = []
+
+    for i, record in enumerate(records):
+        if i % 200 == 0:
+            logger.info("Enriched mining progress: %d/%d records", i, len(records))
+
+        if record.commit_class.value not in target_classes:
+            continue
+
+        if record.commit_class == CommitClass.proof_complete:
+            # Use existing hole-filling miner.
+            parent = record.parent_hashes[0] if record.parent_hashes else ""
+            if not parent:
+                continue
+            commit = RawCommit(
+                hash=record.hash,
+                parent_hash=parent,
+                author=record.author,
+                date=record.date,
+                message=record.message_subject,
+            )
+            challenges = mine_commit(repo_path, commit, analyzer, repo_name)
+            all_challenges.extend(challenges)
+            continue
+
+        miner_fn = _CLASS_MINERS.get(record.commit_class)
+        if miner_fn is None:
+            continue
+
+        challenges = miner_fn(repo_path, record, analyzer, repo_name)
+        if challenges:
+            logger.info(
+                "  %s [%s]: %d challenges",
+                record.hash[:8],
+                record.commit_class.value,
+                len(challenges),
+            )
+            all_challenges.extend(challenges)
+
+    return MiningResult(
+        repo_name=repo_name,
+        proof_assistant=analyzer.proof_assistant,
+        total_commits_scanned=len(records),
+        total_challenges=len(all_challenges),
+        challenges=all_challenges,
+    )
 
 
 def _parse_numstat_line(line: str) -> tuple[int, int, str] | None:

--- a/scaffold/src/scaffold/models.py
+++ b/scaffold/src/scaffold/models.py
@@ -74,6 +74,21 @@ class CommitCandidate(BaseModel):
     proof_diffs: list[CommitProofDiff] = Field(default_factory=list)
 
 
+class ChallengeType(str, Enum):
+    """The kind of proof challenge.
+
+    proof_complete  — fill a hole (Admitted → Qed).
+    proof_optimise  — shorten or simplify a working proof.
+    proof_add       — write or extend a proof for a theorem.
+    spec_change     — adapt a proof to a changed theorem statement.
+    """
+
+    proof_complete = "proof_complete"
+    proof_optimise = "proof_optimise"
+    proof_add = "proof_add"
+    spec_change = "spec_change"
+
+
 class EvalChallenge(BaseModel):
     """A single eval challenge extracted from git history.
 
@@ -88,6 +103,10 @@ class EvalChallenge(BaseModel):
     parent_hash: str
     commit_message: str = ""
     file_path: str
+    challenge_type: ChallengeType = Field(
+        default=ChallengeType.proof_complete,
+        description="Kind of challenge: proof_complete, proof_optimise, proof_add, or spec_change.",
+    )
     challenge_file_content: str = Field(
         description="File content at parent commit (contains hole)"
     )

--- a/scaffold/tests/test_challenge_types.py
+++ b/scaffold/tests/test_challenge_types.py
@@ -1,0 +1,527 @@
+"""Tests for proof_optimise, proof_add, and spec_change challenge formulations."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scaffold.analyzers import ProfileAnalyzer
+from scaffold.git_walker import (
+    iter_commits,
+    mine_from_enriched,
+    mine_proof_add_commit,
+    mine_proof_optimise_commit,
+    mine_spec_change_commit,
+    parse_decl_spans,
+    splice_spec_change,
+)
+from scaffold.models import ChallengeType, CommitClass, CommitRecord
+from scaffold.profile import HoleMarker, RepoProfile
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_COQ_DECL = r"^\s*(?:Theorem|Lemma|Proposition|Corollary|Fact|Remark|Example|Definition|Fixpoint|Program)\s+(\w+)"
+
+
+def _coq_profile() -> RepoProfile:
+    return RepoProfile(
+        proof_assistant="coq",
+        proof_file_globs=["*.v"],
+        hole_markers=[
+            HoleMarker(regex=r"\bAdmitted\b", kind="admitted"),
+            HoleMarker(regex=r"\badmit\b", kind="admit"),
+        ],
+        declaration_patterns=[_COQ_DECL],
+    )
+
+
+def _git_env() -> dict[str, str]:
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@test.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@test.com",
+    }
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=_git_env(),
+    )
+
+
+def _make_commit_record(
+    repo: Path,
+    commit_class: CommitClass,
+    commit_idx: int = 0,
+) -> CommitRecord:
+    """Build a CommitRecord from a real git commit in ``repo``."""
+    commits = iter_commits(repo)
+    c = commits[commit_idx]
+    parent = c.parent_hash
+    # Get changed files.
+    result = subprocess.run(
+        ["git", "-C", str(repo), "diff", "--name-only", parent, c.hash],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    changed = [f.strip() for f in result.stdout.strip().splitlines() if f.strip()]
+    proof_files = [f for f in changed if f.endswith(".v")]
+    return CommitRecord(
+        hash=c.hash,
+        parent_hashes=[parent] if parent else [],
+        author=c.author,
+        date=c.date,
+        message_subject=c.message,
+        proof_files_changed=proof_files,
+        touches_proof_files=bool(proof_files),
+        commit_class=commit_class,
+        class_confidence="test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# parse_decl_spans / splice_spec_change unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseDeclSpans:
+    def test_simple_theorem(self) -> None:
+        content = textwrap.dedent("""\
+            Theorem foo : forall n, n = n.
+            Proof.
+              reflexivity.
+            Qed.
+        """)
+        profile = _coq_profile()
+        spans = parse_decl_spans(content, profile.compiled().declaration_res)
+        assert len(spans) == 1
+        assert spans[0].name == "foo"
+        assert spans[0].proof_start == 1  # "Proof." is line index 1
+        assert "reflexivity" in spans[0].proof_body
+
+    def test_multiple_decls(self) -> None:
+        content = textwrap.dedent("""\
+            Theorem foo : True.
+            Proof.
+              trivial.
+            Qed.
+
+            Lemma bar : 1 = 1.
+            Proof.
+              reflexivity.
+            Qed.
+        """)
+        profile = _coq_profile()
+        spans = parse_decl_spans(content, profile.compiled().declaration_res)
+        assert len(spans) == 2
+        assert spans[0].name == "foo"
+        assert spans[1].name == "bar"
+
+    def test_no_proof_keyword(self) -> None:
+        content = textwrap.dedent("""\
+            Theorem foo : True.
+              trivial.
+            Qed.
+        """)
+        profile = _coq_profile()
+        spans = parse_decl_spans(content, profile.compiled().declaration_res)
+        # Should still parse — proof_start is None.
+        assert len(spans) == 1
+        assert spans[0].name == "foo"
+        assert spans[0].proof_start is None
+
+    def test_empty_content(self) -> None:
+        profile = _coq_profile()
+        spans = parse_decl_spans("", profile.compiled().declaration_res)
+        assert spans == []
+
+
+class TestSpliceSpecChange:
+    def test_basic_splice(self) -> None:
+        parent = textwrap.dedent("""\
+            Theorem foo : forall n, n = n.
+            Proof.
+              reflexivity.
+            Qed.
+        """)
+        child = textwrap.dedent("""\
+            Theorem foo : forall n m, n + m = m + n.
+            Proof.
+              intros. apply Nat.add_comm.
+            Qed.
+        """)
+        profile = _coq_profile()
+        result = splice_spec_change(parent, child, profile.compiled().declaration_res)
+        assert result is not None
+        spliced, names = result
+        assert "foo" in names
+        # Spliced should have new statement + old proof body.
+        assert "forall n m" in spliced  # new statement
+        assert "reflexivity" in spliced  # old proof body
+
+    def test_no_change_returns_none(self) -> None:
+        content = textwrap.dedent("""\
+            Theorem foo : True.
+            Proof.
+              trivial.
+            Qed.
+        """)
+        profile = _coq_profile()
+        result = splice_spec_change(
+            content, content, profile.compiled().declaration_res
+        )
+        assert result is None
+
+    def test_new_decl_not_in_parent(self) -> None:
+        parent = textwrap.dedent("""\
+            Theorem foo : True.
+            Proof.
+              trivial.
+            Qed.
+        """)
+        child = textwrap.dedent("""\
+            Theorem foo : True.
+            Proof.
+              trivial.
+            Qed.
+
+            Theorem bar : False.
+            Proof.
+              admit.
+            Admitted.
+        """)
+        profile = _coq_profile()
+        result = splice_spec_change(parent, child, profile.compiled().declaration_res)
+        # bar is new, not changed — no spec change.
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Git-based integration tests for each challenge type
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def proof_optimise_repo(tmp_path: Path) -> Path:
+    """Git repo with a proof that gets shortened."""
+    repo = tmp_path / "opt-repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "checkout", "-b", "main")
+
+    # Commit 1: verbose proof.
+    (repo / "proof.v").write_text(
+        textwrap.dedent("""\
+            Theorem foo : forall n, n = n.
+            Proof.
+              intros n.
+              destruct n.
+              - reflexivity.
+              - reflexivity.
+            Qed.
+        """)
+    )
+    _git(repo, "add", "proof.v")
+    _git(repo, "commit", "-m", "Add verbose proof")
+
+    # Commit 2: shorter proof.
+    (repo / "proof.v").write_text(
+        textwrap.dedent("""\
+            Theorem foo : forall n, n = n.
+            Proof.
+              reflexivity.
+            Qed.
+        """)
+    )
+    _git(repo, "add", "proof.v")
+    _git(repo, "commit", "-m", "Simplify proof")
+
+    return repo
+
+
+@pytest.fixture
+def proof_add_repo(tmp_path: Path) -> Path:
+    """Git repo where a proof is added to an existing file."""
+    repo = tmp_path / "add-repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "checkout", "-b", "main")
+
+    # Commit 1: file with just a statement and Admitted.
+    (repo / "defs.v").write_text(
+        textwrap.dedent("""\
+            Definition id (n : nat) := n.
+        """)
+    )
+    _git(repo, "add", "defs.v")
+    _git(repo, "commit", "-m", "Add definitions")
+
+    # Commit 2: add a theorem with proof.
+    (repo / "defs.v").write_text(
+        textwrap.dedent("""\
+            Definition id (n : nat) := n.
+
+            Theorem id_correct : forall n, id n = n.
+            Proof.
+              intros n. unfold id. reflexivity.
+            Qed.
+        """)
+    )
+    _git(repo, "add", "defs.v")
+    _git(repo, "commit", "-m", "Prove id_correct")
+
+    return repo
+
+
+@pytest.fixture
+def spec_change_repo(tmp_path: Path) -> Path:
+    """Git repo where a theorem statement is changed and proof adapted."""
+    repo = tmp_path / "spec-repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "checkout", "-b", "main")
+
+    # Commit 1: original statement + proof.
+    (repo / "spec.v").write_text(
+        textwrap.dedent("""\
+            Theorem foo : forall n, n = n.
+            Proof.
+              reflexivity.
+            Qed.
+        """)
+    )
+    _git(repo, "add", "spec.v")
+    _git(repo, "commit", "-m", "Original spec")
+
+    # Commit 2: changed statement + adapted proof.
+    (repo / "spec.v").write_text(
+        textwrap.dedent("""\
+            Theorem foo : forall n m, n + m = m + n.
+            Proof.
+              intros. apply Nat.add_comm.
+            Qed.
+        """)
+    )
+    _git(repo, "add", "spec.v")
+    _git(repo, "commit", "-m", "Generalize foo")
+
+    return repo
+
+
+class TestMineProofOptimise:
+    def test_produces_challenge(self, proof_optimise_repo: Path) -> None:
+        profile = _coq_profile()
+        analyzer = ProfileAnalyzer(profile.compiled())
+        record = _make_commit_record(
+            proof_optimise_repo, CommitClass.proof_optimise, commit_idx=0
+        )
+        challenges = mine_proof_optimise_commit(
+            proof_optimise_repo, record, analyzer, "test"
+        )
+        assert len(challenges) == 1
+        c = challenges[0]
+        assert c.challenge_type == ChallengeType.proof_optimise
+        assert "Simplify" in c.instructions
+        # Challenge (parent) should have the longer proof.
+        assert "destruct" in c.challenge_file_content
+        # Solution (child) should have the shorter proof.
+        assert "reflexivity" in c.solution_file_content
+        assert "destruct" not in c.solution_file_content
+
+    def test_no_parent_returns_empty(self) -> None:
+        profile = _coq_profile()
+        analyzer = ProfileAnalyzer(profile.compiled())
+        record = CommitRecord(
+            hash="abc123",
+            parent_hashes=[],
+            date="2024-01-01",
+            message_subject="test",
+            commit_class=CommitClass.proof_optimise,
+        )
+        challenges = mine_proof_optimise_commit("/fake", record, analyzer, "test")
+        assert challenges == []
+
+
+class TestMineProofAdd:
+    def test_produces_challenge(self, proof_add_repo: Path) -> None:
+        profile = _coq_profile()
+        analyzer = ProfileAnalyzer(profile.compiled())
+        record = _make_commit_record(
+            proof_add_repo, CommitClass.proof_add, commit_idx=0
+        )
+        challenges = mine_proof_add_commit(proof_add_repo, record, analyzer, "test")
+        assert len(challenges) == 1
+        c = challenges[0]
+        assert c.challenge_type == ChallengeType.proof_add
+        assert "Write or extend" in c.instructions
+        # Solution should contain the proof.
+        assert "id_correct" in c.solution_file_content
+
+    def test_new_file_produces_challenge(self, tmp_path: Path) -> None:
+        """When the file didn't exist in the parent, challenge_file_content is empty."""
+        repo = tmp_path / "newfile-repo"
+        repo.mkdir()
+        _git(repo, "init")
+        _git(repo, "checkout", "-b", "main")
+
+        (repo / "dummy.v").write_text("(* placeholder *)\n")
+        _git(repo, "add", "dummy.v")
+        _git(repo, "commit", "-m", "Init")
+
+        (repo / "newproof.v").write_text(
+            textwrap.dedent("""\
+                Theorem bar : True.
+                Proof.
+                  trivial.
+                Qed.
+            """)
+        )
+        _git(repo, "add", "newproof.v")
+        _git(repo, "commit", "-m", "Add new proof file")
+
+        profile = _coq_profile()
+        analyzer = ProfileAnalyzer(profile.compiled())
+        record = _make_commit_record(repo, CommitClass.proof_add, commit_idx=0)
+        challenges = mine_proof_add_commit(repo, record, analyzer, "test")
+        # Should produce a challenge for newproof.v.
+        new_challenges = [c for c in challenges if c.file_path == "newproof.v"]
+        assert len(new_challenges) == 1
+        assert new_challenges[0].challenge_file_content == ""
+        assert "Write the proof" in new_challenges[0].instructions
+
+
+class TestMineSpecChange:
+    def test_produces_challenge(self, spec_change_repo: Path) -> None:
+        profile = _coq_profile()
+        analyzer = ProfileAnalyzer(profile.compiled())
+        record = _make_commit_record(
+            spec_change_repo, CommitClass.spec_change, commit_idx=0
+        )
+        challenges = mine_spec_change_commit(spec_change_repo, record, analyzer, "test")
+        assert len(challenges) == 1
+        c = challenges[0]
+        assert c.challenge_type == ChallengeType.spec_change
+        assert "`foo`" in c.instructions
+        assert "modified" in c.instructions
+        # Challenge should have new statement spliced with old proof.
+        assert "forall n m" in c.challenge_file_content  # new statement
+        assert "reflexivity" in c.challenge_file_content  # old proof body
+        # Solution should have the fully adapted proof.
+        assert "Nat.add_comm" in c.solution_file_content
+
+    def test_no_spec_change_returns_empty(self, proof_optimise_repo: Path) -> None:
+        """No spec change → no challenges from this miner."""
+        profile = _coq_profile()
+        analyzer = ProfileAnalyzer(profile.compiled())
+        record = _make_commit_record(
+            proof_optimise_repo, CommitClass.spec_change, commit_idx=0
+        )
+        challenges = mine_spec_change_commit(
+            proof_optimise_repo, record, analyzer, "test"
+        )
+        assert challenges == []
+
+
+# ---------------------------------------------------------------------------
+# mine_from_enriched integration test
+# ---------------------------------------------------------------------------
+
+
+class TestMineFromEnriched:
+    def test_dispatches_by_class(
+        self,
+        proof_optimise_repo: Path,
+        proof_add_repo: Path,
+        spec_change_repo: Path,
+    ) -> None:
+        profile = _coq_profile()
+        analyzer = ProfileAnalyzer(profile.compiled())
+
+        # Build records from each repo.
+        opt_record = _make_commit_record(
+            proof_optimise_repo, CommitClass.proof_optimise
+        )
+        add_record = _make_commit_record(proof_add_repo, CommitClass.proof_add)
+        spec_record = _make_commit_record(spec_change_repo, CommitClass.spec_change)
+
+        # mine_from_enriched needs all records to point at the same repo,
+        # so we test each type individually.
+        opt_result = mine_from_enriched(
+            proof_optimise_repo,
+            "test",
+            analyzer,
+            [opt_record],
+        )
+        assert opt_result.total_challenges >= 1
+        assert all(
+            c.challenge_type == ChallengeType.proof_optimise
+            for c in opt_result.challenges
+        )
+
+        add_result = mine_from_enriched(
+            proof_add_repo,
+            "test",
+            analyzer,
+            [add_record],
+        )
+        assert add_result.total_challenges >= 1
+        assert all(
+            c.challenge_type == ChallengeType.proof_add for c in add_result.challenges
+        )
+
+        spec_result = mine_from_enriched(
+            spec_change_repo,
+            "test",
+            analyzer,
+            [spec_record],
+        )
+        assert spec_result.total_challenges >= 1
+        assert all(
+            c.challenge_type == ChallengeType.spec_change
+            for c in spec_result.challenges
+        )
+
+    def test_class_filter(self, proof_optimise_repo: Path) -> None:
+        """Only mine the requested classes."""
+        profile = _coq_profile()
+        analyzer = ProfileAnalyzer(profile.compiled())
+        record = _make_commit_record(proof_optimise_repo, CommitClass.proof_optimise)
+
+        # Ask for proof_add only — should skip proof_optimise.
+        result = mine_from_enriched(
+            proof_optimise_repo,
+            "test",
+            analyzer,
+            [record],
+            classes={"proof_add"},
+        )
+        assert result.total_challenges == 0
+
+    def test_skips_unknown_classes(self, proof_optimise_repo: Path) -> None:
+        profile = _coq_profile()
+        analyzer = ProfileAnalyzer(profile.compiled())
+        record = _make_commit_record(
+            proof_optimise_repo,
+            CommitClass.infra,  # not a mineable class
+        )
+        result = mine_from_enriched(
+            proof_optimise_repo,
+            "test",
+            analyzer,
+            [record],
+        )
+        assert result.total_challenges == 0


### PR DESCRIPTION
## Summary

- Adds `ChallengeType` enum and `challenge_type` field to `EvalChallenge` so challenge rows are distinguishable by type (`proof_complete`, `proof_optimise`, `proof_add`, `spec_change`)
- Implements three new mining functions alongside `mine_commit`: `mine_proof_optimise_commit`, `mine_proof_add_commit`, `mine_spec_change_commit`
- Adds a declaration-aware Coq parser (`parse_decl_spans` / `splice_spec_change`) that splices new theorem statements with old proof bodies for `spec_change` challenges
- Adds `mine_from_enriched` dispatcher that routes pre-classified `CommitRecord`s to the appropriate miner by `commit_class`
- Adds `mine-enriched` CLI command to produce challenges from enriched JSONL files
- 16 new tests covering all formulation paths (unit + git-based integration)

## Test plan

- [x] All 160 tests pass (`pytest`)
- [x] `ruff format` clean
- [x] `ruff check` clean
- [x] Re-mine CompCert with `mine-enriched` using existing `CompCert-commits-coq-diff.jsonl` to verify significantly more than 6 challenges
- [ ] Spot-check challenge quality for each type (instructions, splicing correctness)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)