### PR TITLE
Add tiered LLM curation pipeline for challenge quality filtering

### DIFF
--- a/scaffold/src/scaffold/cli.py
+++ b/scaffold/src/scaffold/cli.py
@@ -412,6 +412,82 @@ def profile(
 
 
 @app.command()
+def curate(
+    input_path: Path = typer.Argument(..., help="Path to a challenges JSONL file"),
+    output_path: Path = typer.Option(
+        None, "--output", "-o", help="Output path (default: <input>-curated.jsonl)"
+    ),
+    tier1_model: str = typer.Option(
+        "",
+        "--tier1-model",
+        help="Tier-1 (cheap) model for initial curation (default: claude-haiku-3-5-20241022)",
+    ),
+    tier2_model: str = typer.Option(
+        "",
+        "--tier2-model",
+        help="Tier-2 (strong) model for deferred challenges (default: claude-sonnet-4-6)",
+    ),
+    max_concurrent: int = typer.Option(
+        10, "--max-concurrent", help="Max concurrent API requests"
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v"),
+) -> None:
+    """Run tiered LLM curation on a challenges JSONL file.
+
+    Reads challenges, sends each to a cheap model (Haiku) for ACCEPT/REJECT/DEFER,
+    escalates DEFERs to a stronger model (Sonnet), and writes the filtered result
+    (accepted + borderline only) to the output file.
+    """
+    _setup_logging(verbose)
+    from dotenv import find_dotenv, load_dotenv
+
+    from scaffold.curator import (
+        DEFAULT_TIER1_MODEL,
+        DEFAULT_TIER2_MODEL,
+        apply_curation,
+        curate_challenges_sync,
+    )
+    from scaffold.output import read_jsonl, write_jsonl
+
+    dotenv_path = find_dotenv(usecwd=True)
+    if dotenv_path:
+        load_dotenv(dotenv_path)
+
+    challenges = read_jsonl(input_path)
+    if not challenges:
+        typer.echo("No challenges found in input file.")
+        raise typer.Exit(1)
+
+    t1 = tier1_model or DEFAULT_TIER1_MODEL
+    t2 = tier2_model or DEFAULT_TIER2_MODEL
+    typer.echo(
+        f"Curating {len(challenges)} challenges (tier-1: {t1}, tier-2: {t2}) ..."
+    )
+
+    results = curate_challenges_sync(
+        challenges, tier1_model=t1, tier2_model=t2, max_concurrent=max_concurrent
+    )
+    accepted, rejected, borderline = apply_curation(challenges, results)
+
+    dest = output_path or input_path.with_stem(input_path.stem + "-curated")
+    write_jsonl(accepted + borderline, dest)
+
+    typer.echo("\nCuration results:")
+    typer.echo(f"  Total input   : {len(challenges)}")
+    typer.echo(f"  Accepted      : {len(accepted)}")
+    typer.echo(f"  Rejected      : {len(rejected)}")
+    typer.echo(f"  Borderline    : {len(borderline)}")
+    typer.echo(
+        f"  Output        : {len(accepted) + len(borderline)} challenges -> {dest}"
+    )
+
+    if rejected:
+        typer.echo("\nRejected challenges:")
+        for ch in rejected:
+            typer.echo(f"  {ch.task_id}: {ch.curation_rationale}")
+
+
+@app.command()
 def materialize(
     repo_path: Path = typer.Argument(..., help="Path to the proof engineering repo"),
     profile: Path = _PROFILE_OPT,
@@ -422,6 +498,21 @@ def materialize(
         "handcrafted",
         "--kind",
         help="Miner kind for the manifest: 'handcrafted' or 'agent'",
+    ),
+    do_curate: bool = typer.Option(
+        False,
+        "--curate/--no-curate",
+        help="Run LLM curation between mining and materialization",
+    ),
+    tier1_model: str = typer.Option(
+        "",
+        "--tier1-model",
+        help="Tier-1 curation model (default: claude-haiku-3-5-20241022)",
+    ),
+    tier2_model: str = typer.Option(
+        "",
+        "--tier2-model",
+        help="Tier-2 curation model (default: claude-sonnet-4-6)",
     ),
     promote: bool = typer.Option(
         False,
@@ -438,6 +529,13 @@ def materialize(
     from scaffold.dataset import mine_and_materialize, promote_profile
     from scaffold.profile import load_profile
 
+    if do_curate:
+        from dotenv import find_dotenv, load_dotenv
+
+        dotenv_path = find_dotenv(usecwd=True)
+        if dotenv_path:
+            load_dotenv(dotenv_path)
+
     prof = load_profile(profile)
     dv = mine_and_materialize(
         profile=prof,
@@ -445,6 +543,9 @@ def materialize(
         tag=tag,
         miner_kind=kind,
         artifacts_root=artifacts_dir,
+        curate=do_curate,
+        tier1_model=tier1_model,
+        tier2_model=tier2_model,
     )
     typer.echo(f"Materialized {dv.version} ({dv.n_challenges} challenges) -> {dv.path}")
     typer.echo(f"  manifest_hash: {dv.manifest_hash[:12]}")

--- a/scaffold/src/scaffold/curator.py
+++ b/scaffold/src/scaffold/curator.py
@@ -1,0 +1,262 @@
+"""LLM-based curation pipeline for filtering low-quality mined challenges.
+
+Tiered approach: a cheap model (Haiku) handles the obvious accept/reject calls;
+challenges it marks DEFER are escalated to a stronger model (Sonnet).  DEFER
+from the stronger model becomes ``"borderline"`` in the final output.
+
+The curation is **challenge-type agnostic** — it inspects the fields already
+present on every ``EvalChallenge`` (diff, commit_message, instructions,
+file_path) and works equally well on proof_complete, proof_add, proof_optimise,
+and spec_change challenges.
+
+Usage:
+    from scaffold.curator import curate_challenges_sync, apply_curation
+    results = curate_challenges_sync(challenges)
+    accepted, rejected, borderline = apply_curation(challenges, results)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+
+from anthropic import AsyncAnthropic
+from pydantic import BaseModel
+
+from scaffold.models import EvalChallenge
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_TIER1_MODEL = "claude-haiku-3-5-20241022"
+DEFAULT_TIER2_MODEL = "claude-sonnet-4-6"
+_MAX_DIFF_CHARS = 8000
+
+_SYSTEM_PROMPT = """\
+You are a quality curator for proof engineering benchmark challenges mined \
+from git histories. Your sole job is to decide whether a challenge is worth \
+including in an evaluation dataset for AI-driven proof synthesis.
+
+A GOOD challenge presents genuine proof engineering work: writing tactics, \
+constructing terms, filling holes, fixing broken proofs, optimizing proofs, \
+adding new lemmas/theorems, or adapting proofs to changed specifications.
+
+A BAD challenge is one where the "solution" is:
+- Deleting dead or unused code (e.g. removing an unused axiom)
+- Making purely cosmetic changes (whitespace, comments, formatting)
+- Trivially mechanical changes (renaming with no proof content)
+- Malformed (no actual incomplete proof or meaningful change)
+
+Respond with exactly two lines:
+VERDICT: ACCEPT | REJECT | DEFER
+RATIONALE: <one sentence explaining your decision>
+
+Use DEFER only when you genuinely cannot tell — the challenge is ambiguous \
+enough to warrant a stronger model's evaluation."""
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+class CurationResult(BaseModel):
+    """Result of curating a single challenge."""
+
+    verdict: str  # "accept" | "reject" | "defer" | "borderline"
+    model: str
+    rationale: str
+
+
+# ---------------------------------------------------------------------------
+# Prompt / response helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_curation_prompt(challenge: EvalChallenge) -> str:
+    """Assemble the user-message prompt from an EvalChallenge's fields."""
+    diff = challenge.diff
+    if len(diff) > _MAX_DIFF_CHARS:
+        diff = (
+            diff[:_MAX_DIFF_CHARS]
+            + f"\n... [truncated, {len(challenge.diff)} chars total]"
+        )
+
+    return (
+        f"## Challenge\n"
+        f"- **Repository**: {challenge.repo}\n"
+        f"- **Proof assistant**: {challenge.proof_assistant}\n"
+        f"- **File**: {challenge.file_path}\n"
+        f"- **Commit message**: {challenge.commit_message}\n"
+        f"- **Instructions**: {challenge.instructions}\n"
+        f"\n## Diff\n```\n{diff}\n```"
+    )
+
+
+_VERDICT_RE = re.compile(r"VERDICT:\s*(ACCEPT|REJECT|DEFER)", re.IGNORECASE)
+_RATIONALE_RE = re.compile(r"RATIONALE:\s*(.+)", re.IGNORECASE)
+
+
+def _parse_response(text: str) -> tuple[str, str]:
+    """Extract ``(verdict, rationale)`` from the model's response text.
+
+    Returns ``("defer", ...)`` if parsing fails — the challenge will be
+    escalated to the stronger model rather than silently dropped.
+    """
+    verdict_match = _VERDICT_RE.search(text)
+    rationale_match = _RATIONALE_RE.search(text)
+
+    verdict = verdict_match.group(1).lower() if verdict_match else "defer"
+    rationale = (
+        rationale_match.group(1).strip()
+        if rationale_match
+        else text.strip()[:200] or "Could not parse curation response"
+    )
+    return verdict, rationale
+
+
+# ---------------------------------------------------------------------------
+# Async curation engine
+# ---------------------------------------------------------------------------
+
+
+async def _curate_one(
+    challenge: EvalChallenge,
+    client: AsyncAnthropic,
+    model: str,
+    semaphore: asyncio.Semaphore,
+) -> CurationResult:
+    """Send a single challenge to the LLM and return a CurationResult."""
+    prompt = _build_curation_prompt(challenge)
+
+    async with semaphore:
+        response = await client.messages.create(
+            model=model,
+            max_tokens=150,
+            system=_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": prompt}],
+        )
+
+    text = response.content[0].text if response.content else ""
+    verdict, rationale = _parse_response(text)
+    return CurationResult(verdict=verdict, model=model, rationale=rationale)
+
+
+async def curate_challenges(
+    challenges: list[EvalChallenge],
+    *,
+    tier1_model: str = DEFAULT_TIER1_MODEL,
+    tier2_model: str = DEFAULT_TIER2_MODEL,
+    max_concurrent: int = 10,
+) -> list[CurationResult]:
+    """Run tiered LLM curation on a list of challenges.
+
+    Tier 1 (cheap model) processes all challenges concurrently.  Any that
+    return DEFER are escalated to tier 2 (stronger model).  DEFER from
+    tier 2 becomes ``"borderline"`` in the final result.
+    """
+    if not challenges:
+        return []
+
+    client = AsyncAnthropic(max_retries=5)
+    sem = asyncio.Semaphore(max_concurrent)
+
+    # --- Tier 1 ---
+    logger.info("Tier-1 curation: %d challenges with %s", len(challenges), tier1_model)
+    tier1_tasks = [_curate_one(c, client, tier1_model, sem) for c in challenges]
+    results: list[CurationResult] = list(await asyncio.gather(*tier1_tasks))
+
+    # --- Tier 2: escalate DEFERs ---
+    deferred = [
+        (i, challenges[i]) for i, r in enumerate(results) if r.verdict == "defer"
+    ]
+    if deferred:
+        logger.info(
+            "Tier-2 escalation: %d deferred challenges with %s",
+            len(deferred),
+            tier2_model,
+        )
+        tier2_tasks = [_curate_one(ch, client, tier2_model, sem) for _, ch in deferred]
+        tier2_results = await asyncio.gather(*tier2_tasks)
+        for (idx, _), t2r in zip(deferred, tier2_results):
+            # DEFER from tier-2 becomes "borderline" (no further escalation)
+            if t2r.verdict == "defer":
+                t2r = CurationResult(
+                    verdict="borderline", model=t2r.model, rationale=t2r.rationale
+                )
+            results[idx] = t2r
+
+    accept_n = sum(1 for r in results if r.verdict == "accept")
+    reject_n = sum(1 for r in results if r.verdict == "reject")
+    border_n = sum(1 for r in results if r.verdict == "borderline")
+    logger.info(
+        "Curation complete: %d accepted, %d rejected, %d borderline",
+        accept_n,
+        reject_n,
+        border_n,
+    )
+    return results
+
+
+def curate_challenges_sync(
+    challenges: list[EvalChallenge],
+    *,
+    tier1_model: str = DEFAULT_TIER1_MODEL,
+    tier2_model: str = DEFAULT_TIER2_MODEL,
+    max_concurrent: int = 10,
+) -> list[CurationResult]:
+    """Synchronous wrapper around :func:`curate_challenges`."""
+    return asyncio.run(
+        curate_challenges(
+            challenges,
+            tier1_model=tier1_model,
+            tier2_model=tier2_model,
+            max_concurrent=max_concurrent,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Post-curation annotation + filtering
+# ---------------------------------------------------------------------------
+
+
+def apply_curation(
+    challenges: list[EvalChallenge],
+    results: list[CurationResult],
+) -> tuple[list[EvalChallenge], list[EvalChallenge], list[EvalChallenge]]:
+    """Annotate challenges with curation fields and partition by verdict.
+
+    Returns ``(accepted, rejected, borderline)``.  Rejected challenges are
+    excluded from the materialized dataset; borderline challenges are included
+    with their annotation so downstream consumers can filter further.
+    """
+    if len(challenges) != len(results):
+        raise ValueError(
+            f"challenges ({len(challenges)}) and results ({len(results)}) must have same length"
+        )
+
+    accepted: list[EvalChallenge] = []
+    rejected: list[EvalChallenge] = []
+    borderline: list[EvalChallenge] = []
+
+    for challenge, result in zip(challenges, results):
+        annotated = challenge.model_copy(
+            update={
+                "curation_verdict": result.verdict,
+                "curation_model": result.model,
+                "curation_rationale": result.rationale,
+            }
+        )
+        if result.verdict == "accept":
+            accepted.append(annotated)
+        elif result.verdict == "reject":
+            rejected.append(annotated)
+        else:
+            borderline.append(annotated)
+
+    return accepted, rejected, borderline

--- a/scaffold/src/scaffold/dataset.py
+++ b/scaffold/src/scaffold/dataset.py
@@ -266,6 +266,7 @@ def materialize_dataset_version(
     transcript: list[str] | None = None,
     range_filter: str = "",
     created_at: str | None = None,
+    curation_stats: dict | None = None,
 ) -> DatasetVersion:
     """Write a mined eval as a ``<repo>-eval/<tag>-<short_hash>/`` version dir.
 
@@ -334,12 +335,16 @@ def materialize_dataset_version(
         }
     ]
 
+    stats = _challenge_stats(result.challenges)
+    if curation_stats:
+        stats["curation"] = curation_stats
+
     manifest, version, manifest_hash = build_manifest(
         dataset_id=f"forall/{repo_path.name}-eval",
         source=source,
         miner=miner,
         assistant=profile.proof_assistant,
-        stats=_challenge_stats(result.challenges),
+        stats=stats,
         blobs=blobs,
         tag=tag,
         created_at=created_at,
@@ -379,8 +384,16 @@ def mine_and_materialize(
     model: str = "",
     prompt_text: str | None = None,
     transcript: list[str] | None = None,
+    curate: bool = False,
+    tier1_model: str = "",
+    tier2_model: str = "",
 ) -> DatasetVersion:
-    """Mine `repo_path` full-history with `profile` and materialize a version dir."""
+    """Mine `repo_path` full-history with `profile` and materialize a version dir.
+
+    When ``curate=True``, runs an LLM curation pass between mining and
+    materialization.  Rejected challenges are excluded; borderline challenges
+    are included with their curation annotation.
+    """
     from scaffold.analyzers import ProfileAnalyzer
     from scaffold.git_walker import mine_repo
 
@@ -392,6 +405,45 @@ def mine_and_materialize(
     miner_pkg_dir = Path(__file__).resolve().parent  # .../src/scaffold
     analyzer = ProfileAnalyzer(profile.compiled())
     mined = mine_repo(repo_path, repo_path.name, analyzer)
+
+    curation_stats: dict | None = None
+    if curate and mined.challenges:
+        from scaffold.curator import (
+            DEFAULT_TIER1_MODEL,
+            DEFAULT_TIER2_MODEL,
+            apply_curation,
+            curate_challenges_sync,
+        )
+
+        t1 = tier1_model or DEFAULT_TIER1_MODEL
+        t2 = tier2_model or DEFAULT_TIER2_MODEL
+        results = curate_challenges_sync(
+            mined.challenges, tier1_model=t1, tier2_model=t2
+        )
+        accepted, rejected, borderline = apply_curation(mined.challenges, results)
+        curation_stats = {
+            "n_before_curation": len(mined.challenges),
+            "n_accepted": len(accepted),
+            "n_rejected": len(rejected),
+            "n_borderline": len(borderline),
+            "tier1_model": t1,
+            "tier2_model": t2,
+        }
+        logger.info(
+            "Curation: %d -> %d challenges (%d rejected, %d borderline)",
+            len(mined.challenges),
+            len(accepted) + len(borderline),
+            len(rejected),
+            len(borderline),
+        )
+        # Replace mined challenges with curated set (accepted + borderline)
+        mined = mined.model_copy(
+            update={
+                "challenges": accepted + borderline,
+                "total_challenges": len(accepted) + len(borderline),
+            }
+        )
+
     return materialize_dataset_version(
         profile=profile,
         result=mined,
@@ -404,6 +456,7 @@ def mine_and_materialize(
         tag=tag,
         miner_kind=miner_kind,
         transcript=transcript,
+        curation_stats=curation_stats,
     )
 
 

--- a/scaffold/src/scaffold/models.py
+++ b/scaffold/src/scaffold/models.py
@@ -102,6 +102,19 @@ class EvalChallenge(BaseModel):
         default="",
         description="Human-readable instructions for the challenge",
     )
+    # Curation fields (populated by LLM curation pass; None for uncurated datasets)
+    curation_verdict: str | None = Field(
+        default=None,
+        description="'accept' | 'reject' | 'borderline' — set by LLM curation",
+    )
+    curation_model: str | None = Field(
+        default=None,
+        description="Model that made the curation call",
+    )
+    curation_rationale: str | None = Field(
+        default=None,
+        description="One-sentence explanation from curator",
+    )
 
 
 class MiningResult(BaseModel):

--- a/scaffold/tests/test_curator.py
+++ b/scaffold/tests/test_curator.py
@@ -1,0 +1,243 @@
+"""Tests for the LLM-based curation pipeline.
+
+All tests are pure-function unit tests — no LLM API calls needed.
+"""
+
+from __future__ import annotations
+
+from scaffold.curator import (
+    CurationResult,
+    _build_curation_prompt,
+    _parse_response,
+    apply_curation,
+)
+from scaffold.models import EvalChallenge, ProofHole
+
+
+def _make_challenge(**overrides) -> EvalChallenge:
+    """Build a minimal EvalChallenge with sensible defaults."""
+    defaults = {
+        "task_id": "test_repo_abc123_file",
+        "repo": "test-repo",
+        "proof_assistant": "coq",
+        "commit_hash": "abc123",
+        "parent_hash": "def456",
+        "commit_message": "Complete proof of add_comm",
+        "file_path": "src/Proof.v",
+        "challenge_file_content": "Theorem foo : True.\nProof.\n  Admitted.\n",
+        "solution_file_content": "Theorem foo : True.\nProof.\n  trivial.\nQed.\n",
+        "holes_filled": [
+            ProofHole(line=3, column=2, kind="admitted", proof_assistant="coq")
+        ],
+        "diff": "--- a/src/Proof.v\n+++ b/src/Proof.v\n-  Admitted.\n+  trivial.\n+Qed.\n",
+        "instructions": "Fill in the proof of foo in src/Proof.v.",
+    }
+    defaults.update(overrides)
+    return EvalChallenge(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Prompt building
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCurationPrompt:
+    def test_contains_key_fields(self) -> None:
+        ch = _make_challenge()
+        prompt = _build_curation_prompt(ch)
+
+        assert "test-repo" in prompt
+        assert "coq" in prompt
+        assert "src/Proof.v" in prompt
+        assert "Complete proof of add_comm" in prompt
+        assert "Fill in the proof of foo" in prompt
+        assert "Admitted" in prompt
+
+    def test_truncates_long_diff(self) -> None:
+        long_diff = "x" * 20000
+        ch = _make_challenge(diff=long_diff)
+        prompt = _build_curation_prompt(ch)
+
+        assert "truncated" in prompt
+        assert "20000 chars total" in prompt
+        # The prompt should not contain the full 20k chars
+        assert len(prompt) < 15000
+
+    def test_short_diff_not_truncated(self) -> None:
+        ch = _make_challenge(diff="short diff")
+        prompt = _build_curation_prompt(ch)
+
+        assert "truncated" not in prompt
+        assert "short diff" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseResponse:
+    def test_accept(self) -> None:
+        verdict, rationale = _parse_response(
+            "VERDICT: ACCEPT\nRATIONALE: This is a genuine proof completion."
+        )
+        assert verdict == "accept"
+        assert "genuine proof" in rationale
+
+    def test_reject(self) -> None:
+        verdict, rationale = _parse_response(
+            "VERDICT: REJECT\nRATIONALE: Just deleting unused dead code."
+        )
+        assert verdict == "reject"
+        assert "dead code" in rationale
+
+    def test_defer(self) -> None:
+        verdict, rationale = _parse_response(
+            "VERDICT: DEFER\nRATIONALE: Ambiguous whether this is real proof work."
+        )
+        assert verdict == "defer"
+        assert "Ambiguous" in rationale
+
+    def test_case_insensitive(self) -> None:
+        verdict, _ = _parse_response("verdict: accept\nrationale: looks good")
+        assert verdict == "accept"
+
+    def test_malformed_falls_back_to_defer(self) -> None:
+        verdict, rationale = _parse_response("I'm not sure about this one.")
+        assert verdict == "defer"
+        assert len(rationale) > 0
+
+    def test_empty_response(self) -> None:
+        verdict, rationale = _parse_response("")
+        assert verdict == "defer"
+        assert "Could not parse" in rationale
+
+    def test_verdict_only_no_rationale(self) -> None:
+        verdict, rationale = _parse_response("VERDICT: ACCEPT")
+        assert verdict == "accept"
+        # Should still have some rationale (falls back to raw text)
+        assert len(rationale) > 0
+
+    def test_extra_text_around_verdict(self) -> None:
+        verdict, rationale = _parse_response(
+            "Let me analyze this.\nVERDICT: REJECT\n"
+            "RATIONALE: No actual proof content changed."
+        )
+        assert verdict == "reject"
+        assert "proof content" in rationale
+
+
+# ---------------------------------------------------------------------------
+# apply_curation
+# ---------------------------------------------------------------------------
+
+
+class TestApplyCuration:
+    def test_partitions_correctly(self) -> None:
+        challenges = [_make_challenge(task_id=f"t{i}") for i in range(4)]
+        results = [
+            CurationResult(verdict="accept", model="haiku", rationale="good"),
+            CurationResult(verdict="reject", model="haiku", rationale="junk"),
+            CurationResult(verdict="borderline", model="sonnet", rationale="unclear"),
+            CurationResult(verdict="accept", model="haiku", rationale="good too"),
+        ]
+
+        accepted, rejected, borderline = apply_curation(challenges, results)
+
+        assert len(accepted) == 2
+        assert len(rejected) == 1
+        assert len(borderline) == 1
+
+        assert accepted[0].task_id == "t0"
+        assert accepted[1].task_id == "t3"
+        assert rejected[0].task_id == "t1"
+        assert borderline[0].task_id == "t2"
+
+    def test_annotations_set_on_challenges(self) -> None:
+        challenges = [_make_challenge()]
+        results = [
+            CurationResult(
+                verdict="accept", model="test-model", rationale="real proof work"
+            ),
+        ]
+
+        accepted, _, _ = apply_curation(challenges, results)
+
+        ch = accepted[0]
+        assert ch.curation_verdict == "accept"
+        assert ch.curation_model == "test-model"
+        assert ch.curation_rationale == "real proof work"
+
+    def test_original_challenge_not_mutated(self) -> None:
+        original = _make_challenge()
+        results = [
+            CurationResult(verdict="accept", model="m", rationale="r"),
+        ]
+
+        apply_curation([original], results)
+
+        # Original should not have curation fields set
+        assert original.curation_verdict is None
+        assert original.curation_model is None
+        assert original.curation_rationale is None
+
+    def test_rejected_excluded_from_accepted_and_borderline(self) -> None:
+        challenges = [_make_challenge(task_id=f"t{i}") for i in range(3)]
+        results = [
+            CurationResult(verdict="accept", model="m", rationale="ok"),
+            CurationResult(verdict="reject", model="m", rationale="bad"),
+            CurationResult(verdict="borderline", model="m", rationale="meh"),
+        ]
+
+        accepted, rejected, borderline = apply_curation(challenges, results)
+
+        # Rejected task_id should not appear in accepted or borderline
+        accepted_ids = {c.task_id for c in accepted}
+        borderline_ids = {c.task_id for c in borderline}
+        rejected_ids = {c.task_id for c in rejected}
+
+        assert rejected_ids == {"t1"}
+        assert "t1" not in accepted_ids
+        assert "t1" not in borderline_ids
+
+    def test_mismatched_lengths_raises(self) -> None:
+        import pytest
+
+        challenges = [_make_challenge(), _make_challenge()]
+        results = [CurationResult(verdict="accept", model="m", rationale="r")]
+
+        with pytest.raises(ValueError, match="same length"):
+            apply_curation(challenges, results)
+
+    def test_all_accepted(self) -> None:
+        challenges = [_make_challenge(task_id=f"t{i}") for i in range(3)]
+        results = [
+            CurationResult(verdict="accept", model="m", rationale="good")
+            for _ in range(3)
+        ]
+
+        accepted, rejected, borderline = apply_curation(challenges, results)
+
+        assert len(accepted) == 3
+        assert len(rejected) == 0
+        assert len(borderline) == 0
+
+    def test_all_rejected(self) -> None:
+        challenges = [_make_challenge(task_id=f"t{i}") for i in range(3)]
+        results = [
+            CurationResult(verdict="reject", model="m", rationale="junk")
+            for _ in range(3)
+        ]
+
+        accepted, rejected, borderline = apply_curation(challenges, results)
+
+        assert len(accepted) == 0
+        assert len(rejected) == 3
+        assert len(borderline) == 0
+
+    def test_empty_input(self) -> None:
+        accepted, rejected, borderline = apply_curation([], [])
+
+        assert accepted == []
+        assert rejected == []
+        assert borderline == []


### PR DESCRIPTION
## Summary

- Adds `scaffold curate <jsonl>` CLI command that runs mined challenges through a two-tier LLM quality filter: Haiku handles obvious accept/reject calls cheaply, DEFERs escalate to Sonnet, and remaining ambiguous cases become "borderline"
- Adds `--curate/--no-curate` flag on `scaffold materialize` to curate inline between mining and materialization
- Adds 3 optional curation annotation fields to `EvalChallenge` (`curation_verdict`, `curation_model`, `curation_rationale`) — `None` by default for backward compatibility
- Rejected challenges are excluded from materialized datasets; borderline challenges are included with their annotation
- Curation stats (n_before/accepted/rejected/borderline, models used) are recorded in the manifest
- 19 new unit tests covering prompt building, response parsing, and curation application logic (no API key needed)

The curation is **challenge-type agnostic** — it works on any `EvalChallenge` using only existing fields (diff, commit_message, instructions, file_path), so it's compatible with the new challenge types from #76.

## Test plan

- [x] All 163 tests pass (19 new + 144 existing)
- [x] `ruff format` clean
- [x] `ruff check` clean
- [ ] Manual test: `uv run scaffold curate artifacts/compcert-eval/compcert-v1-*/challenges.jsonl` — should reject the known dud challenges (5 and 6)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)