### PR TITLE
Logfire tracing for curation + calibration LLM calls (issue #89)

### DIFF
--- a/scaffold/src/scaffold/cli.py
+++ b/scaffold/src/scaffold/cli.py
@@ -535,10 +535,12 @@ def curate(
     )
     from scaffold.model_roles import load_model_roles
     from scaffold.output import read_jsonl_slim, write_curated_stream
+    from scaffold.telemetry import configure_telemetry
 
     dotenv_path = find_dotenv(usecwd=True)
     if dotenv_path:
         load_dotenv(dotenv_path)
+    configure_telemetry("scaffold-curator")
 
     # Slim load: curation only reads diff + metadata, and large datasets
     # (fiat-crypto is 1GB / 25k challenges) OOM if fully materialized.
@@ -712,10 +714,12 @@ def calibrate(
     from scaffold.model_roles import load_model_roles
     from scaffold.output import read_jsonl_slim
     from scaffold.profile import load_profile
+    from scaffold.telemetry import configure_telemetry
 
     dotenv_path = find_dotenv(usecwd=True)
     if dotenv_path:
         load_dotenv(dotenv_path)
+    configure_telemetry("scaffold-calibrator")
 
     if bundle is not None:
         input_path = input_path or bundle / "challenges.jsonl"
@@ -849,9 +853,12 @@ def materialize(
     if do_curate:
         from dotenv import find_dotenv, load_dotenv
 
+        from scaffold.telemetry import configure_telemetry
+
         dotenv_path = find_dotenv(usecwd=True)
         if dotenv_path:
             load_dotenv(dotenv_path)
+        configure_telemetry("scaffold-curator")
 
     prof = load_profile(profile)
     dv = mine_and_materialize(

--- a/scaffold/src/scaffold/profiler/runner.py
+++ b/scaffold/src/scaffold/profiler/runner.py
@@ -59,18 +59,12 @@ class ProfileBuildResult:
 def _configure_logfire() -> None:
     """Wire Logfire so pydantic-ai + CodeMode spans register (user requirement).
 
-    ``send_to_logfire='if-token-present'`` keeps this a no-op when no token is
-    configured, so calibration never blocks on telemetry.
+    Delegates to the shared helper (scaffold/telemetry.py) so the profiler,
+    curator, and calibrator all trace identically.
     """
-    try:
-        import logfire
+    from scaffold.telemetry import configure_telemetry
 
-        logfire.configure(
-            send_to_logfire="if-token-present", service_name="scaffold-profiler"
-        )
-        logfire.instrument_pydantic_ai()
-    except Exception as exc:  # logfire is optional at runtime
-        logger.warning("logfire not configured: %s", exc)
+    configure_telemetry("scaffold-profiler")
 
 
 def _git_remote(repo_path: Path) -> str:

--- a/scaffold/src/scaffold/telemetry.py
+++ b/scaffold/src/scaffold/telemetry.py
@@ -1,0 +1,45 @@
+"""Logfire telemetry wiring shared by every LLM-calling entry point.
+
+One helper, three guarantees (issue #89):
+
+- **No-op without a token.** ``send_to_logfire="if-token-present"`` means a
+  machine without ``LOGFIRE_TOKEN`` (env or ``.env``) runs exactly as before —
+  telemetry never blocks or alters a mining/curation run.
+- **Every LLM call traced when a token is present.** ``instrument_anthropic()``
+  covers the raw Anthropic SDK clients used by the curator and the calibration
+  loop (labeler, tier-1/tier-2 scoring, the writer conversation);
+  ``instrument_pydantic_ai()`` covers the profiler agent.
+- **Idempotent.** Safe to call from multiple entry points; the first call wins
+  (one process is one CLI command, so its service name is the right label).
+
+Call this *after* dotenv loading so a token in ``.env`` is honoured.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_configured = False
+
+
+def configure_telemetry(service_name: str) -> None:
+    """Configure Logfire tracing for this process; safe no-op without a token.
+
+    *service_name* labels the traces (e.g. ``scaffold-curator``,
+    ``scaffold-calibrator``, ``scaffold-profiler``). Repeated calls are
+    ignored — the first entry point to configure wins.
+    """
+    global _configured
+    if _configured:
+        return
+    try:
+        import logfire
+
+        logfire.configure(send_to_logfire="if-token-present", service_name=service_name)
+        logfire.instrument_anthropic()
+        logfire.instrument_pydantic_ai()
+        _configured = True
+    except Exception as exc:  # telemetry must never break a run
+        logger.warning("logfire not configured: %s", exc)

--- a/scaffold/tests/test_telemetry.py
+++ b/scaffold/tests/test_telemetry.py
@@ -1,0 +1,53 @@
+"""Tests for the shared Logfire telemetry wiring (issue #89)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import scaffold.telemetry as telemetry
+
+
+def _reset() -> None:
+    telemetry._configured = False
+
+
+class TestConfigureTelemetry:
+    def test_configures_and_instruments(self, monkeypatch) -> None:
+        _reset()
+        fake = MagicMock()
+        with patch.dict("sys.modules", {"logfire": fake}):
+            telemetry.configure_telemetry("scaffold-test")
+        fake.configure.assert_called_once_with(
+            send_to_logfire="if-token-present", service_name="scaffold-test"
+        )
+        fake.instrument_anthropic.assert_called_once()
+        fake.instrument_pydantic_ai.assert_called_once()
+        _reset()
+
+    def test_idempotent_first_call_wins(self) -> None:
+        _reset()
+        fake = MagicMock()
+        with patch.dict("sys.modules", {"logfire": fake}):
+            telemetry.configure_telemetry("first")
+            telemetry.configure_telemetry("second")
+        assert fake.configure.call_count == 1
+        assert fake.configure.call_args.kwargs["service_name"] == "first"
+        _reset()
+
+    def test_never_raises_when_logfire_breaks(self) -> None:
+        _reset()
+        broken = MagicMock()
+        broken.configure.side_effect = RuntimeError("no telemetry backend")
+        with patch.dict("sys.modules", {"logfire": broken}):
+            telemetry.configure_telemetry("scaffold-test")  # must not raise
+        assert telemetry._configured is False  # next entry point may retry
+        _reset()
+
+    def test_real_logfire_noop_without_token(self, monkeypatch) -> None:
+        # End-to-end with the actual logfire package: no token configured,
+        # so configure + instrument must succeed silently as a local no-op.
+        _reset()
+        monkeypatch.delenv("LOGFIRE_TOKEN", raising=False)
+        telemetry.configure_telemetry("scaffold-test")
+        assert telemetry._configured is True
+        _reset()


### PR DESCRIPTION
## Summary

Extends the Logfire tracing that the profiler agent already has to the two pipelines that were dark: curation (`curator.py`) and prompt calibration (`calibrate.py`). With a `LOGFIRE_TOKEN` present (env or `.env`), every Anthropic SDK call — ground-truth labeling, tier-1/tier-2 scoring, the persistent writer conversation, full curation runs — produces spans with latency/token/retry detail. Without a token, behavior is byte-identical to today.

**Closes #89.**

## Design

- **`scaffold/telemetry.py`** — one shared `configure_telemetry(service_name)`:
  - `send_to_logfire="if-token-present"` → guaranteed no-op without credentials
  - `logfire.instrument_anthropic()` (covers all raw-SDK clients, sync/async/streaming) + `logfire.instrument_pydantic_ai()` (covers the profiler agent)
  - idempotent (first entry point wins — one process is one CLI command), and never raises: telemetry failure logs a warning and leaves the run untouched
- **Wired into** `curate`, `calibrate`, and `materialize --curate`, after dotenv loading so the token can live in `.env`. Service names: `scaffold-curator`, `scaffold-calibrator`, `scaffold-profiler`.
- **Profiler refactored** onto the shared helper — same behavior and service name as before, no duplicate configure logic.

## Tests

4 new tests (`test_telemetry.py`): configure+instrument calls, idempotency, telemetry-failure isolation, and an end-to-end check against the real installed `logfire` package with no token (clean local no-op). 245 passed; ruff + ty clean.

## Notes for review

- No new dependencies — `logfire` was already in `pyproject.toml` for the profiler.
- Deliberately kept off the issue-88 seL4 branch; if this merges before the l4v full-curation run, that run's ~32k calls will be the first fully traced curation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)