### PR TITLE
feat: Isabelle Ablator

### DIFF
--- a/isabelle-ablator/.gitignore
+++ b/isabelle-ablator/.gitignore
@@ -1,0 +1,4 @@
+/build/
+result
+result-*
+.isabelle/

--- a/isabelle-ablator/README.md
+++ b/isabelle-ablator/README.md
@@ -71,9 +71,10 @@ Records are **indented by default** (a stream of pretty JSON objects, nice in
 one-object-per-line JSONL (e.g. HuggingFace upload). Each record carries
 `challenge_file_content` (proofs → `sorry`), `solution_file_content` (ground
 truth), the difficulty knobs used, and `holes_filled` — the removed proofs, each
-with `theorem_name`, `depth`, `n_commands`, `n_lines`, `is_leaf`, and `method`
-(e.g. `by:simp`, `apply`, `structured`), so a single dump can be **stratified by
-difficulty post-hoc**. Field names mirror the git-history datasets in `../artifacts`.
+with `theorem_name`, `depth`, `n_commands`, `n_lines`, `is_leaf`, `centrality`
+(corpus fan-in), and `method` (e.g. `by:simp`, `apply`, `structured`), so a
+single dump can be **stratified by difficulty post-hoc**. Field names mirror the
+git-history datasets in `../artifacts`.
 
 Or via the flake directly: `nix run .# -- --all theory.thy`.
 
@@ -101,8 +102,18 @@ true bottom of the proof tree), `--min-size N`/`--max-size N` (filter by proof
 seeded spread; mutually exclusive with `-p`). `--count` is exact when matches
 don't nest (a single depth, or `--leaves-only`); with overlapping ranges an
 ablated ancestor can shadow selected descendants, so it's best-effort up to N.
-Centrality/dependency-based difficulty (ablate the lemmas other proofs lean on)
-is a planned follow-up.
+
+**Centrality.** Difficulty also has a dependency axis: removing a lemma that
+many proofs lean on is harder and more consequential than removing a leaf. A
+corpus-wide **fan-in** is computed by textual name-citation (a fact `B` is cited
+by theorem `A` if `A`'s proof mentions `B`) — no prover needed. `--min-centrality
+N`/`--max-centrality N` filter by it, and `--count N --by-centrality` ablates the
+N *most-cited* matching lemmas (e.g. "blank the 5 load-bearing lemmas in each
+theory"). `centrality` is recorded on every hole regardless. On `src/HOL/Algebra`
+the top-cited come out as `one_closed`, `subringE`, `is_group`, `inv_closed`, …
+— the genuinely foundational lemmas. It's approximate (matched by name; short
+names that collide with variables are dropped); the accurate version via
+Isabelle's `export_theory` theorem deps is a planned upgrade.
 
 ### Options
 
@@ -116,9 +127,12 @@ is a planned follow-up.
 | `--leaves-only` | only ablate goals whose proof has no nested goal |
 | `--min-size N` | only ablate proofs with ≥ N proof commands (default `0`) |
 | `--max-size N` | only ablate proofs with ≤ N proof commands; `N` may be `inf` |
+| `--min-centrality N` | only ablate lemmas with corpus fan-in ≥ N |
+| `--max-centrality N` | only ablate lemmas with corpus fan-in ≤ N; `N` may be `inf` |
 | `-p PROB` | probability of ablating each selected proof (default `0.5`) |
 | `--all` | ablate every selected proof (`-p 1.0`) |
 | `--count N` | ablate exactly `min(N, matching)` proofs, a random spread (excl. `-p`/`--all`) |
+| `--by-centrality` | with `--count`, pick the most-cited proofs instead of random |
 | `-s SESSION` | session whose keyword table to parse with (default `HOL`) |
 | `-d DIR` | extra session root directory (repeatable) |
 | `--afp DIR` | AFP `thys` dir added (`-d`) for `--check-build` deps (repeatable) |
@@ -180,5 +194,6 @@ entries. `--keep` preserves the working copies for inspection.
 - `src/Ablate.scala` — ablation library + CLI + JSONL records (`proofablate.Ablate`)
 - `src/Check.scala` — corpus self-test, run via `ablate --check` (`proofablate.Check`)
 - `src/CheckBuild.scala` — build validation, run via `ablate --check-build`
+- `src/Centrality.scala` — corpus fan-in (dependency centrality)
 - `build.sh` — `isabelle scalac` → `build/ablator.jar`
 - `bin/ablate` — classpath wrapper (checkout or nix-installed)

--- a/isabelle-ablator/README.md
+++ b/isabelle-ablator/README.md
@@ -31,10 +31,11 @@ goals and any session-specific commands are recognised.
    (`have`/`show`/`obtain`/…) and `prf_open` (`{`) push; `qed`/`prf_close` (`}`)
    pop; `qed_global` (`oops`) closes.
 4. Replace a goal's proof with `sorry` iff its depth is in `[--min-depth, --max-depth]`
-   (and a per-proof coin `-p` fires), keeping the statement and the proof's leading
-   indentation. Shallower goals keep their structure and we recurse in; deeper goals
-   are left verbatim. Everything outside proofs is emitted verbatim — `-p 0` is the
-   identity.
+   (and a per-proof coin `-p` fires), keeping the statement and placing `sorry`
+   right after it on the same line (e.g. `have a: "Q" sorry`) rather than dangling
+   on its own line. Shallower goals keep their structure and we recurse in; deeper
+   goals are left verbatim. Everything outside proofs is emitted verbatim — `-p 0`
+   is the identity.
 
 **Depth** = open goal/block-stack level when the goal opens (so `{ }` blocks add a
 level). Because `sorry` erases a whole proof body, ablating a goal stops the descent

--- a/isabelle-ablator/README.md
+++ b/isabelle-ablator/README.md
@@ -64,8 +64,13 @@ theory** to stdout:
 ./bin/ablate --difficulty L4 dir/                  # hard: every proof gone (code+spec)
 ./bin/ablate --min-depth 2 --max-depth inf t.thy   # keep skeletons, sorry sub-proofs
 ./bin/ablate --leaves-only --min-size 5 t.thy      # only big terminal proofs
+./bin/ablate --text --all theory.thy               # just the ablated theory (no JSON)
 ./bin/ablate --compact dir/ > out.jsonl            # strict one-line-per-record JSONL
 ```
+
+Output is JSONL by default; `--text` instead writes the ablated theory source
+itself to stdout (byte-exact at `-p 0`). Progress is silent by default; pass `-v`
+for a stderr summary.
 
 Records are **indented by default** (a stream of pretty JSON objects, nice in
 `less`/`bat`); still `jq`-readable (`jq -c . out`). Use `--compact` for strict
@@ -116,6 +121,29 @@ the top-cited come out as `one_closed`, `subringE`, `is_group`, `inv_closed`, �
 names that collide with variables are dropped); the accurate version via
 Isabelle's `export_theory` theorem deps is a planned upgrade.
 
+### Focusing the challenge, and augmentation
+
+Two flags shape the **challenge text** to keep the model on the theorem in front
+of it rather than extrapolating to later ones (they're prompt-shaping, so they're
+ignored by `--check`/`--check-build`):
+
+- `--truncate` drops everything after the last inserted `sorry` — the file ends
+  at the proof to complete.
+- `--shrink-context` drops top-level lemmas/theorems that come *after* the last
+  ablated one (keeping earlier context, definitions, and `end`).
+
+`--repeat N` emits up to N ablations of each theory, **deduplicated** by the
+resulting text — data augmentation that's only fruitful with a stochastic
+selector (`-p`, `--count`); with `--all` every repeat is identical so it collapses
+to one. Each variant gets its own `task_id` suffix and a `variant` field.
+
+`-d DIR` doubles as a path-prefix strip: emitted `file_path`s (and the
+path-derived `task_id`) drop a matching `-d` prefix, so datasets don't carry
+machine-specific absolute paths like `/home/you/...`. The `-d` dirs that are
+actual session roots (have `ROOT`/`ROOTS`) also feed session resolution; the
+rest are used for stripping only — so it's fine to pass the directory your
+theories live under even if it isn't a session root.
+
 ### Options
 
 | flag | meaning |
@@ -134,13 +162,17 @@ Isabelle's `export_theory` theorem deps is a planned upgrade.
 | `--all` | ablate every selected proof (`-p 1.0`) |
 | `--count N` | ablate exactly `min(N, matching)` proofs, a random spread (excl. `-p`/`--all`) |
 | `--by-centrality` | with `--count`, pick the most-cited proofs instead of random |
+| `--truncate` | challenge: drop everything after the last inserted `sorry` |
+| `--shrink-context` | challenge: drop top-level lemmas/theorems after the last ablated one |
+| `--repeat N` | emit up to N deduplicated ablations per theory (default `1`) |
 | `-s SESSION` | session whose keyword table to parse with (default `HOL`) |
-| `-d DIR` | extra session root directory (repeatable) |
+| `-d DIR` | session root dir; also stripped from emitted `file_path`s (repeatable) |
 | `--afp DIR` | AFP `thys` dir added (`-d`) for `--check-build` deps (repeatable) |
 | `--keep` | keep `--check-build` working copies |
 | `--seed N` | RNG seed for reproducibility (per-file seed derived from it) |
+| `--text` | output the ablated theory source instead of JSONL records |
 | `--compact` | strict one-object-per-line JSONL (no indentation) |
-| `-q` | suppress incidental progress on stderr |
+| `-v` | verbose: show progress/summary on stderr |
 
 ## Self-test (`--check`)
 

--- a/isabelle-ablator/README.md
+++ b/isabelle-ablator/README.md
@@ -1,0 +1,184 @@
+# isabelle-ablator
+
+**Semantic ablation for Isabelle theories.** Parse a `.thy` file with the
+*bundled Isabelle/Scala outer-syntax parser* and replace whole proofs with
+`sorry`, preserving everything else (statements, definitions, comments,
+whitespace) byte-for-byte. The ablated theories are the *challenge* side of a
+proof-synthesis training/eval pair; the original theories are the ground truth.
+
+This is the "ablate" complement to the git-history miner in this repo: instead
+of harvesting `(commit, file)` holes from history, it manufactures holes
+*synthetically* from any theory at a tunable rate — the
+[seL4-ablate-bench](../docs/SoW.md) idea of "progressively delete proofs and see
+how much an agent can reconstruct," with a slider on how much to delete.
+
+## Why a Scala tool
+
+Isabelle ships its own outer-syntax tokenizer/parser in Scala
+(`isabelle.Token`, `isabelle.Outer_Syntax`, `isabelle.Keyword`,
+`isabelle.Command_Span`). Reusing it means we classify commands with the *exact*
+keyword kinds Isabelle uses, so proof boundaries are found correctly rather than
+by brittle regex. The keyword table itself is loaded from a real session
+(`Sessions.deps(...).overall_syntax`), so `function`/`instance`/`lift_definition`
+goals and any session-specific commands are recognised.
+
+## How it works
+
+1. Load a session's `Outer_Syntax` (keyword table) — default `HOL`, sub-second.
+2. `syntax.parse_spans(text)` → command spans, each carrying its `keyword_kind`.
+3. Walk the spans tracking Isar goal-stack **depth**, recursing into kept proofs.
+   Goals nest: a `thy_goal*` command opens a depth-1 proof; `prf_goal`/`prf_asm_goal`
+   (`have`/`show`/`obtain`/…) and `prf_open` (`{`) push; `qed`/`prf_close` (`}`)
+   pop; `qed_global` (`oops`) closes.
+4. Replace a goal's proof with `sorry` iff its depth is in `[--min-depth, --max-depth]`
+   (and a per-proof coin `-p` fires), keeping the statement and the proof's leading
+   indentation. Shallower goals keep their structure and we recurse in; deeper goals
+   are left verbatim. Everything outside proofs is emitted verbatim — `-p 0` is the
+   identity.
+
+**Depth** = open goal/block-stack level when the goal opens (so `{ }` blocks add a
+level). Because `sorry` erases a whole proof body, ablating a goal stops the descent
+there — you either replace a `proof…qed` wholesale or keep its skeleton and ablate
+inside, never both.
+
+**Script-style goals** (`subgoal` and friends: `prf_script_goal`/`_asm_goal`) are
+never replaced — `sorry` isn't reliably valid in apply-script position — though they
+still nest. A theory command appearing while a goal is open (a desync) makes the tool
+keep that proof verbatim — it never corrupts the source.
+
+## Build & run
+
+```bash
+nix develop            # provides isabelle (2025) + JDK
+bash build.sh          # -> build/ablator.jar
+```
+
+`ablate` takes any mix of `.thy` files and directories (directories are walked
+recursively for `*.thy`) and emits one **(challenge, solution) JSON record per
+theory** to stdout:
+
+```bash
+./bin/ablate theory.thy                            # 50% of top-level proofs -> sorry
+./bin/ablate --difficulty L1 src/HOL/Library       # easy: only leaf steps -> sorry
+./bin/ablate --difficulty L4 dir/                  # hard: every proof gone (code+spec)
+./bin/ablate --min-depth 2 --max-depth inf t.thy   # keep skeletons, sorry sub-proofs
+./bin/ablate --leaves-only --min-size 5 t.thy      # only big terminal proofs
+./bin/ablate --compact dir/ > out.jsonl            # strict one-line-per-record JSONL
+```
+
+Records are **indented by default** (a stream of pretty JSON objects, nice in
+`less`/`bat`); still `jq`-readable (`jq -c . out`). Use `--compact` for strict
+one-object-per-line JSONL (e.g. HuggingFace upload). Each record carries
+`challenge_file_content` (proofs → `sorry`), `solution_file_content` (ground
+truth), the difficulty knobs used, and `holes_filled` — the removed proofs, each
+with `theorem_name`, `depth`, `n_commands`, `n_lines`, `is_leaf`, and `method`
+(e.g. `by:simp`, `apply`, `structured`), so a single dump can be **stratified by
+difficulty post-hoc**. Field names mirror the git-history datasets in `../artifacts`.
+
+Or via the flake directly: `nix run .# -- --all theory.thy`.
+
+### Difficulty
+
+Reconstruction difficulty has a few roughly-orthogonal axes, exposed as raw
+knobs and composed into a preset **ladder** (raw knobs override any preset field):
+
+| `--difficulty` | composition | character |
+|---|---|---|
+| `L0` | `--leaves-only --max-depth inf -p 0.3` | a few terminal steps |
+| `L1` | `--leaves-only --max-depth inf --all` | all leaf steps; skeletons fully kept |
+| `L2` | `--min-depth 2 --max-depth inf --all` | all sub-proofs; only top skeletons kept |
+| `L3` | `--min-depth 1 --max-depth 1 -p 0.5` | half the whole proofs gone |
+| `L4` | `--min-depth 1 --max-depth 1 --all` | every proof gone (code + spec only) |
+
+Easier levels keep more structure as scaffolding; `L4` is the seL4-ablate-bench
+extreme. The discrete rungs are meant for plotting agent success vs. difficulty.
+
+Raw knobs: `--leaves-only` (only goals whose proof has no nested goal — the
+true bottom of the proof tree), `--min-size N`/`--max-size N` (filter by proof
+*command count*, so you can target trivial `by simp`s or long manual proofs),
+`--min-depth`/`--max-depth`, and the rate — either `-p PROB` (per-proof coin) or
+`--count N` (exactly `min(N, matching)` proofs per theory, a uniformly-random
+seeded spread; mutually exclusive with `-p`). `--count` is exact when matches
+don't nest (a single depth, or `--leaves-only`); with overlapping ranges an
+ablated ancestor can shadow selected descendants, so it's best-effort up to N.
+Centrality/dependency-based difficulty (ablate the lemmas other proofs lean on)
+is a planned follow-up.
+
+### Options
+
+| flag | meaning |
+|------|---------|
+| `--check` | run the corpus self-test instead of emitting records |
+| `--check-build D` | copy + ablate + `isabelle build` session dir D (repeatable) |
+| `--difficulty L` | preset ladder `L0` (easy) … `L4` (code+spec only) |
+| `--min-depth N` | ablate goals at nesting depth ≥ N (default `1`) |
+| `--max-depth N` | ablate goals at nesting depth ≤ N; `N` may be `inf` (default `1`) |
+| `--leaves-only` | only ablate goals whose proof has no nested goal |
+| `--min-size N` | only ablate proofs with ≥ N proof commands (default `0`) |
+| `--max-size N` | only ablate proofs with ≤ N proof commands; `N` may be `inf` |
+| `-p PROB` | probability of ablating each selected proof (default `0.5`) |
+| `--all` | ablate every selected proof (`-p 1.0`) |
+| `--count N` | ablate exactly `min(N, matching)` proofs, a random spread (excl. `-p`/`--all`) |
+| `-s SESSION` | session whose keyword table to parse with (default `HOL`) |
+| `-d DIR` | extra session root directory (repeatable) |
+| `--afp DIR` | AFP `thys` dir added (`-d`) for `--check-build` deps (repeatable) |
+| `--keep` | keep `--check-build` working copies |
+| `--seed N` | RNG seed for reproducibility (per-file seed derived from it) |
+| `--compact` | strict one-object-per-line JSONL (no indentation) |
+| `-q` | suppress incidental progress on stderr |
+
+## Self-test (`--check`)
+
+`ablate --check PATH...` loads the syntax once and, for every theory at the
+configured `--min-depth`/`--max-depth`, verifies (1) lossless round-trip
+(parse→implode == source), (2) every in-range proof is cleanly delimited (prob-1
+ablates all of them), and (3) the ablated text preserves all theory-level goal
+statements. It also times the ablation pass. Prints a report, exits non-zero on
+any failure — a CI gate.
+
+```bash
+./bin/ablate --check "$(isabelle getenv -b ISABELLE_HOME)/src/HOL"
+./bin/ablate --check --min-depth 2 --max-depth inf "$ISABELLE_HOME/src/HOL"
+```
+
+Last run over `src/HOL` (1467 theories), all checks clean:
+
+- depth `1..1` (top-level): **69,679 proofs**, 100% ablated, 0 failures
+- depth `2..inf` (sub-proofs): **64,364 proofs**, 100% ablated, 0 failures
+
+## Build validation (`--check-build`)
+
+`--check` proves the ablated text *parses* and round-trips; `--check-build`
+proves it still *type-checks*. For each session directory (one containing a
+`ROOT`) it copies the dir, renames the declared session(s) (a `__ablated`
+suffix, so the copy never clashes with the original on the build path), ablates
+every `.thy` in the copy, then runs `isabelle build -o quick_and_dirty=true`. A
+clean build certifies the challenge is well-formed Isabelle — statements and
+definitions elaborate, only the proof bodies are admitted (`quick_and_dirty`
+turns `sorry` from a build error into an admitted goal). This is the gate that
+matters most for sub-proof ablation, where nested `sorry` validity isn't
+guaranteed by parsing alone.
+
+```bash
+# one or more targets; --afp adds AFP `thys` dirs (-d) so dependencies resolve
+./bin/ablate --check-build path/to/Entry --afp /path/to/afp/thys --all
+./bin/ablate --min-depth 2 --max-depth inf \
+    --check-build EntryA --check-build EntryB --afp /path/to/afp/thys
+```
+
+Validated end-to-end: a `Main`-importing session, multiple targets at once, an
+AFP-style cross-session dependency resolved via `--afp` (with the rename
+avoiding a clash against the on-path original), and — crucially — a **depth
+`2..inf` sub-proof ablation that builds cleanly** (nested `sorry` accepted).
+Builds reuse the bundled HOL/Pure heaps; targets importing heavier sessions
+(HOL-Analysis, …) build those first, so it is intensive — start with small
+entries. `--keep` preserves the working copies for inspection.
+
+## Layout
+
+- `flake.nix` — Isabelle 2025 + JDK dev shell and `ablator` package
+- `src/Ablate.scala` — ablation library + CLI + JSONL records (`proofablate.Ablate`)
+- `src/Check.scala` — corpus self-test, run via `ablate --check` (`proofablate.Check`)
+- `src/CheckBuild.scala` — build validation, run via `ablate --check-build`
+- `build.sh` — `isabelle scalac` → `build/ablator.jar`
+- `bin/ablate` — classpath wrapper (checkout or nix-installed)

--- a/isabelle-ablator/bin/ablate
+++ b/isabelle-ablator/bin/ablate
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Run the ablator with the Isabelle/Scala classpath assembled by `isabelle`.
+# Works both from a checkout (uses ./build/ablator.jar + `isabelle` on PATH)
+# and when installed by the nix flake (placeholders substituted at install).
+set -euo pipefail
+
+JAR="@JAR@"
+ISABELLE="@ISABELLE@"
+case "$JAR" in @*@) JAR="$(cd "$(dirname "$0")/.." && pwd)/build/ablator.jar" ;; esac
+case "$ISABELLE" in @*@) ISABELLE="$(command -v isabelle)" ;; esac
+
+MAIN="${ABLATE_MAIN:-proofablate.Ablate}"
+ISA_JAR="$("$ISABELLE" getenv -b ISABELLE_SCALA_JAR)"
+CP="$("$ISABELLE" getenv -b ISABELLE_CLASSPATH)"
+exec "$ISABELLE" java -cp "$JAR:$ISA_JAR:$CP" "$MAIN" "$@"

--- a/isabelle-ablator/build.sh
+++ b/isabelle-ablator/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Compile the ablator against the bundled Isabelle/Scala classpath.
+# Requires `isabelle` on PATH (provided by `nix develop`).
+set -euo pipefail
+cd "$(dirname "$0")"
+mkdir -p build
+isabelle scalac -d build/ablator.jar src/*.scala
+echo "built $(pwd)/build/ablator.jar"

--- a/isabelle-ablator/flake.lock
+++ b/isabelle-ablator/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/isabelle-ablator/flake.nix
+++ b/isabelle-ablator/flake.nix
@@ -1,0 +1,65 @@
+{
+  description = "Isabelle semantic-ablation toolkit — parse .thy files with the bundled Isabelle/Scala outer-syntax parser and replace proofs with `sorry` to synthesise post-training data.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        isabelle = pkgs.isabelle;
+        # The bundled Isabelle ships its own JDK and Scala compiler under
+        # $ISABELLE_HOME/contrib; `isabelle scalac` / `isabelle java` use those.
+        # We only need a JDK in the shell for ad-hoc tooling.
+        jdk = pkgs.jdk21;
+      in
+      {
+        packages = {
+          inherit isabelle;
+          default = self.packages.${system}.ablator;
+
+          # The ablator CLI: a small Scala program compiled against the
+          # Isabelle/Scala classpath, wrapped so `ablate file.thy` runs it
+          # inside the Isabelle environment.
+          ablator = pkgs.stdenv.mkDerivation {
+            pname = "isabelle-ablator";
+            version = "0.1.0";
+            src = ./.;
+            nativeBuildInputs = [ isabelle jdk ];
+            # Isabelle writes user settings under $ISABELLE_HOME_USER; in the
+            # nix sandbox $HOME is not writable, so point it at the build tree.
+            buildPhase = ''
+              export HOME=$TMPDIR
+              export ISABELLE_HOME_USER=$TMPDIR/.isabelle
+              mkdir -p $ISABELLE_HOME_USER
+              bash build.sh
+            '';
+            installPhase = ''
+              mkdir -p $out/lib $out/bin
+              cp build/ablator.jar $out/lib/
+              substitute bin/ablate $out/bin/ablate \
+                --replace '@JAR@' "$out/lib/ablator.jar" \
+                --replace '@ISABELLE@' "${isabelle}/bin/isabelle"
+              chmod +x $out/bin/ablate
+            '';
+          };
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${self.packages.${system}.ablator}/bin/ablate";
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = [ isabelle jdk pkgs.bashInteractive ];
+          shellHook = ''
+            echo "Isabelle: $(isabelle version 2>/dev/null || echo '?')"
+            echo "Build the ablator:  bash build.sh"
+            echo "Run it:             ./bin/ablate <theory.thy>"
+          '';
+        };
+      });
+}

--- a/isabelle-ablator/src/Ablate.scala
+++ b/isabelle-ablator/src/Ablate.scala
@@ -85,16 +85,22 @@ object Ablate {
   sealed case class Spec(
     prob: Double = 0.5,
     count: Option[Int] = None,
+    by_centrality: Boolean = false,  // for `count`: pick the most-cited, not random
     min_depth: Int = 1,
     max_depth: Int = 1,
     leaves_only: Boolean = false,
-    min_size: Int = 0,            // proof-command count, inclusive lower bound
-    max_size: Int = Int.MaxValue  // inclusive upper bound
-  )
+    min_size: Int = 0,               // proof-command count, inclusive lower bound
+    max_size: Int = Int.MaxValue,    // inclusive upper bound
+    min_centrality: Int = 0,         // fan-in (distinct theorems citing this lemma)
+    max_centrality: Int = Int.MaxValue
+  ) {
+    def uses_centrality: Boolean =
+      min_centrality > 0 || max_centrality != Int.MaxValue || by_centrality
+  }
 
   /** A removed proof and its difficulty signals. */
   sealed case class Hole(theorem_name: String, depth: Int, n_commands: Int, n_lines: Int,
-    is_leaf: Boolean, method: String, proof_text: String)
+    is_leaf: Boolean, centrality: Int, method: String, proof_text: String)
 
   sealed case class Result(text: String, total: Int, ablated: Int, holes: List[Hole])
 
@@ -110,18 +116,19 @@ object Ablate {
    *  exactly those — exact when matches don't nest (a single depth, or
    *  `--leaves-only`); otherwise an ablated ancestor may shadow selected
    *  descendants, so it is best-effort up to N. */
-  def ablate(syntax: Outer_Syntax, text: CharSequence, spec: Spec, rng: Random): Result = {
+  def ablate(syntax: Outer_Syntax, text: CharSequence, spec: Spec,
+    rng: Random, centrality: String => Int = (_ => 0)): Result = {
     val spans = syntax.parse_spans(text).toArray
     val n = spans.length
 
     def src(j: Int): String = Token.implode(spans(j).content)
 
     // One pass; `decide(stmt_index)` says whether to ablate each matching proof.
-    // Returns the result plus the statement-span indices of all matching proofs.
-    def walk_all(decide: Int => Boolean): (Result, List[Int]) = {
+    // Returns the result plus, for every matching proof, (stmt index, centrality).
+    def walk_all(decide: Int => Boolean): (Result, List[(Int, Int)]) = {
     val out = new mutable.StringBuilder
     val holes = new mutable.ListBuffer[Hole]
-    val matches = new mutable.ListBuffer[Int]
+    val matches = new mutable.ListBuffer[(Int, Int)]
     var total = 0
     var ablated = 0
     var i = 0
@@ -180,21 +187,23 @@ object Ablate {
       depth = d + 1
       val goal_depth = d + 1
       val m = measure(i, d)
+      val cent = centrality(name)
 
       val candidate =
         is_ablatable(k) && m.clean &&
           goal_depth >= spec.min_depth && goal_depth <= spec.max_depth &&
           (!spec.leaves_only || m.is_leaf) &&
-          m.n_commands >= spec.min_size && m.n_commands <= spec.max_size
+          m.n_commands >= spec.min_size && m.n_commands <= spec.max_size &&
+          cent >= spec.min_centrality && cent <= spec.max_centrality
 
       if (candidate) {
         total += 1
-        matches += stmt_idx
+        matches += ((stmt_idx, cent))
         if (decide(stmt_idx)) {
           out ++= (if (m.lead.nonEmpty) m.lead else " ")    // separate glued proofs
           out ++= "sorry"
           ablated += 1
-          holes += Hole(name, goal_depth, m.n_commands, n_lines(m.text), m.is_leaf, m.method, m.text)
+          holes += Hole(name, goal_depth, m.n_commands, n_lines(m.text), m.is_leaf, cent, m.method, m.text)
           i = m.end; depth = d
         } else walk_body(d)                                  // not selected: keep, recurse deeper
       }
@@ -216,12 +225,14 @@ object Ablate {
 
     spec.count match {
       case Some(target) =>
-        // enumerate matching proofs (decide=false), pick a random subset of N,
-        // then ablate exactly those. rng is used only for the selection.
-        val cands = walk_all(_ => false)._2
+        // enumerate matching proofs (decide=false), pick a subset of N, then
+        // ablate exactly those. Random spread, or the most-cited if --by-centrality.
+        val cands = walk_all(_ => false)._2   // List[(stmt_idx, centrality)]
         val selected: Set[Int] =
-          if (cands.length <= target) cands.toSet
-          else rng.shuffle(cands).take(target).toSet
+          if (cands.length <= target) cands.map(_._1).toSet
+          else if (spec.by_centrality)
+            cands.sortBy { case (idx, c) => (-c, idx) }.take(target).map(_._1).toSet
+          else rng.shuffle(cands.map(_._1)).take(target).toSet
         walk_all(selected.contains)._1.copy(total = cands.length)
       case None =>
         walk_all(_ => rng.nextDouble() < spec.prob)._1
@@ -290,8 +301,8 @@ object Ablate {
     val holes: List[JSON.T] =
       result.holes.map(h => ListMap[String, JSON.T](
         "theorem_name" -> h.theorem_name, "depth" -> h.depth, "n_commands" -> h.n_commands,
-        "n_lines" -> h.n_lines, "is_leaf" -> h.is_leaf, "method" -> h.method,
-        "proof_text" -> h.proof_text))
+        "n_lines" -> h.n_lines, "is_leaf" -> h.is_leaf, "centrality" -> h.centrality,
+        "method" -> h.method, "proof_text" -> h.proof_text))
     ListMap[String, JSON.T](
       "task_id" -> task_id(path),
       "proof_assistant" -> "isabelle",
@@ -301,12 +312,15 @@ object Ablate {
       "challenge_type" -> "proof_ablate",
       "difficulty" -> difficulty.map(d => d: JSON.T).getOrElse(null),
       "count" -> spec.count.map(c => c: JSON.T).getOrElse(null),
+      "by_centrality" -> spec.by_centrality,
       "ablation_prob" -> (if (spec.count.isDefined) (null: JSON.T) else spec.prob),
       "min_depth" -> spec.min_depth,
       "max_depth" -> depth_json(spec.max_depth),
       "leaves_only" -> spec.leaves_only,
       "min_size" -> spec.min_size,
       "max_size" -> depth_json(spec.max_size),
+      "min_centrality" -> spec.min_centrality,
+      "max_centrality" -> depth_json(spec.max_centrality),
       "seed" -> seed,
       "n_proofs" -> result.total,
       "n_ablated" -> result.ablated,
@@ -341,10 +355,13 @@ object Ablate {
       |    --leaves-only    only ablate goals whose proof has no nested goal
       |    --min-size N     only ablate proofs with >= N proof commands (default: 0)
       |    --max-size N     only ablate proofs with <= N proof commands; N may be `inf`
+      |    --min-centrality N  only ablate lemmas cited by >= N other proofs (corpus fan-in)
+      |    --max-centrality N  only ablate lemmas cited by <= N other proofs; N may be `inf`
       |    -p PROB          probability of ablating each selected proof (default: 0.5)
       |    --all            ablate every selected proof (equivalent to -p 1.0)
-      |    --count N        ablate ~N selected proofs per theory, spread across it
+      |    --count N        ablate exactly min(N, matching) selected proofs per theory
       |                     (mutually exclusive with -p / --all)
+      |    --by-centrality  with --count, pick the most-cited proofs (not random)
       |
       |  Other:
       |    -s SESSION       session whose syntax/keywords to parse with (default: HOL)
@@ -372,6 +389,9 @@ object Ablate {
     var leavesOpt: Option[Boolean] = None
     var minSizeOpt: Option[Int] = None
     var maxSizeOpt: Option[Int] = None
+    var minCentralityOpt: Option[Int] = None
+    var maxCentralityOpt: Option[Int] = None
+    var byCentrality = false
     val paths = new mutable.ListBuffer[String]
     val build_targets = new mutable.ListBuffer[String]
     val afp_dirs = new mutable.ListBuffer[String]
@@ -390,6 +410,9 @@ object Ablate {
         case "--leaves-only" :: tl => leavesOpt = Some(true); rest = tl
         case "--min-size" :: v :: tl => minSizeOpt = Some(parse_depth(v)); rest = tl
         case "--max-size" :: v :: tl => maxSizeOpt = Some(parse_depth(v)); rest = tl
+        case "--min-centrality" :: v :: tl => minCentralityOpt = Some(parse_depth(v)); rest = tl
+        case "--max-centrality" :: v :: tl => maxCentralityOpt = Some(parse_depth(v)); rest = tl
+        case "--by-centrality" :: tl => byCentrality = true; rest = tl
         case "-s" :: v :: tl => session = v; rest = tl
         case "-d" :: v :: tl => dirs = dirs ::: List(Path.explode(v)); rest = tl
         case "-p" :: v :: tl => probOpt = Some(v.toDouble); rest = tl
@@ -414,14 +437,20 @@ object Ablate {
       Console.err.println("--count cannot be combined with -p / --all (they set the rate two ways)")
       sys.exit(2)
     }
+    if (byCentrality && countOpt.isEmpty) {
+      Console.err.println("--by-centrality only applies with --count"); sys.exit(2)
+    }
     val spec = Spec(
       prob = probOpt.orElse(preset.map(_.prob)).getOrElse(0.5),
       count = countOpt,
+      by_centrality = byCentrality,
       min_depth = minDepthOpt.orElse(preset.map(_.min_depth)).getOrElse(1),
       max_depth = maxDepthOpt.orElse(preset.map(_.max_depth)).getOrElse(1),
       leaves_only = leavesOpt.orElse(preset.map(_.leaves_only)).getOrElse(false),
       min_size = minSizeOpt.getOrElse(0),
-      max_size = maxSizeOpt.getOrElse(Int.MaxValue))
+      max_size = maxSizeOpt.getOrElse(Int.MaxValue),
+      min_centrality = minCentralityOpt.getOrElse(0),
+      max_centrality = maxCentralityOpt.getOrElse(Int.MaxValue))
 
     if (spec.min_depth < 1) { Console.err.println("--min-depth must be >= 1"); sys.exit(2) }
     if (paths.isEmpty && build_targets.isEmpty) { Console.err.println(usage); sys.exit(2) }
@@ -435,6 +464,9 @@ object Ablate {
         (if (spec.leaves_only) " leaves-only" else "") +
         (if (spec.min_size > 0 || spec.max_size != Int.MaxValue)
           s" size ${spec.min_size}..${depth_json(spec.max_size)}" else "") +
+        (if (spec.uses_centrality)
+          s" centrality ${spec.min_centrality}..${depth_json(spec.max_centrality)}" +
+            (if (spec.by_centrality) " by-centrality" else "") else "") +
         spec.count.map(c => s" count=$c").getOrElse(f" p=${spec.prob}%.2f") +
         difficulty.map(d => s" [$d]").getOrElse("")
 
@@ -451,8 +483,17 @@ object Ablate {
     if (!quiet) progress.echo(s"[session $session: ${syntax.keywords.kinds.size} keywords; " +
       s"${theories.length} theories; $spec_line]")
 
+    // corpus fan-in over all input theories: always for the emit path (so the
+    // metadata is complete for post-hoc stratification), and for --check only
+    // when a centrality filter is actually in play.
+    val centrality: String => Int =
+      if (!check || spec.uses_centrality) {
+        val fan = Centrality.fan_in(syntax, theories, progress)
+        (name => fan.getOrElse(name, 0))
+      } else (_ => 0)
+
     if (check) {
-      val ok = Check.run(syntax, theories, spec)
+      val ok = Check.run(syntax, theories, spec, centrality)
       if (!ok) sys.exit(1)
       return
     }
@@ -461,7 +502,7 @@ object Ablate {
     for (thy <- theories) {
       val original = File.read(thy)
       val rng = new Random(base ^ thy.implode.hashCode.toLong)
-      val result = ablate(syntax, original, spec, rng)
+      val result = ablate(syntax, original, spec, rng, centrality)
       val obj = record(thy, session, spec, base, difficulty, original, result)
       System.out.println(if (compact) JSON.Format(obj) else JSON.Format.pretty_print(obj))
       emitted += 1

--- a/isabelle-ablator/src/Ablate.scala
+++ b/isabelle-ablator/src/Ablate.scala
@@ -1,0 +1,472 @@
+/*  Isabelle semantic-ablation tool.
+
+    Parse Isabelle theories with the bundled Isabelle/Scala outer-syntax parser
+    and replace proofs with `sorry`, preserving everything else (statements,
+    definitions, comments, whitespace) byte-for-byte.
+
+    Usage:
+      ablate [OPTIONS] PATH...            emit (challenge, solution) JSONL pairs
+      ablate --check [OPTIONS] PATH...    run the corpus self-test instead
+      ablate --check-build DIR ...        copy+ablate+`isabelle build` a session
+
+    PATH... is any mix of .thy files and directories (walked for *.thy). The
+    ablated theory is the *challenge*; the original is the ground-truth *solution*.
+
+    The unit of ablation is the proof of a *goal* command. Goals nest:
+
+        lemma foo: "P"          depth 1   (thy_goal*)
+        proof -
+          have a: "Q"           depth 2   (prf_goal / prf_asm_goal)
+            by simp
+          show "P" ...          depth 2
+        qed
+
+    Which proofs are ablated is controlled by a difficulty Spec (depth range,
+    leaves-only, proof-size window, per-proof probability), or a `--difficulty`
+    preset that composes those knobs. Script-style goals (`subgoal` &c.:
+    prf_script_goal/_asm_goal) are never replaced but still nest.
+*/
+
+package proofablate
+
+import isabelle._
+
+import scala.util.Random
+import scala.collection.mutable
+import scala.collection.immutable.ListMap
+
+
+object Ablate {
+  /* keyword-kind predicates (see Pure/Isar/keyword.scala) */
+
+  private def is_goal(k: String): Boolean =
+    Keyword.theory_goal.contains(k) || Keyword.proof_goal.contains(k)
+  private def is_ablatable(k: String): Boolean =
+    Keyword.theory_goal.contains(k) || k == Keyword.PRF_GOAL || k == Keyword.PRF_ASM_GOAL
+  private def closes(k: String): Boolean = Keyword.proof_close.contains(k)
+  private def closes_global(k: String): Boolean = Keyword.qed_global.contains(k)
+  private def is_theory(k: String): Boolean = Keyword.theory.contains(k)
+  // commands that precede the "real" proof method (using/unfolding/from/then/note/
+  // also/moreover/ultimately/fix/assume/let/case) — skipped when classifying method
+  private def is_prefatory(k: String): Boolean =
+    k == Keyword.PRF_CHAIN || k == Keyword.PRF_DECL || k == Keyword.PRF_ASM
+
+  private def kind_of(span: Command_Span.Span): Option[String] = span.kind.keyword_kind
+
+  private def n_lines(s: String): Int = if (s.isEmpty) 0 else s.count(_ == '\n') + 1
+
+  /** A short label for a proof's main method, for difficulty stratification. */
+  private def classify_method(span: Command_Span.Span): String =
+    span.name match {
+      case "by" =>
+        span.content.dropWhile(t => !t.is_command).drop(1).filter(_.is_proper)
+          .find(_.is_ident).map("by:" + _.source).getOrElse("by")
+      case "apply" | "apply_end" => "apply"
+      case "proof" => "structured"
+      case "." | ".." => "trivial"
+      case other => other
+    }
+
+  /** Best-effort theorem name from a goal statement span. "" when anonymous. */
+  def goal_name(span: Command_Span.Span): String = {
+    val after = span.content.dropWhile(t => !t.is_command).drop(1).filter(_.is_proper)
+    val rest =
+      if (after.headOption.exists(_.is_keyword("(")))
+        after.dropWhile(t => !t.is_keyword(")")).drop(1)
+      else after
+    rest match {
+      case t :: next :: _ if t.is_ident && (next.is_keyword(":") || next.is_keyword("[")) => t.source
+      case _ => ""
+    }
+  }
+
+  /** Which proofs to ablate. `count`, when set, overrides `prob`: ablate a
+   *  uniformly-random subset of that many matching proofs (see `ablate`). */
+  sealed case class Spec(
+    prob: Double = 0.5,
+    count: Option[Int] = None,
+    min_depth: Int = 1,
+    max_depth: Int = 1,
+    leaves_only: Boolean = false,
+    min_size: Int = 0,            // proof-command count, inclusive lower bound
+    max_size: Int = Int.MaxValue  // inclusive upper bound
+  )
+
+  /** A removed proof and its difficulty signals. */
+  sealed case class Hole(theorem_name: String, depth: Int, n_commands: Int, n_lines: Int,
+    is_leaf: Boolean, method: String, proof_text: String)
+
+  sealed case class Result(text: String, total: Int, ablated: Int, holes: List[Hole])
+
+  // Measured properties of a goal body.
+  private sealed case class Body(end: Int, lead: String, text: String,
+    n_commands: Int, is_leaf: Boolean, method: String, clean: Boolean)
+
+  /** Ablate proofs selected by `spec`, each replaced by `sorry`.
+   *
+   *  With `spec.prob`, each matching proof is ablated by an independent coin.
+   *  With `spec.count = Some(N)`, we first enumerate the T matching proofs, pick
+   *  a uniformly-random subset of min(N, T) (seeded, reproducible), and ablate
+   *  exactly those — exact when matches don't nest (a single depth, or
+   *  `--leaves-only`); otherwise an ablated ancestor may shadow selected
+   *  descendants, so it is best-effort up to N. */
+  def ablate(syntax: Outer_Syntax, text: CharSequence, spec: Spec, rng: Random): Result = {
+    val spans = syntax.parse_spans(text).toArray
+    val n = spans.length
+
+    def src(j: Int): String = Token.implode(spans(j).content)
+
+    // One pass; `decide(stmt_index)` says whether to ablate each matching proof.
+    // Returns the result plus the statement-span indices of all matching proofs.
+    def walk_all(decide: Int => Boolean): (Result, List[Int]) = {
+    val out = new mutable.StringBuilder
+    val holes = new mutable.ListBuffer[Hole]
+    val matches = new mutable.ListBuffer[Int]
+    var total = 0
+    var ablated = 0
+    var i = 0
+    var depth = 0
+
+    // Pure lookahead — does NOT mutate i/depth/out. Scans the whole subtree.
+    def measure(start: Int, d: Int): Body = {
+      val lead = new mutable.StringBuilder
+      val body = new mutable.StringBuilder
+      var j = start; var dep = d + 1
+      var seen = false; var clean = true
+      var n_cmds = 0; var is_leaf = true; var method = ""
+      while (j < n && dep > d && clean) {
+        kind_of(spans(j)) match {
+          case Some(k) if is_theory(k) => clean = false
+          case Some(k) =>
+            seen = true; body ++= src(j); n_cmds += 1
+            if (is_ablatable(k)) is_leaf = false
+            if (method.isEmpty && !is_prefatory(k)) method = classify_method(spans(j))
+            if (Keyword.proof_goal.contains(k) || k == Keyword.PRF_OPEN) dep += 1
+            else if (closes(k)) dep -= 1
+            else if (closes_global(k)) dep = d
+            j += 1
+          case None =>
+            if (seen) body ++= src(j) else lead ++= src(j)
+            j += 1
+        }
+      }
+      Body(j, lead.toString, body.toString, n_cmds, is_leaf,
+        if (method.isEmpty) "?" else method, clean && dep == d)
+    }
+
+    // Emit the body verbatim, recursing into nested goals (the "keep" path).
+    def walk_body(d: Int): Unit =
+      while (i < n && depth > d) {
+        kind_of(spans(i)) match {
+          case Some(k) if is_theory(k) => depth = d                 // desync: bail
+          case Some(k) if is_goal(k) => handle_goal()                // recurse
+          case Some(k) =>
+            out ++= src(i)
+            if (k == Keyword.PRF_OPEN) depth += 1
+            else if (closes(k)) depth -= 1
+            else if (closes_global(k)) depth = d
+            i += 1
+          case None => out ++= src(i); i += 1
+        }
+      }
+
+    def handle_goal(): Unit = {
+      val d = depth
+      val stmt_idx = i                                       // stable id of this goal across passes
+      val k = kind_of(spans(i)).get
+      val name = goal_name(spans(i))
+      out ++= src(i)
+      i += 1
+      depth = d + 1
+      val goal_depth = d + 1
+      val m = measure(i, d)
+
+      val candidate =
+        is_ablatable(k) && m.clean &&
+          goal_depth >= spec.min_depth && goal_depth <= spec.max_depth &&
+          (!spec.leaves_only || m.is_leaf) &&
+          m.n_commands >= spec.min_size && m.n_commands <= spec.max_size
+
+      if (candidate) {
+        total += 1
+        matches += stmt_idx
+        if (decide(stmt_idx)) {
+          out ++= (if (m.lead.nonEmpty) m.lead else " ")    // separate glued proofs
+          out ++= "sorry"
+          ablated += 1
+          holes += Hole(name, goal_depth, m.n_commands, n_lines(m.text), m.is_leaf, m.method, m.text)
+          i = m.end; depth = d
+        } else walk_body(d)                                  // not selected: keep, recurse deeper
+      }
+      else if (goal_depth > spec.max_depth) {                // too deep: verbatim (keep lead!)
+        out ++= m.lead; out ++= m.text; i = m.end; depth = d
+      }
+      else walk_body(d)                                      // too shallow / filtered out: recurse
+    }
+
+    while (i < n) {
+      kind_of(spans(i)) match {
+        case Some(k) if is_goal(k) => handle_goal()
+        case _ => out ++= src(i); i += 1
+      }
+    }
+
+    (Result(out.toString, total, ablated, holes.toList), matches.toList)
+    }  // walk_all
+
+    spec.count match {
+      case Some(target) =>
+        // enumerate matching proofs (decide=false), pick a random subset of N,
+        // then ablate exactly those. rng is used only for the selection.
+        val cands = walk_all(_ => false)._2
+        val selected: Set[Int] =
+          if (cands.length <= target) cands.toSet
+          else rng.shuffle(cands).take(target).toSet
+        walk_all(selected.contains)._1.copy(total = cands.length)
+      case None =>
+        walk_all(_ => rng.nextDouble() < spec.prob)._1
+    }
+  }
+
+
+  /* difficulty preset ladder (easy -> hard); raw knobs override any preset field */
+
+  sealed case class Preset(prob: Double, min_depth: Int, max_depth: Int, leaves_only: Boolean)
+
+  val LADDER: Vector[Preset] = Vector(
+    Preset(0.3, 1, Int.MaxValue, leaves_only = true),    // L0: a few leaf steps
+    Preset(1.0, 1, Int.MaxValue, leaves_only = true),    // L1: all leaf steps, skeletons kept
+    Preset(1.0, 2, Int.MaxValue, leaves_only = false),   // L2: all sub-proofs, top skeleton only
+    Preset(0.5, 1, 1, leaves_only = false),              // L3: half of whole top-level proofs
+    Preset(1.0, 1, 1, leaves_only = false))              // L4: every proof (code + spec only)
+
+  def preset_of(s: String): Option[Preset] = {
+    val t = s.toLowerCase.stripPrefix("l")
+    t.toIntOption.filter(i => i >= 0 && i < LADDER.length).map(LADDER)
+  }
+
+
+  /* theory discovery: files as-is, directories walked recursively for *.thy */
+
+  def collect_theories(paths: List[String]): List[Path] = {
+    val buf = new mutable.ListBuffer[Path]
+    def walk(p: Path): Unit = {
+      val f = p.file
+      if (f.isDirectory)
+        Option(f.listFiles()).getOrElse(Array.empty[java.io.File])
+          .sortBy(_.getName).foreach(k => walk(Path.explode(k.getPath)))
+      else if (f.getName.endsWith(".thy")) buf += p
+    }
+    paths.foreach(p => walk(Path.explode(p)))
+    buf.toList.distinct
+  }
+
+
+  /* session syntax */
+
+  def load_syntax(session: String, dirs: List[Path], progress: Progress): Outer_Syntax = {
+    val options = Options.init()
+    val structure = Sessions.load_structure(options, dirs = dirs)
+    val selected = structure.selection(Sessions.Selection(sessions = List(session)))
+    val deps = Sessions.deps(selected, progress = progress)
+    deps(session).overall_syntax
+  }
+
+
+  /* (challenge, solution) record, aligned with the dataset row schema */
+
+  private def task_id(path: Path): String =
+    "ablate_" + SHA1.digest(path.implode).toString.substring(0, 12)
+
+  private def theory_name(path: Path): String = {
+    val b = path.file.getName
+    if (b.endsWith(".thy")) b.dropRight(4) else b
+  }
+
+  private def depth_json(d: Int): JSON.T = if (d == Int.MaxValue) "inf" else d
+
+  def record(path: Path, session: String, spec: Spec, seed: Long, difficulty: Option[String],
+    original: String, result: Result): JSON.Object.T = {
+    val holes: List[JSON.T] =
+      result.holes.map(h => ListMap[String, JSON.T](
+        "theorem_name" -> h.theorem_name, "depth" -> h.depth, "n_commands" -> h.n_commands,
+        "n_lines" -> h.n_lines, "is_leaf" -> h.is_leaf, "method" -> h.method,
+        "proof_text" -> h.proof_text))
+    ListMap[String, JSON.T](
+      "task_id" -> task_id(path),
+      "proof_assistant" -> "isabelle",
+      "session" -> session,
+      "file_path" -> path.implode,
+      "theory" -> theory_name(path),
+      "challenge_type" -> "proof_ablate",
+      "difficulty" -> difficulty.map(d => d: JSON.T).getOrElse(null),
+      "count" -> spec.count.map(c => c: JSON.T).getOrElse(null),
+      "ablation_prob" -> (if (spec.count.isDefined) (null: JSON.T) else spec.prob),
+      "min_depth" -> spec.min_depth,
+      "max_depth" -> depth_json(spec.max_depth),
+      "leaves_only" -> spec.leaves_only,
+      "min_size" -> spec.min_size,
+      "max_size" -> depth_json(spec.max_size),
+      "seed" -> seed,
+      "n_proofs" -> result.total,
+      "n_ablated" -> result.ablated,
+      "holes_filled" -> holes,
+      "challenge_file_content" -> result.text,
+      "solution_file_content" -> original)
+  }
+
+
+  /* command line */
+
+  private def parse_depth(s: String): Int =
+    if (s == "inf" || s == "infinity") Int.MaxValue else s.toInt
+
+  private val usage =
+    """Usage: ablate [OPTIONS] PATH...
+      |
+      |  Ablate proofs in Isabelle theories, replacing them with `sorry`.
+      |  PATH... is any mix of .thy files and directories (walked for *.thy).
+      |  Default: emit one indented JSON (challenge, solution) record per theory.
+      |
+      |  Modes:
+      |    --check          run the corpus self-test instead of emitting records
+      |    --check-build D  copy session dir D, ablate it, and `isabelle build` it
+      |                     (-o quick_and_dirty); certifies it still type-checks.
+      |                     Repeatable. --afp DIR / --keep apply.
+      |
+      |  Difficulty (raw knobs override any --difficulty preset):
+      |    --difficulty L   preset ladder L0 (easy) .. L4 (code+spec only)
+      |    --min-depth N    ablate goals at nesting depth >= N (default: 1)
+      |    --max-depth N    ablate goals at nesting depth <= N; N may be `inf` (default: 1)
+      |    --leaves-only    only ablate goals whose proof has no nested goal
+      |    --min-size N     only ablate proofs with >= N proof commands (default: 0)
+      |    --max-size N     only ablate proofs with <= N proof commands; N may be `inf`
+      |    -p PROB          probability of ablating each selected proof (default: 0.5)
+      |    --all            ablate every selected proof (equivalent to -p 1.0)
+      |    --count N        ablate ~N selected proofs per theory, spread across it
+      |                     (mutually exclusive with -p / --all)
+      |
+      |  Other:
+      |    -s SESSION       session whose syntax/keywords to parse with (default: HOL)
+      |    -d DIR           extra session root directory (repeatable)
+      |    --afp DIR        AFP `thys` dir added (-d) for --check-build deps (repeatable)
+      |    --keep           keep --check-build working copies
+      |    --seed N         RNG seed for reproducibility (default: nondeterministic)
+      |    --compact        emit strict one-object-per-line JSONL (no indentation)
+      |    -q               quiet: suppress incidental progress on stderr
+      |""".stripMargin
+
+  def main(args: Array[String]): Unit = {
+    var session = "HOL"
+    var dirs: List[Path] = Nil
+    var seed: Option[Long] = None
+    var quiet = false
+    var check = false
+    var compact = false
+    var keep = false
+    var difficulty: Option[String] = None
+    var probOpt: Option[Double] = None
+    var countOpt: Option[Int] = None
+    var minDepthOpt: Option[Int] = None
+    var maxDepthOpt: Option[Int] = None
+    var leavesOpt: Option[Boolean] = None
+    var minSizeOpt: Option[Int] = None
+    var maxSizeOpt: Option[Int] = None
+    val paths = new mutable.ListBuffer[String]
+    val build_targets = new mutable.ListBuffer[String]
+    val afp_dirs = new mutable.ListBuffer[String]
+
+    var rest = args.toList
+    while (rest.nonEmpty) {
+      rest match {
+        case "--check" :: tl => check = true; rest = tl
+        case "--check-build" :: v :: tl => build_targets += v; rest = tl
+        case "--afp" :: v :: tl => afp_dirs += v; rest = tl
+        case "--keep" :: tl => keep = true; rest = tl
+        case "--compact" :: tl => compact = true; rest = tl
+        case "--difficulty" :: v :: tl => difficulty = Some(v); rest = tl
+        case "--min-depth" :: v :: tl => minDepthOpt = Some(parse_depth(v)); rest = tl
+        case "--max-depth" :: v :: tl => maxDepthOpt = Some(parse_depth(v)); rest = tl
+        case "--leaves-only" :: tl => leavesOpt = Some(true); rest = tl
+        case "--min-size" :: v :: tl => minSizeOpt = Some(parse_depth(v)); rest = tl
+        case "--max-size" :: v :: tl => maxSizeOpt = Some(parse_depth(v)); rest = tl
+        case "-s" :: v :: tl => session = v; rest = tl
+        case "-d" :: v :: tl => dirs = dirs ::: List(Path.explode(v)); rest = tl
+        case "-p" :: v :: tl => probOpt = Some(v.toDouble); rest = tl
+        case "--count" :: v :: tl => countOpt = Some(v.toInt); rest = tl
+        case "--seed" :: v :: tl => seed = Some(v.toLong); rest = tl
+        case "--all" :: tl => probOpt = Some(1.0); rest = tl
+        case "-q" :: tl => quiet = true; rest = tl
+        case ("-h" | "--help") :: _ => println(usage); return
+        case arg :: tl if arg.startsWith("-") && arg != "-" =>
+          Console.err.println("Unknown option: " + arg); Console.err.println(usage); sys.exit(2)
+        case arg :: tl => paths += arg; rest = tl
+        case Nil =>
+      }
+    }
+
+    val preset = difficulty.flatMap(preset_of)
+    if (difficulty.isDefined && preset.isEmpty) {
+      Console.err.println(s"Unknown --difficulty ${difficulty.get} (expected L0..L${LADDER.length - 1})")
+      sys.exit(2)
+    }
+    if (countOpt.isDefined && probOpt.isDefined) {
+      Console.err.println("--count cannot be combined with -p / --all (they set the rate two ways)")
+      sys.exit(2)
+    }
+    val spec = Spec(
+      prob = probOpt.orElse(preset.map(_.prob)).getOrElse(0.5),
+      count = countOpt,
+      min_depth = minDepthOpt.orElse(preset.map(_.min_depth)).getOrElse(1),
+      max_depth = maxDepthOpt.orElse(preset.map(_.max_depth)).getOrElse(1),
+      leaves_only = leavesOpt.orElse(preset.map(_.leaves_only)).getOrElse(false),
+      min_size = minSizeOpt.getOrElse(0),
+      max_size = maxSizeOpt.getOrElse(Int.MaxValue))
+
+    if (spec.min_depth < 1) { Console.err.println("--min-depth must be >= 1"); sys.exit(2) }
+    if (paths.isEmpty && build_targets.isEmpty) { Console.err.println(usage); sys.exit(2) }
+
+    val progress = if (quiet) new Progress else new Console_Progress()
+    val syntax = load_syntax(session, dirs, progress)
+    val base = seed.getOrElse(new Random().nextLong())
+
+    def spec_line: String =
+      s"depth ${spec.min_depth}..${depth_json(spec.max_depth)}" +
+        (if (spec.leaves_only) " leaves-only" else "") +
+        (if (spec.min_size > 0 || spec.max_size != Int.MaxValue)
+          s" size ${spec.min_size}..${depth_json(spec.max_size)}" else "") +
+        spec.count.map(c => s" count=$c").getOrElse(f" p=${spec.prob}%.2f") +
+        difficulty.map(d => s" [$d]").getOrElse("")
+
+    // build-validation mode
+    if (build_targets.nonEmpty) {
+      if (!quiet) progress.echo(s"[session $session; $spec_line; ${build_targets.length} build target(s)]")
+      val ok = CheckBuild.run(syntax, build_targets.toList.map(Path.explode),
+        afp_dirs.toList.map(Path.explode), spec, base, keep, progress)
+      if (!ok) sys.exit(1)
+      return
+    }
+
+    val theories = collect_theories(paths.toList)
+    if (!quiet) progress.echo(s"[session $session: ${syntax.keywords.kinds.size} keywords; " +
+      s"${theories.length} theories; $spec_line]")
+
+    if (check) {
+      val ok = Check.run(syntax, theories, spec)
+      if (!ok) sys.exit(1)
+      return
+    }
+
+    var emitted = 0
+    for (thy <- theories) {
+      val original = File.read(thy)
+      val rng = new Random(base ^ thy.implode.hashCode.toLong)
+      val result = ablate(syntax, original, spec, rng)
+      val obj = record(thy, session, spec, base, difficulty, original, result)
+      System.out.println(if (compact) JSON.Format(obj) else JSON.Format.pretty_print(obj))
+      emitted += 1
+    }
+    System.out.flush()
+    if (!quiet) progress.echo(s"[emitted $emitted records]")
+  }
+}

--- a/isabelle-ablator/src/Ablate.scala
+++ b/isabelle-ablator/src/Ablate.scala
@@ -200,8 +200,9 @@ object Ablate {
         total += 1
         matches += ((stmt_idx, cent))
         if (decide(stmt_idx)) {
-          out ++= (if (m.lead.nonEmpty) m.lead else " ")    // separate glued proofs
-          out ++= "sorry"
+          // sit `sorry` right after the statement (swallow the gap to the old
+          // proof) so it never dangles flush-left on its own line.
+          out ++= " sorry"
           ablated += 1
           holes += Hole(name, goal_depth, m.n_commands, n_lines(m.text), m.is_leaf, cent, m.method, m.text)
           i = m.end; depth = d

--- a/isabelle-ablator/src/Ablate.scala
+++ b/isabelle-ablator/src/Ablate.scala
@@ -92,7 +92,9 @@ object Ablate {
     min_size: Int = 0,               // proof-command count, inclusive lower bound
     max_size: Int = Int.MaxValue,    // inclusive upper bound
     min_centrality: Int = 0,         // fan-in (distinct theorems citing this lemma)
-    max_centrality: Int = Int.MaxValue
+    max_centrality: Int = Int.MaxValue,
+    truncate: Boolean = false,       // drop everything after the last inserted `sorry`
+    shrink_context: Boolean = false  // drop top-level goals after the last ablated one
   ) {
     def uses_centrality: Boolean =
       min_centrality > 0 || max_centrality != Int.MaxValue || by_centrality
@@ -107,6 +109,27 @@ object Ablate {
   // Measured properties of a goal body.
   private sealed case class Body(end: Int, lead: String, text: String,
     n_commands: Int, is_leaf: Boolean, method: String, clean: Boolean)
+
+  // Drop top-level goal segments that start after the last ablated top-level
+  // goal (keeping definitions / `end` / comments), to focus the model on the
+  // theorem in front of it rather than later theorems. `segs` is the list of
+  // top-level (end-offset, is-goal, had-sorry) in document order.
+  private def shrink_context(full: String, segs: List[(Int, Boolean, Boolean)]): String = {
+    val last = segs.lastIndexWhere { case (_, is_goal, had_sorry) => is_goal && had_sorry }
+    if (last < 0) full
+    else {
+      val sb = new mutable.StringBuilder
+      var prev = 0
+      var idx = 0
+      for ((end, is_goal, _) <- segs) {
+        if (idx <= last || !is_goal) sb ++= full.substring(prev, end)
+        prev = end
+        idx += 1
+      }
+      // collapse the blank-line runs left where dropped goals used to be
+      sb.toString.replaceAll("\n[ \t]*\n([ \t]*\n)+", "\n\n")
+    }
+  }
 
   /** Ablate proofs selected by `spec`, each replaced by `sorry`.
    *
@@ -129,6 +152,8 @@ object Ablate {
     val out = new mutable.StringBuilder
     val holes = new mutable.ListBuffer[Hole]
     val matches = new mutable.ListBuffer[(Int, Int)]
+    val top_segs = new mutable.ListBuffer[(Int, Boolean, Boolean)]  // (end offset, is goal, had sorry)
+    var last_sorry_end = -1                                          // out offset just after the last `sorry`
     var total = 0
     var ablated = 0
     var i = 0
@@ -203,6 +228,7 @@ object Ablate {
           // sit `sorry` right after the statement (swallow the gap to the old
           // proof) so it never dangles flush-left on its own line.
           out ++= " sorry"
+          last_sorry_end = out.length
           ablated += 1
           holes += Hole(name, goal_depth, m.n_commands, n_lines(m.text), m.is_leaf, cent, m.method, m.text)
           i = m.end; depth = d
@@ -216,12 +242,24 @@ object Ablate {
 
     while (i < n) {
       kind_of(spans(i)) match {
-        case Some(k) if is_goal(k) => handle_goal()
-        case _ => out ++= src(i); i += 1
+        case Some(k) if is_goal(k) =>
+          val ablated0 = ablated
+          handle_goal()
+          top_segs += ((out.length, true, ablated > ablated0))
+        case _ =>
+          out ++= src(i); i += 1
+          top_segs += ((out.length, false, false))
       }
     }
 
-    (Result(out.toString, total, ablated, holes.toList), matches.toList)
+    // optional context shaping (challenge-only; --check / --check-build disable these)
+    val full = out.toString
+    val shaped =
+      if (spec.truncate && last_sorry_end >= 0) full.substring(0, last_sorry_end)
+      else if (spec.shrink_context) shrink_context(full, top_segs.toList)
+      else full
+
+    (Result(shaped, total, ablated, holes.toList), matches.toList)
     }  // walk_all
 
     spec.count match {
@@ -287,29 +325,30 @@ object Ablate {
 
   /* (challenge, solution) record, aligned with the dataset row schema */
 
-  private def task_id(path: Path): String =
-    "ablate_" + SHA1.digest(path.implode).toString.substring(0, 12)
+  private def task_id(file_path: String, variant: Option[Int]): String =
+    "ablate_" + SHA1.digest(file_path).toString.substring(0, 12) + variant.map("_" + _).getOrElse("")
 
-  private def theory_name(path: Path): String = {
-    val b = path.file.getName
+  private def theory_name(file_path: String): String = {
+    val b = file_path.split('/').lastOption.getOrElse(file_path)
     if (b.endsWith(".thy")) b.dropRight(4) else b
   }
 
   private def depth_json(d: Int): JSON.T = if (d == Int.MaxValue) "inf" else d
 
-  def record(path: Path, session: String, spec: Spec, seed: Long, difficulty: Option[String],
-    original: String, result: Result): JSON.Object.T = {
+  def record(file_path: String, session: String, spec: Spec, seed: Long, variant: Option[Int],
+    difficulty: Option[String], original: String, result: Result): JSON.Object.T = {
     val holes: List[JSON.T] =
       result.holes.map(h => ListMap[String, JSON.T](
         "theorem_name" -> h.theorem_name, "depth" -> h.depth, "n_commands" -> h.n_commands,
         "n_lines" -> h.n_lines, "is_leaf" -> h.is_leaf, "centrality" -> h.centrality,
         "method" -> h.method, "proof_text" -> h.proof_text))
     ListMap[String, JSON.T](
-      "task_id" -> task_id(path),
+      "task_id" -> task_id(file_path, variant),
       "proof_assistant" -> "isabelle",
       "session" -> session,
-      "file_path" -> path.implode,
-      "theory" -> theory_name(path),
+      "file_path" -> file_path,
+      "theory" -> theory_name(file_path),
+      "variant" -> variant.map(v => v: JSON.T).getOrElse(null),
       "challenge_type" -> "proof_ablate",
       "difficulty" -> difficulty.map(d => d: JSON.T).getOrElse(null),
       "count" -> spec.count.map(c => c: JSON.T).getOrElse(null),
@@ -364,23 +403,30 @@ object Ablate {
       |                     (mutually exclusive with -p / --all)
       |    --by-centrality  with --count, pick the most-cited proofs (not random)
       |
+      |  Context shaping (challenge text only; ignored by --check / --check-build):
+      |    --truncate       drop everything after the last inserted `sorry`
+      |    --shrink-context drop top-level lemmas/theorems after the last ablated one
+      |
       |  Other:
       |    -s SESSION       session whose syntax/keywords to parse with (default: HOL)
-      |    -d DIR           extra session root directory (repeatable)
+      |    -d DIR           extra session root dir; also stripped from emitted paths (repeatable)
       |    --afp DIR        AFP `thys` dir added (-d) for --check-build deps (repeatable)
       |    --keep           keep --check-build working copies
+      |    --repeat N       emit up to N deduplicated ablations per theory (default: 1)
       |    --seed N         RNG seed for reproducibility (default: nondeterministic)
+      |    --text           output the ablated theory text instead of JSONL records
       |    --compact        emit strict one-object-per-line JSONL (no indentation)
-      |    -q               quiet: suppress incidental progress on stderr
+      |    -v               verbose: show progress/summary on stderr
       |""".stripMargin
 
   def main(args: Array[String]): Unit = {
     var session = "HOL"
     var dirs: List[Path] = Nil
     var seed: Option[Long] = None
-    var quiet = false
+    var verbose = false
     var check = false
     var compact = false
+    var text_mode = false
     var keep = false
     var difficulty: Option[String] = None
     var probOpt: Option[Double] = None
@@ -393,6 +439,9 @@ object Ablate {
     var minCentralityOpt: Option[Int] = None
     var maxCentralityOpt: Option[Int] = None
     var byCentrality = false
+    var truncate = false
+    var shrinkContext = false
+    var repeat = 1
     val paths = new mutable.ListBuffer[String]
     val build_targets = new mutable.ListBuffer[String]
     val afp_dirs = new mutable.ListBuffer[String]
@@ -405,6 +454,7 @@ object Ablate {
         case "--afp" :: v :: tl => afp_dirs += v; rest = tl
         case "--keep" :: tl => keep = true; rest = tl
         case "--compact" :: tl => compact = true; rest = tl
+        case "--text" :: tl => text_mode = true; rest = tl
         case "--difficulty" :: v :: tl => difficulty = Some(v); rest = tl
         case "--min-depth" :: v :: tl => minDepthOpt = Some(parse_depth(v)); rest = tl
         case "--max-depth" :: v :: tl => maxDepthOpt = Some(parse_depth(v)); rest = tl
@@ -414,13 +464,16 @@ object Ablate {
         case "--min-centrality" :: v :: tl => minCentralityOpt = Some(parse_depth(v)); rest = tl
         case "--max-centrality" :: v :: tl => maxCentralityOpt = Some(parse_depth(v)); rest = tl
         case "--by-centrality" :: tl => byCentrality = true; rest = tl
+        case "--truncate" :: tl => truncate = true; rest = tl
+        case "--shrink-context" :: tl => shrinkContext = true; rest = tl
+        case "--repeat" :: v :: tl => repeat = v.toInt; rest = tl
         case "-s" :: v :: tl => session = v; rest = tl
         case "-d" :: v :: tl => dirs = dirs ::: List(Path.explode(v)); rest = tl
         case "-p" :: v :: tl => probOpt = Some(v.toDouble); rest = tl
         case "--count" :: v :: tl => countOpt = Some(v.toInt); rest = tl
         case "--seed" :: v :: tl => seed = Some(v.toLong); rest = tl
         case "--all" :: tl => probOpt = Some(1.0); rest = tl
-        case "-q" :: tl => quiet = true; rest = tl
+        case "-v" :: tl => verbose = true; rest = tl
         case ("-h" | "--help") :: _ => println(usage); return
         case arg :: tl if arg.startsWith("-") && arg != "-" =>
           Console.err.println("Unknown option: " + arg); Console.err.println(usage); sys.exit(2)
@@ -451,13 +504,20 @@ object Ablate {
       min_size = minSizeOpt.getOrElse(0),
       max_size = maxSizeOpt.getOrElse(Int.MaxValue),
       min_centrality = minCentralityOpt.getOrElse(0),
-      max_centrality = maxCentralityOpt.getOrElse(Int.MaxValue))
+      max_centrality = maxCentralityOpt.getOrElse(Int.MaxValue),
+      truncate = truncate,
+      shrink_context = shrinkContext)
 
     if (spec.min_depth < 1) { Console.err.println("--min-depth must be >= 1"); sys.exit(2) }
     if (paths.isEmpty && build_targets.isEmpty) { Console.err.println(usage); sys.exit(2) }
 
-    val progress = if (quiet) new Progress else new Console_Progress()
-    val syntax = load_syntax(session, dirs, progress)
+    // progress to stderr so stdout stays clean for JSONL / --text output
+    val progress = if (verbose) new Console_Progress(stderr = true) else new Progress
+    // -d dirs serve double duty: those that are session roots (have ROOT/ROOTS)
+    // feed session resolution; all of them strip emitted file-path prefixes.
+    val session_dirs = dirs.filter(d =>
+      (d + Path.basic("ROOT")).file.isFile || (d + Path.basic("ROOTS")).file.isFile)
+    val syntax = load_syntax(session, session_dirs, progress)
     val base = seed.getOrElse(new Random().nextLong())
 
     def spec_line: String =
@@ -473,7 +533,7 @@ object Ablate {
 
     // build-validation mode
     if (build_targets.nonEmpty) {
-      if (!quiet) progress.echo(s"[session $session; $spec_line; ${build_targets.length} build target(s)]")
+      if (verbose) progress.echo(s"[session $session; $spec_line; ${build_targets.length} build target(s)]")
       val ok = CheckBuild.run(syntax, build_targets.toList.map(Path.explode),
         afp_dirs.toList.map(Path.explode), spec, base, keep, progress)
       if (!ok) sys.exit(1)
@@ -481,14 +541,14 @@ object Ablate {
     }
 
     val theories = collect_theories(paths.toList)
-    if (!quiet) progress.echo(s"[session $session: ${syntax.keywords.kinds.size} keywords; " +
+    if (verbose) progress.echo(s"[session $session: ${syntax.keywords.kinds.size} keywords; " +
       s"${theories.length} theories; $spec_line]")
 
-    // corpus fan-in over all input theories: always for the emit path (so the
-    // metadata is complete for post-hoc stratification), and for --check only
+    // corpus fan-in over all input theories: always for JSONL emit (so the
+    // metadata is complete for post-hoc stratification), and otherwise only
     // when a centrality filter is actually in play.
     val centrality: String => Int =
-      if (!check || spec.uses_centrality) {
+      if (spec.uses_centrality || (!check && !text_mode)) {
         val fan = Centrality.fan_in(syntax, theories, progress)
         (name => fan.getOrElse(name, 0))
       } else (_ => 0)
@@ -499,16 +559,43 @@ object Ablate {
       return
     }
 
+    // emitted file path: strip the longest matching -d prefix (so JSONL paths
+    // are relative, not /home/.../...); otherwise the absolute path.
+    val strip = dirs.map(_.absolute.implode).sortBy(-_.length)
+    def display_path(thy: Path): String = {
+      val abs = thy.absolute.implode
+      strip.iterator.flatMap { base =>
+        if (abs == base) Some(thy.file.getName)
+        else if (abs.startsWith(base + "/")) Some(abs.substring(base.length + 1))
+        else None
+      }.nextOption().getOrElse(abs)
+    }
+
+    val n_repeat = math.max(1, repeat)
     var emitted = 0
     for (thy <- theories) {
       val original = File.read(thy)
-      val rng = new Random(base ^ thy.implode.hashCode.toLong)
-      val result = ablate(syntax, original, spec, rng, centrality)
-      val obj = record(thy, session, spec, base, difficulty, original, result)
-      System.out.println(if (compact) JSON.Format(obj) else JSON.Format.pretty_print(obj))
-      emitted += 1
+      val display = display_path(thy)
+      val seen = new mutable.HashSet[String]   // dedup identical ablations of this theory
+      var k = 0
+      var produced = 0
+      while (k < n_repeat) {
+        val rng = new Random(base ^ thy.implode.hashCode.toLong ^ (k.toLong * 0x9E3779B97F4A7C15L))
+        val result = ablate(syntax, original, spec, rng, centrality)
+        if (seen.add(result.text)) {           // best-effort dedup across repeats
+          if (text_mode) System.out.print(result.text)   // raw ablated theory, byte-exact
+          else {
+            val variant = if (n_repeat > 1) Some(produced) else None
+            val obj = record(display, session, spec, base, variant, difficulty, original, result)
+            System.out.println(if (compact) JSON.Format(obj) else JSON.Format.pretty_print(obj))
+          }
+          produced += 1
+          emitted += 1
+        }
+        k += 1
+      }
     }
     System.out.flush()
-    if (!quiet) progress.echo(s"[emitted $emitted records]")
+    if (verbose) progress.echo(s"[emitted $emitted ${if (text_mode) "theories" else "records"}]")
   }
 }

--- a/isabelle-ablator/src/Centrality.scala
+++ b/isabelle-ablator/src/Centrality.scala
@@ -1,0 +1,87 @@
+/*  Corpus-wide proof-dependency centrality.
+
+    Builds an approximate dependency graph by *textual name citation*: a
+    top-level fact (lemma/theorem/…) named `B` is "cited" by theorem `A` if `A`'s
+    proof body mentions the identifier `B` (in `using B`, `simp add: B`,
+    `rule B`, a bundle, …). The **centrality** of `B` is its fan-in — the number
+    of distinct top-level theorems across the corpus whose proof cites it.
+
+    This needs only the parser (no prover, no build) and works on any corpus, so
+    it is cheap but approximate: anonymous facts have centrality 0 (they can't be
+    cited by name) and citations are matched on the (last-segment) identifier.
+    The big failure mode is short names that collide with ordinary variables — a
+    field `K` used as a term in 90 proofs would read as 90 "citations" — so we
+    ignore declared names shorter than `MIN_NAME_LEN`. The accurate alternative
+    is Isabelle's own theorem dependencies via `export_theory`, which requires
+    building the session — a planned upgrade.
+*/
+
+package proofablate
+
+import isabelle._
+
+import scala.collection.mutable
+
+
+object Centrality {
+  // Names shorter than this are dropped from the graph: they collide with
+  // ordinary variables (a field `K`, an index `i`) and produce spurious fan-in.
+  private val MIN_NAME_LEN = 3
+
+  private def is_cite_token(t: Token): Boolean =
+    t.is_ident || t.kind == Token.Kind.LONG_IDENT
+
+  /** Identifiers a proof body might be citing: each name token's source, plus
+   *  its last dotted segment (so a qualified `Foo.bar` also matches `bar`). */
+  private def cited_names(tokens: Iterable[Token], into: mutable.Set[String]): Unit =
+    for (t <- tokens if is_cite_token(t)) {
+      val s = t.source
+      into += s
+      val dot = s.lastIndexOf('.')
+      if (dot >= 0 && dot < s.length - 1) into += s.substring(dot + 1)
+    }
+
+  /** name -> fan-in (distinct top-level theorems whose proof cites it). */
+  def fan_in(syntax: Outer_Syntax, theories: List[Path], progress: Progress): Map[String, Int] = {
+    // per top-level goal: (name, set of identifiers cited anywhere in its proof)
+    val goals = new mutable.ListBuffer[(String, Set[String])]
+
+    for (thy <- theories) {
+      try {
+        val spans = syntax.parse_spans(File.read(thy)).toArray
+        val n = spans.length
+        var i = 0
+        while (i < n) {
+          val k = spans(i).kind.keyword_kind
+          if (k.exists(Keyword.theory_goal.contains)) {
+            val name = Ablate.goal_name(spans(i))
+            i += 1
+            var depth = 1
+            val cited = mutable.Set.empty[String]
+            while (i < n && depth > 0) {
+              val span = spans(i)
+              cited_names(span.content, cited)
+              span.kind.keyword_kind match {
+                case Some(kk) if Keyword.theory.contains(kk) => depth = 0   // desync: bail
+                case Some(kk) =>
+                  if (Keyword.proof_goal.contains(kk) || kk == Keyword.PRF_OPEN) depth += 1
+                  else if (Keyword.proof_close.contains(kk)) depth -= 1
+                  else if (Keyword.qed_global.contains(kk)) depth = 0
+                case None =>
+              }
+              i += 1
+            }
+            goals += ((name, cited.toSet))
+          } else i += 1
+        }
+      } catch { case _: Throwable => () }
+    }
+
+    val declared = goals.iterator.map(_._1).filter(_.length >= MIN_NAME_LEN).toSet
+    val fan = mutable.Map.empty[String, Int].withDefaultValue(0)
+    for ((name, cited) <- goals; d <- cited if d != name && declared.contains(d)) fan(d) += 1
+    progress.echo(s"[centrality: ${declared.size} named facts, " +
+      s"${fan.count(_._2 > 0)} cited; max fan-in ${if (fan.isEmpty) 0 else fan.values.max}]")
+    fan.toMap
+  }
+}

--- a/isabelle-ablator/src/Check.scala
+++ b/isabelle-ablator/src/Check.scala
@@ -1,0 +1,93 @@
+/*  Corpus self-test for the ablator, invoked via `ablate --check PATH...`.
+
+    For each theory it checks (at the configured --min-depth/--max-depth):
+      (1) round-trip:  imploding the parsed spans reproduces the source exactly
+                       (i.e. ablating with prob 0 is the identity);
+      (2) delimitation: every in-range goal's proof is cleanly delimited, so
+                       prob 1 ablates *all* of them (no desyncs / leftovers);
+      (3) re-parse:    the ablated text still parses with all theory-level goal
+                       statements preserved (a mangled rewrite would drop one).
+    Reports aggregate statistics and lists any files that fail a check.
+*/
+
+package proofablate
+
+import isabelle._
+
+import scala.util.Random
+import scala.collection.mutable
+
+
+object Check {
+  private def count_goals(syntax: Outer_Syntax, text: CharSequence): Int =
+    syntax.parse_spans(text).count(sp =>
+      sp.kind.keyword_kind.exists(Keyword.theory_goal.contains))
+
+  /** Returns true if all checks pass. */
+  def run(syntax: Outer_Syntax, theories: List[Path], spec: Ablate.Spec): Boolean = {
+    var n_files = 0
+    var n_goals = 0
+    var n_ablated = 0
+    val roundtrip_fail = new mutable.ListBuffer[String]
+    val delimit_fail = new mutable.ListBuffer[(String, Int, Int)]
+    val reparse_fail = new mutable.ListBuffer[(String, Int, Int)]
+    val errored = new mutable.ListBuffer[(String, String)]
+    var ablate_ns = 0L   // time spent in ablate() alone, across all theories
+
+    val wall0 = System.nanoTime()
+    for (thy <- theories) {
+      val name = thy.implode
+      try {
+        val text = File.read(thy)
+
+        // --check ignores --count/-p: prob 0 must be identity, prob 1 must ablate all candidates
+        val identity = Ablate.ablate(syntax, text, spec.copy(prob = 0.0, count = None), new Random(0))
+        if (identity.text != text) roundtrip_fail += name
+
+        val t = System.nanoTime()
+        val all = Ablate.ablate(syntax, text, spec.copy(prob = 1.0, count = None), new Random(0))
+        ablate_ns += System.nanoTime() - t
+        n_files += 1
+        n_goals += all.total
+        n_ablated += all.ablated
+        if (all.ablated != all.total) delimit_fail += ((name, all.ablated, all.total))
+
+        // theory-level goal statements must survive ablation verbatim
+        if (count_goals(syntax, all.text) != count_goals(syntax, text))
+          reparse_fail += ((name, count_goals(syntax, text), count_goals(syntax, all.text)))
+      } catch {
+        case e: Throwable => errored += ((name, e.toString))
+      }
+    }
+    val wall_s = (System.nanoTime() - wall0) / 1e9
+    val ablate_s = ablate_ns / 1e9
+
+    println("")
+    println("================ ablation self-test ================")
+    println(s"theories checked     : $n_files")
+    println(s"in-range goals       : $n_goals")
+    println(s"cleanly ablated      : $n_ablated " +
+      (if (n_goals > 0) f"(${100.0 * n_ablated / n_goals}%.2f%%)" else ""))
+    println(f"ablation time        : $ablate_s%.2f s " +
+      (if (ablate_s > 0) f"(${n_files / ablate_s}%,.0f theories/s, ${n_goals / ablate_s}%,.0f goals/s)" else ""))
+    println(f"self-test wall time  : $wall_s%.2f s")
+    println(s"round-trip failures  : ${roundtrip_fail.length}")
+    println(s"delimitation misses  : ${delimit_fail.length}")
+    println(s"re-parse mismatches  : ${reparse_fail.length}")
+    println(s"errored theories     : ${errored.length}")
+
+    def sample[A](label: String, xs: mutable.ListBuffer[A]): Unit =
+      if (xs.nonEmpty) {
+        println(s"\n-- $label (${xs.length}), first 10:")
+        xs.take(10).foreach(x => println("   " + x.toString))
+      }
+    sample("round-trip failures", roundtrip_fail)
+    sample("delimitation misses", delimit_fail)
+    sample("re-parse mismatches", reparse_fail)
+    sample("errored", errored)
+
+    val ok = roundtrip_fail.isEmpty && reparse_fail.isEmpty && errored.isEmpty
+    println(if (ok) "\nRESULT: OK" else "\nRESULT: FAILURES PRESENT")
+    ok
+  }
+}

--- a/isabelle-ablator/src/Check.scala
+++ b/isabelle-ablator/src/Check.scala
@@ -41,12 +41,14 @@ object Check {
       try {
         val text = File.read(thy)
 
-        // --check ignores --count/-p: prob 0 must be identity, prob 1 must ablate all candidates
-        val identity = Ablate.ablate(syntax, text, spec.copy(prob = 0.0, count = None), new Random(0), centrality)
+        // --check ignores --count/-p and context shaping: prob 0 must be the
+        // identity, prob 1 must ablate all candidates.
+        val base = spec.copy(count = None, truncate = false, shrink_context = false)
+        val identity = Ablate.ablate(syntax, text, base.copy(prob = 0.0), new Random(0), centrality)
         if (identity.text != text) roundtrip_fail += name
 
         val t = System.nanoTime()
-        val all = Ablate.ablate(syntax, text, spec.copy(prob = 1.0, count = None), new Random(0), centrality)
+        val all = Ablate.ablate(syntax, text, base.copy(prob = 1.0), new Random(0), centrality)
         ablate_ns += System.nanoTime() - t
         n_files += 1
         n_goals += all.total

--- a/isabelle-ablator/src/Check.scala
+++ b/isabelle-ablator/src/Check.scala
@@ -24,7 +24,8 @@ object Check {
       sp.kind.keyword_kind.exists(Keyword.theory_goal.contains))
 
   /** Returns true if all checks pass. */
-  def run(syntax: Outer_Syntax, theories: List[Path], spec: Ablate.Spec): Boolean = {
+  def run(syntax: Outer_Syntax, theories: List[Path], spec: Ablate.Spec,
+    centrality: String => Int = (_ => 0)): Boolean = {
     var n_files = 0
     var n_goals = 0
     var n_ablated = 0
@@ -41,11 +42,11 @@ object Check {
         val text = File.read(thy)
 
         // --check ignores --count/-p: prob 0 must be identity, prob 1 must ablate all candidates
-        val identity = Ablate.ablate(syntax, text, spec.copy(prob = 0.0, count = None), new Random(0))
+        val identity = Ablate.ablate(syntax, text, spec.copy(prob = 0.0, count = None), new Random(0), centrality)
         if (identity.text != text) roundtrip_fail += name
 
         val t = System.nanoTime()
-        val all = Ablate.ablate(syntax, text, spec.copy(prob = 1.0, count = None), new Random(0))
+        val all = Ablate.ablate(syntax, text, spec.copy(prob = 1.0, count = None), new Random(0), centrality)
         ablate_ns += System.nanoTime() - t
         n_files += 1
         n_goals += all.total

--- a/isabelle-ablator/src/CheckBuild.scala
+++ b/isabelle-ablator/src/CheckBuild.scala
@@ -1,0 +1,139 @@
+/*  Build-level validation, invoked via `ablate --check-build DIR ...`.
+
+    For each target session directory (one containing a `ROOT`):
+      1. copy it to a fresh temp dir (the original is never touched);
+      2. rename the declared session(s) in the copy's ROOT (a `__ablated`
+         suffix) so the copy never clashes with the original on the build path
+         (important when the original is reachable via an `--afp` directory);
+      3. ablate every *.thy in the copy at the configured prob / depth range;
+      4. run `isabelle build -o quick_and_dirty=true` on the copy, with any
+         `--afp` directories added via `-d` so dependencies resolve.
+
+    `quick_and_dirty=true` is required: otherwise `sorry` is a build error rather
+    than an admitted proof. A clean build (rc 0) therefore certifies that the
+    ablated theory is still well-formed Isabelle — it parses, the statements and
+    definitions elaborate and type-check, and only the proof bodies are missing.
+    This is the gate that parsing alone cannot give, and it matters most for
+    sub-proof ablation (nested `sorry` validity).
+
+    Builds are intensive; the bundled HOL/Pure heaps are reused, but anything
+    importing heavier sessions (HOL-Analysis, ...) will build those first.
+*/
+
+package proofablate
+
+import isabelle._
+
+import scala.util.Random
+import scala.util.matching.Regex
+import scala.collection.mutable
+
+
+object CheckBuild {
+  private val SUFFIX = "__ablated"
+
+  /** Rename declared session names (at the `session NAME` declaration and at
+   *  `= PARENT` references to a declared name) with a suffix, so the copy does
+   *  not clash with the original. Theory/document names are left untouched.
+   *  Returns (rewritten ROOT, declared names). */
+  def rename_sessions(root: String): (String, List[String]) = {
+    // session names may be quoted and contain hyphens (e.g. "General-Triangle")
+    // group 2 = quoted name (no quotes), group 3 = bare name
+    def name_of(m: Regex.Match): String = if (m.group(2) != null) m.group(2) else m.group(3)
+    def requote(m: Regex.Match, prefix: String, nm: String): String =
+      if (m.group(2) != null) prefix + "\"" + nm + "\"" else prefix + nm
+
+    val decl = """(?m)^([ \t]*session[ \t]+)(?:"([^"]+)"|([^\s"()=]+))""".r
+    val names = decl.findAllMatchIn(root).map(name_of).toSet
+    val r1 = decl.replaceAllIn(root, m =>
+      Regex.quoteReplacement(requote(m, m.group(1), name_of(m) + SUFFIX)))
+
+    val parent = """(=[ \t]*)(?:"([^"]+)"|([^\s"()+]+))""".r
+    val r2 = parent.replaceAllIn(r1, m =>
+      Regex.quoteReplacement(
+        if (names.contains(name_of(m))) requote(m, m.group(1), name_of(m) + SUFFIX)
+        else m.matched))
+    (r2, names.toList.sorted)
+  }
+
+  private sealed case class Outcome(
+    name: String, sessions: List[String], n_files: Int, n_total: Int, n_ablated: Int,
+    rc: Int, ok: Boolean, secs: Double, note: String)
+
+  /** Returns true if every target built cleanly. */
+  def run(syntax: Outer_Syntax, targets: List[Path], afp: List[Path],
+    spec: Ablate.Spec, seed_base: Long, keep: Boolean, progress: Progress): Boolean = {
+
+    val isabelle = Isabelle_System.getenv("ISABELLE_HOME") + "/bin/isabelle"
+    val afp_args = afp.map(d => "-d " + Bash.string(d.absolute.implode)).mkString(" ")
+    val results = new mutable.ListBuffer[Outcome]
+
+    for (target <- targets) {
+      val name = target.file.getName
+      progress.echo(s"\n================ check-build: $name ================")
+
+      if (!(target + Path.basic("ROOT")).file.isFile) {
+        progress.echo(s"  no ROOT in ${target.implode} — skipping")
+        results += Outcome(name, Nil, 0, 0, 0, -1, ok = false, 0.0, "no ROOT")
+      }
+      else {
+        val base = File.path(java.nio.file.Files.createTempDirectory("ablate-build-").toFile)
+        val work = base + Path.basic(name)
+        try {
+          Isabelle_System.copy_dir(target, work, direct = true)
+
+          // 1. rename sessions in the copied ROOT
+          val root_path = work + Path.basic("ROOT")
+          val (new_root, sessions) = rename_sessions(File.read(root_path))
+          File.write(root_path, new_root)
+
+          // 2. ablate every theory in the copy
+          var n_files = 0; var n_total = 0; var n_ablated = 0
+          for (thy <- Ablate.collect_theories(List(work.implode))) {
+            val text = File.read(thy)
+            val rng = new Random(seed_base ^ thy.implode.hashCode.toLong)
+            val res = Ablate.ablate(syntax, text, spec, rng)
+            File.write(thy, res.text)
+            n_files += 1; n_total += res.total; n_ablated += res.ablated
+          }
+          progress.echo(s"  sessions: ${sessions.mkString(", ")}  " +
+            s"(ablated $n_ablated/$n_total proofs across $n_files theories)")
+
+          // 3. build the ablated copy
+          val cmd = isabelle + " build -o quick_and_dirty=true " +
+            (if (afp_args.nonEmpty) afp_args + " " else "") +
+            "-D " + Bash.string(work.absolute.implode)
+          progress.echo("  $ " + cmd)
+          val t0 = System.nanoTime()
+          val res =
+            Isabelle_System.bash(cmd,
+              progress_stdout = s => progress.echo("    " + s),
+              progress_stderr = s => progress.echo("    " + s))
+          val secs = (System.nanoTime() - t0) / 1e9
+          results += Outcome(name, sessions, n_files, n_total, n_ablated,
+            res.rc, res.ok, secs, if (res.ok) "" else res.err.takeRight(200))
+        } catch {
+          case e: Throwable =>
+            results += Outcome(name, Nil, 0, 0, 0, -1, ok = false, 0.0, e.toString.takeRight(200))
+        } finally {
+          if (keep) progress.echo(s"  [kept working copy: ${work.implode}]")
+          else Isabelle_System.rm_tree(base)
+        }
+      }
+    }
+
+    // summary
+    println("")
+    println("================ check-build summary ================")
+    for (o <- results) {
+      val status = if (o.ok) "PASS" else s"FAIL (rc=${o.rc})"
+      println(f"  ${o.name}%-32s $status%-14s " +
+        f"${o.n_ablated}%5d/${o.n_total}%-5d proofs  ${o.secs}%7.1f s")
+      if (!o.ok && o.note.nonEmpty) println(s"       ${o.note}")
+    }
+    val ok = results.forall(_.ok)
+    println(s"\nRESULT: ${if (ok) "OK" else "BUILD FAILURES PRESENT"} " +
+      s"(${results.count(_.ok)}/${results.length} built)")
+    ok
+  }
+}

--- a/isabelle-ablator/src/CheckBuild.scala
+++ b/isabelle-ablator/src/CheckBuild.scala
@@ -94,11 +94,13 @@ object CheckBuild {
               val fan = Centrality.fan_in(syntax, thys, progress)
               (nm => fan.getOrElse(nm, 0))
             } else (_ => 0)
+          // context shaping would truncate the file and break the build
+          val build_spec = spec.copy(truncate = false, shrink_context = false)
           var n_files = 0; var n_total = 0; var n_ablated = 0
           for (thy <- thys) {
             val text = File.read(thy)
             val rng = new Random(seed_base ^ thy.implode.hashCode.toLong)
-            val res = Ablate.ablate(syntax, text, spec, rng, centrality)
+            val res = Ablate.ablate(syntax, text, build_spec, rng, centrality)
             File.write(thy, res.text)
             n_files += 1; n_total += res.total; n_ablated += res.ablated
           }

--- a/isabelle-ablator/src/CheckBuild.scala
+++ b/isabelle-ablator/src/CheckBuild.scala
@@ -88,11 +88,17 @@ object CheckBuild {
           File.write(root_path, new_root)
 
           // 2. ablate every theory in the copy
+          val thys = Ablate.collect_theories(List(work.implode))
+          val centrality: String => Int =
+            if (spec.uses_centrality) {
+              val fan = Centrality.fan_in(syntax, thys, progress)
+              (nm => fan.getOrElse(nm, 0))
+            } else (_ => 0)
           var n_files = 0; var n_total = 0; var n_ablated = 0
-          for (thy <- Ablate.collect_theories(List(work.implode))) {
+          for (thy <- thys) {
             val text = File.read(thy)
             val rng = new Random(seed_base ^ thy.implode.hashCode.toLong)
-            val res = Ablate.ablate(syntax, text, spec, rng)
+            val res = Ablate.ablate(syntax, text, spec, rng, centrality)
             File.write(thy, res.text)
             n_files += 1; n_total += res.total; n_ablated += res.ablated
           }


### PR DESCRIPTION

This PR introduces an ablator for Isabelle theories.

The idea is to use Isabelle's scala parser to parse theory files, identify proofs, and replace them with `sorry` holes, which can then be used in evals.

One key limitation is that proof scripts are not supported, only declarative proofs. This is because it is difficult, in a proof script, to determine whether a particular tactic being applied is proving the goal or a subgoal.

Basic usage -- given a file `/tmp/Nat.thy`:

```isabelle
theory Nat
  imports Main
begin

lemma add_zero: "n + 0 = (n::nat)"
  by simp

lemma rev_rev: "rev (rev xs) = xs"
  apply (induct xs)
   apply simp
  apply simp
  done

fun sumto :: "nat \<Rightarrow> nat" where
  "sumto 0 = 0"
| "sumto (Suc n) = Suc n + sumto n"

lemma sumto_closed: "2 * sumto n = n * (n + 1)"
  by (induct n) (auto simp: algebra_simps)

lemma sumto_even: "even (2 * sumto n)"
  using sumto_closed by simp

lemma sumto_small: "2 * sumto 3 = 12"
  using sumto_closed by simp

lemma conj_comm:
  assumes ab: "A \<and> B"
  shows "B \<and> A"
proof
  show "B" using ab by simp
  show "A" using ab by simp
qed

lemma nested_demo:
  assumes ab: "A \<and> B"
  shows "B \<and> A"
proof
  have a: "A"
  proof -
    show "A" using ab by simp
  qed
  show "B" using ab by simp
  show "A" by (rule a)
qed

end
```

You can run the ablator with `nix run .# -- -q /tmp/Nat.thy` and it will output:

```jsonl
{"task_id": "ablate_892a80f9070f", "proof_assistant": "isabelle",
 "session": "HOL", "file_path": "/tmp/Nat.thy", "theory": "Nat",
 "challenge_type": "proof_ablate", "difficulty": null, "count": null,
 "by_centrality": false, "ablation_prob": 0.5, "min_depth": 1,
 "max_depth": 1, "leaves_only": false, "min_size": 0, "max_size": "inf",
 "min_centrality": 0, "max_centrality": "inf", "seed": 367422408852410776,
 "n_proofs": 7, "n_ablated": 5,
 "holes_filled":
   [{"theorem_name": "add_zero", "depth": 1, "n_commands": 1, "n_lines": 1,
     "is_leaf": true, "centrality": 0, "method": "by:simp",
     "proof_text": "by simp"},
    {"theorem_name": "sumto_even", "depth": 1, "n_commands": 2,
     "n_lines": 1, "is_leaf": true, "centrality": 0, "method": "by:simp",
     "proof_text": "using sumto_closed by simp"},
    {"theorem_name": "sumto_small", "depth": 1, "n_commands": 2,
     "n_lines": 1, "is_leaf": true, "centrality": 0, "method": "by:simp",
     "proof_text": "using sumto_closed by simp"},
    {"theorem_name": "conj_comm", "depth": 1, "n_commands": 8, "n_lines": 4,
     "is_leaf": false, "centrality": 0, "method": "structured",
     "proof_text":
       "proof\n  show \"B\" using ab by simp\n  show \"A\" using ab by simp\nqed"},
    {"theorem_name": "nested_demo", "depth": 1, "n_commands": 13,
     "n_lines": 8, "is_leaf": false, "centrality": 0,
     "method": "structured",
     "proof_text":
       "proof\n  have a: \"A\"\n  proof -\n    show \"A\" using ab by simp\n  qed\n  show \"B\" using ab by simp\n  show \"A\" by (rule a)\nqed"}],
 "challenge_file_content":
   "theory Nat\n  imports Main\nbegin\n\nlemma add_zero: \"n + 0 = (n::nat)\" sorry\n\nlemma rev_rev: \"rev (rev xs) = xs\"\n  apply (induct xs)\n   apply simp\n  apply simp\n  done\n\nfun sumto :: \"nat \\<Rightarrow> nat\" where\n  \"sumto 0 = 0\"\n| \"sumto (Suc n) = Suc n + sumto n\"\n\nlemma sumto_closed: \"2 * sumto n = n * (n + 1)\"\n  by (induct n) (auto simp: algebra_simps)\n\nlemma sumto_even: \"even (2 * sumto n)\" sorry\n\nlemma sumto_small: \"2 * sumto 3 = 12\" sorry\n\nlemma conj_comm:\n  assumes ab: \"A \\<and> B\"\n  shows \"B \\<and> A\" sorry\n\nlemma nested_demo:\n  assumes ab: \"A \\<and> B\"\n  shows \"B \\<and> A\" sorry\n\nend\n",
 "solution_file_content":
   "theory Nat\n  imports Main\nbegin\n\nlemma add_zero: \"n + 0 = (n::nat)\"\n  by simp\n\nlemma rev_rev: \"rev (rev xs) = xs\"\n  apply (induct xs)\n   apply simp\n  apply simp\n  done\n\nfun sumto :: \"nat \\<Rightarrow> nat\" where\n  \"sumto 0 = 0\"\n| \"sumto (Suc n) = Suc n + sumto n\"\n\nlemma sumto_closed: \"2 * sumto n = n * (n + 1)\"\n  by (induct n) (auto simp: algebra_simps)\n\nlemma sumto_even: \"even (2 * sumto n)\"\n  using sumto_closed by simp\n\nlemma sumto_small: \"2 * sumto 3 = 12\"\n  using sumto_closed by simp\n\nlemma conj_comm:\n  assumes ab: \"A \\<and> B\"\n  shows \"B \\<and> A\"\nproof\n  show \"B\" using ab by simp\n  show \"A\" using ab by simp\nqed\n\nlemma nested_demo:\n  assumes ab: \"A \\<and> B\"\n  shows \"B \\<and> A\"\nproof\n  have a: \"A\"\n  proof -\n    show \"A\" using ab by simp\n  qed\n  show \"B\" using ab by simp\n  show \"A\" by (rule a)\nqed\n\nend\n"}
```

The ablator supports various knobs and sanity checks:

| flag | meaning |
|------|---------|
| `--check` | run the corpus self-test instead of emitting records |
| `--check-build D` | copy + ablate + `isabelle build` session dir D (repeatable) |
| `--difficulty L` | preset ladder `L0` (easy) … `L4` (code+spec only) |
| `--min-depth N` | ablate goals at nesting depth ≥ N (default `1`) |
| `--max-depth N` | ablate goals at nesting depth ≤ N; `N` may be `inf` (default `1`) |
| `--leaves-only` | only ablate goals whose proof has no nested goal |
| `--min-size N` | only ablate proofs with ≥ N proof commands (default `0`) |
| `--max-size N` | only ablate proofs with ≤ N proof commands; `N` may be `inf` |
| `--min-centrality N` | only ablate lemmas with corpus fan-in ≥ N |
| `--max-centrality N` | only ablate lemmas with corpus fan-in ≤ N; `N` may be `inf` |
| `-p PROB` | probability of ablating each selected proof (default `0.5`) |
| `--all` | ablate every selected proof (`-p 1.0`) |
| `--count N` | ablate exactly `min(N, matching)` proofs, a random spread (excl. `-p`/`--all`) |
| `--by-centrality` | with `--count`, pick the most-cited proofs instead of random |
| `-s SESSION` | session whose keyword table to parse with (default `HOL`) |
| `-d DIR` | extra session root directory (repeatable) |
| `--afp DIR` | AFP `thys` dir added (`-d`) for `--check-build` deps (repeatable) |
| `--keep` | keep `--check-build` working copies |
| `--seed N` | RNG seed for reproducibility (per-file seed derived from it) |
| `--compact` | strict one-object-per-line JSONL (no indentation) |
| `-q` | suppress incidental progress on stderr |