### PR TITLE
website: AFP entry importer for the Isabelle ablator (#113)

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -55,24 +55,34 @@ provides the isolation fallback.
 The **Import AFP entry** control loads a real [Archive of Formal
 Proofs](https://www.isa-afp.org/) theory into the Isabelle source pane. Because
 isa-afp.org sends no permissive CORS, a pure-static site can't fetch it
-directly; instead we **pre-mirror** a curated, version-pinned set of entries
-into a world-readable bucket we control and fetch raw `.thy` text from there
+directly; instead we **pre-mirror the whole AFP**, version-pinned, into a
+world-readable bucket we control and fetch raw `.thy` text from there
 client-side. This keeps the deploy fully static — **no server, and no DO
-credentials on Vercel** (reads are anonymous, objects are public-read).
+credentials on Vercel** (reads are anonymous, objects are public-read). The
+current mirror is the `afp-2026-07-07` release: **1000 entries / ~10.2k
+theories / ~294 MB**.
 
-- `scripts/mirror-afp.py` downloads AFP release tarballs, extracts every `.thy`,
-  uploads them public-read to `s3://forall-git-evals/afp/<Entry>/…`, and writes
-  the manifest `afp/index.json`. Re-run to refresh or extend the curated set:
+- `scripts/mirror-afp.py` mirrors the corpus. `--full` downloads the single AFP
+  release tarball once, extracts every `.thy`, and uploads (parallel `s3cmd`)
+  public-read to `s3://forall-git-evals/afp/<Entry>/…`:
 
   ```bash
-  python scripts/mirror-afp.py                 # mirror the curated set
-  python scripts/mirror-afp.py --entry Kruskal # a subset
-  python scripts/mirror-afp.py --dry-run       # download + plan, no uploads
+  python scripts/mirror-afp.py --full              # whole AFP (the deliverable)
+  python scripts/mirror-afp.py --full --workers 12 # more parallel uploaders
+  python scripts/mirror-afp.py --entry Kruskal     # curated subset instead
+  python scripts/mirror-afp.py --full --dry-run    # download + stage, no upload
   ```
 
   (Requires `s3cmd` configured for the DO Space; not needed to *run* the site.)
 
-- `src/lib/afp.ts` reads the manifest + theory text. The mirror base URL is
+- **Split manifest** (keeps first paint light for 1000 entries):
+  - `afp/index.json` — lightweight: `{ schema:"afp-mirror/2", release, entries:
+    [{name, n_theories, afp_url}] }`. Loaded once when the panel opens.
+  - `afp/<Entry>/theories.json` — that entry's theory list (`{file, url, bytes}`),
+    fetched lazily when the entry is selected.
+
+- `src/lib/afp.ts` reads the manifest + theory text; the UI is a searchable
+  entry combobox (1000 entries) + theory dropdown. The mirror base URL is
   `https://forall-git-evals.nyc3.digitaloceanspaces.com/afp` by default;
   override with the **non-secret** build env var `VITE_AFP_BASE_URL` to point at
   a different bucket/CDN.

--- a/website/README.md
+++ b/website/README.md
@@ -14,7 +14,7 @@ records it becomes). Implements issue #112.
   dependency closure. A slider raises the number of theorems to delete.
 - **Output modes:** the ablated challenge file (default) or the generated JSON
   evals. In JSON mode a *repeat* slider generates N deduplicated variants.
-- **Seed** is hidden behind an **↻ Generate** button (re-rolls the seed); the raw
+- **Seed** is hidden behind an **↻ Random** button (re-rolls the seed); the raw
   seed is editable under *Advanced*.
 - **Nice-to-haves:** language auto-detection, lightweight syntax highlighting,
   collapsible JSON (challenge + solution unfolded by default), copy buttons.

--- a/website/README.md
+++ b/website/README.md
@@ -49,3 +49,47 @@ Deploy: point Vercel at this directory (root `website/`); the committed
 `public/wasm/` ships as-is. It also works on any static host — on hosts that
 can't set COOP/COEP (e.g. GitHub Pages), `public/wasm/lean/coi-serviceworker.js`
 provides the isolation fallback.
+
+## AFP importer (issue #113)
+
+The **Import AFP entry** control loads a real [Archive of Formal
+Proofs](https://www.isa-afp.org/) theory into the Isabelle source pane. Because
+isa-afp.org sends no permissive CORS, a pure-static site can't fetch it
+directly; instead we **pre-mirror** a curated, version-pinned set of entries
+into a world-readable bucket we control and fetch raw `.thy` text from there
+client-side. This keeps the deploy fully static — **no server, and no DO
+credentials on Vercel** (reads are anonymous, objects are public-read).
+
+- `scripts/mirror-afp.py` downloads AFP release tarballs, extracts every `.thy`,
+  uploads them public-read to `s3://forall-git-evals/afp/<Entry>/…`, and writes
+  the manifest `afp/index.json`. Re-run to refresh or extend the curated set:
+
+  ```bash
+  python scripts/mirror-afp.py                 # mirror the curated set
+  python scripts/mirror-afp.py --entry Kruskal # a subset
+  python scripts/mirror-afp.py --dry-run       # download + plan, no uploads
+  ```
+
+  (Requires `s3cmd` configured for the DO Space; not needed to *run* the site.)
+
+- `src/lib/afp.ts` reads the manifest + theory text. The mirror base URL is
+  `https://forall-git-evals.nyc3.digitaloceanspaces.com/afp` by default;
+  override with the **non-secret** build env var `VITE_AFP_BASE_URL` to point at
+  a different bucket/CDN.
+
+- **One-time bucket CORS** (required, since the browser reads cross-origin):
+
+  ```bash
+  cat > cors.xml <<'XML'
+  <CORSConfiguration>
+    <CORSRule>
+      <AllowedOrigin>*</AllowedOrigin>
+      <AllowedMethod>GET</AllowedMethod>
+      <AllowedMethod>HEAD</AllowedMethod>
+      <AllowedHeader>*</AllowedHeader>
+      <MaxAgeSeconds>3600</MaxAgeSeconds>
+    </CORSRule>
+  </CORSConfiguration>
+  XML
+  s3cmd setcors cors.xml s3://forall-git-evals
+  ```

--- a/website/scripts/mirror-afp.py
+++ b/website/scripts/mirror-afp.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Mirror a curated set of AFP entries into the forall-git-evals DO Space.
+
+Issue #113. The ablation playground (`website/`) is a *pure static* Vercel
+deploy, so it cannot fetch AFP theories directly from isa-afp.org (no permissive
+CORS there). Instead we pre-mirror a curated, version-pinned set of AFP entries
+into a bucket **we** control (world-readable + CORS), and the site fetches raw
+`.thy` text from there client-side.
+
+For each entry we download the AFP release tarball
+(`https://www.isa-afp.org/release/afp-<Entry>-current.tar.gz`), extract every
+`.thy` file, and upload it public-read to
+
+    s3://forall-git-evals/afp/<Entry>/<relative/path>.thy
+
+Finally we assemble and upload `afp/index.json`, the manifest the frontend reads
+(`src/lib/afp.ts`): entry -> theory list (+ byte sizes + object keys).
+
+Idempotent: re-running re-downloads and re-uploads (overwrites) in place.
+
+Prereqs: `s3cmd` configured for the DO Space (host_base nyc3.digitaloceanspaces
+.com). CORS on the bucket is a one-time separate step (see website/README.md).
+
+Usage:
+    python scripts/mirror-afp.py                # mirror the CURATED set
+    python scripts/mirror-afp.py --entry Kruskal --entry Show   # subset
+    python scripts/mirror-afp.py --dry-run      # download+plan, no uploads
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path
+
+BUCKET = "forall-git-evals"
+PREFIX = "afp"  # object key prefix within the bucket
+BASE_URL = f"https://{BUCKET}.nyc3.digitaloceanspaces.com"
+RELEASE_URL = "https://www.isa-afp.org/release/afp-{entry}-current.tar.gz"
+ENTRY_PAGE = "https://www.isa-afp.org/entries/{entry}.html"
+
+# Curated set: small-to-medium, self-contained entries with several
+# cross-citing lemmas, so fan-in-weighted corollary deletion has something to
+# chew on. Byte sizes are the release tarball sizes at time of curation.
+CURATED: list[str] = [
+    "Depth-First-Search",  # ~3KB   graph DFS, tiny + classic
+    "Fisher_Yates",        # ~6KB   in-place shuffle correctness
+    "List-Index",          # ~6KB   indexed list operations
+    "Sqrt_Babylonian",     # ~20KB  Newton/Heron sqrt bounds
+    "Show",                # ~22KB  show-class, multi-theory
+    "Regular-Sets",        # ~23KB  regex derivatives, rich fan-in
+    "Bernoulli",           # ~28KB  Bernoulli numbers
+    "Stirling_Formula",    # ~28KB  Stirling's approximation
+    "Dijkstra_Shortest_Path",  # ~31KB shortest paths
+    "Amortized_Complexity",    # ~32KB amortized analysis
+    "Kruskal",             # ~37KB  MST correctness
+]
+
+
+def log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def download_tarball(entry: str) -> bytes:
+    url = RELEASE_URL.format(entry=entry)
+    log(f"  ↓ {url}")
+    with urllib.request.urlopen(url, timeout=120) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"{entry}: HTTP {resp.status}")
+        return resp.read()
+
+
+def s3_put(local: Path, key: str, mime: str, dry_run: bool) -> None:
+    cmd = [
+        "s3cmd", "put", str(local), f"s3://{BUCKET}/{key}",
+        "--acl-public", "--mime-type", mime, "--no-progress",
+    ]
+    if dry_run:
+        log(f"    [dry-run] {' '.join(cmd)}")
+        return
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+
+def mirror_entry(entry: str, tmp: Path, dry_run: bool) -> dict | None:
+    """Download + extract + upload one entry. Returns its index record."""
+    try:
+        raw = download_tarball(entry)
+    except Exception as exc:  # noqa: BLE001 - report and skip
+        log(f"  ✗ {entry}: download failed: {exc}")
+        return None
+
+    theories: list[dict] = []
+    with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as tf:
+        for member in tf.getmembers():
+            if not member.isfile() or not member.name.endswith(".thy"):
+                continue
+            # member.name looks like "<Entry>/path/to/Theory.thy"; strip the
+            # leading "<Entry>/" so the object key mirrors the intra-entry path.
+            parts = member.name.split("/", 1)
+            rel = parts[1] if len(parts) == 2 else member.name
+            data = tf.extractfile(member).read()  # type: ignore[union-attr]
+            key = f"{PREFIX}/{entry}/{rel}"
+
+            local = tmp / entry / rel
+            local.parent.mkdir(parents=True, exist_ok=True)
+            local.write_bytes(data)
+            s3_put(local, key, "text/plain; charset=utf-8", dry_run)
+
+            theories.append({
+                "file": rel,                       # e.g. "Regular_Set.thy"
+                "key": key,                        # object key in the bucket
+                "url": f"{BASE_URL}/{key}",        # absolute public URL
+                "bytes": len(data),
+            })
+            log(f"    ↑ {key}  ({len(data)}b)")
+
+    if not theories:
+        log(f"  ✗ {entry}: no .thy files found in tarball")
+        return None
+
+    theories.sort(key=lambda t: t["file"])
+    return {
+        "name": entry,
+        "afp_url": ENTRY_PAGE.format(entry=entry),
+        "theories": theories,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--entry", action="append", dest="entries",
+                    help="mirror only this entry (repeatable); default: CURATED")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="download + plan but do not upload")
+    args = ap.parse_args()
+
+    entries = args.entries or CURATED
+    log(f"Mirroring {len(entries)} AFP entr{'y' if len(entries) == 1 else 'ies'} "
+        f"-> s3://{BUCKET}/{PREFIX}/  (dry_run={args.dry_run})")
+
+    records: list[dict] = []
+    with tempfile.TemporaryDirectory(prefix="afp-mirror-") as td:
+        tmp = Path(td)
+        for entry in entries:
+            log(f"• {entry}")
+            rec = mirror_entry(entry, tmp, args.dry_run)
+            if rec is not None:
+                records.append(rec)
+
+    records.sort(key=lambda r: r["name"].lower())
+    index = {
+        "schema": "afp-mirror/1",
+        "base_url": BASE_URL,
+        "source": "https://www.isa-afp.org/",
+        "entries": records,
+    }
+    index_bytes = json.dumps(index, indent=2).encode()
+
+    with tempfile.NamedTemporaryFile("wb", suffix=".json", delete=False) as f:
+        f.write(index_bytes)
+        index_local = Path(f.name)
+    s3_put(index_local, f"{PREFIX}/index.json", "application/json", args.dry_run)
+    index_local.unlink()
+
+    log(f"\nDone: {len(records)}/{len(entries)} entries, "
+        f"{sum(len(r['theories']) for r in records)} theories.")
+    log(f"Index: {BASE_URL}/{PREFIX}/index.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/website/scripts/mirror-afp.py
+++ b/website/scripts/mirror-afp.py
@@ -1,65 +1,67 @@
 #!/usr/bin/env python3
-"""Mirror a curated set of AFP entries into the forall-git-evals DO Space.
+"""Mirror AFP entries into the forall-git-evals DO Space (issue #113).
 
-Issue #113. The ablation playground (`website/`) is a *pure static* Vercel
-deploy, so it cannot fetch AFP theories directly from isa-afp.org (no permissive
-CORS there). Instead we pre-mirror a curated, version-pinned set of AFP entries
-into a bucket **we** control (world-readable + CORS), and the site fetches raw
-`.thy` text from there client-side.
+The ablation playground (`website/`) is a *pure static* Vercel deploy, so it
+can't fetch AFP theories directly from isa-afp.org (no permissive CORS there).
+We pre-mirror a version-pinned copy into a bucket **we** control (world-readable
++ CORS) and the site fetches raw `.thy` text from there client-side.
 
-For each entry we download the AFP release tarball
-(`https://www.isa-afp.org/release/afp-<Entry>-current.tar.gz`), extract every
-`.thy` file, and upload it public-read to
+Two modes:
 
-    s3://forall-git-evals/afp/<Entry>/<relative/path>.thy
+  --full      Mirror the ENTIRE AFP from the single release tarball
+              (`afp-current.tar.gz`, ~1000 entries / ~10k theories / ~280 MB).
+              One download, then a parallel upload. This is the deliverable.
 
-Finally we assemble and upload `afp/index.json`, the manifest the frontend reads
-(`src/lib/afp.ts`): entry -> theory list (+ byte sizes + object keys).
+  (default)   Mirror only the small CURATED list below — handy for a quick
+              refresh or a local smoke test.
 
-Idempotent: re-running re-downloads and re-uploads (overwrites) in place.
+Layout in the bucket (both modes):
 
-Prereqs: `s3cmd` configured for the DO Space (host_base nyc3.digitaloceanspaces
-.com). CORS on the bucket is a one-time separate step (see website/README.md).
+    afp/index.json                 lightweight manifest the site loads on open:
+                                     { schema, base_url, source, release,
+                                       entries: [{name, n_theories, afp_url}] }
+    afp/<Entry>/theories.json      per-entry theory list, fetched lazily when an
+                                     entry is picked: { name, theories:[{file,
+                                     key, url, bytes}] }
+    afp/<Entry>/<path>.thy         raw theory source (public-read)
+
+Splitting the index keeps first paint light: ~1000 entries is a ~90 KB
+index.json, while the ~10k per-theory records live in the lazy shards.
+
+Idempotent: re-running overwrites in place. `s3cmd` must be configured for the
+Space. Bucket CORS is a one-time separate step (see website/README.md).
 
 Usage:
-    python scripts/mirror-afp.py                # mirror the CURATED set
-    python scripts/mirror-afp.py --entry Kruskal --entry Show   # subset
-    python scripts/mirror-afp.py --dry-run      # download+plan, no uploads
+    python scripts/mirror-afp.py --full            # whole AFP
+    python scripts/mirror-afp.py --full --workers 12
+    python scripts/mirror-afp.py                   # curated set
+    python scripts/mirror-afp.py --entry Kruskal   # a subset
+    python scripts/mirror-afp.py --full --dry-run  # download + plan, no uploads
 """
 
 from __future__ import annotations
 
 import argparse
-import io
 import json
 import subprocess
 import sys
 import tarfile
 import tempfile
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 BUCKET = "forall-git-evals"
-PREFIX = "afp"  # object key prefix within the bucket
-BASE_URL = f"https://{BUCKET}.nyc3.digitaloceanspaces.com"
-RELEASE_URL = "https://www.isa-afp.org/release/afp-{entry}-current.tar.gz"
+PREFIX = "afp"
+BASE_URL = f"https://{BUCKET}.nyc3.digitaloceanspaces.com/{PREFIX}"
+FULL_RELEASE_URL = "https://isa-afp.org/release/afp-current.tar.gz"
+ENTRY_RELEASE_URL = "https://www.isa-afp.org/release/afp-{entry}-current.tar.gz"
 ENTRY_PAGE = "https://www.isa-afp.org/entries/{entry}.html"
 
-# Curated set: small-to-medium, self-contained entries with several
-# cross-citing lemmas, so fan-in-weighted corollary deletion has something to
-# chew on. Byte sizes are the release tarball sizes at time of curation.
 CURATED: list[str] = [
-    "Depth-First-Search",  # ~3KB   graph DFS, tiny + classic
-    "Fisher_Yates",        # ~6KB   in-place shuffle correctness
-    "List-Index",          # ~6KB   indexed list operations
-    "Sqrt_Babylonian",     # ~20KB  Newton/Heron sqrt bounds
-    "Show",                # ~22KB  show-class, multi-theory
-    "Regular-Sets",        # ~23KB  regex derivatives, rich fan-in
-    "Bernoulli",           # ~28KB  Bernoulli numbers
-    "Stirling_Formula",    # ~28KB  Stirling's approximation
-    "Dijkstra_Shortest_Path",  # ~31KB shortest paths
-    "Amortized_Complexity",    # ~32KB amortized analysis
-    "Kruskal",             # ~37KB  MST correctness
+    "Depth-First-Search", "Fisher_Yates", "List-Index", "Sqrt_Babylonian",
+    "Show", "Regular-Sets", "Bernoulli", "Stirling_Formula",
+    "Dijkstra_Shortest_Path", "Amortized_Complexity", "Kruskal",
 ]
 
 
@@ -67,110 +69,179 @@ def log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
-def download_tarball(entry: str) -> bytes:
-    url = RELEASE_URL.format(entry=entry)
-    log(f"  ↓ {url}")
-    with urllib.request.urlopen(url, timeout=120) as resp:
-        if resp.status != 200:
-            raise RuntimeError(f"{entry}: HTTP {resp.status}")
-        return resp.read()
+# --------------------------------------------------------------------------- #
+# Staging: build a local `<Entry>/<path>.thy` tree + per-entry theories.json    #
+# --------------------------------------------------------------------------- #
+
+def _theory_record(entry: str, rel: str, nbytes: int) -> dict:
+    key = f"{PREFIX}/{entry}/{rel}"
+    return {"file": rel, "key": key, "url": f"{BASE_URL}/{entry}/{rel}", "bytes": nbytes}
 
 
-def s3_put(local: Path, key: str, mime: str, dry_run: bool) -> None:
-    cmd = [
-        "s3cmd", "put", str(local), f"s3://{BUCKET}/{key}",
-        "--acl-public", "--mime-type", mime, "--no-progress",
+def stage_from_full(stage: Path) -> list[dict]:
+    """Download the full release tarball and extract every entry's .thy files.
+    Returns the lightweight per-entry index records."""
+    log(f"↓ {FULL_RELEASE_URL}")
+    with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
+        with urllib.request.urlopen(FULL_RELEASE_URL, timeout=600) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"full release HTTP {resp.status}")
+            # stream to disk (tarfile needs seek for gz members on some inputs)
+            while chunk := resp.read(1 << 20):
+                tmp.write(chunk)
+        tarball = Path(tmp.name)
+    log(f"  got {tarball.stat().st_size / 1048576:.0f} MB, extracting .thy …")
+
+    release = ""
+    per_entry: dict[str, list[dict]] = {}
+    with tarfile.open(tarball, mode="r:gz") as tf:
+        for m in tf:
+            if not m.isfile() or not m.name.endswith(".thy"):
+                continue
+            # paths look like "afp-YYYY-MM-DD/thys/<Entry>/<rel>.thy"
+            parts = m.name.split("/")
+            if len(parts) < 4 or parts[1] != "thys":
+                continue
+            release = release or parts[0]
+            entry, rel = parts[2], "/".join(parts[3:])
+            data = tf.extractfile(m).read()  # type: ignore[union-attr]
+            dest = stage / entry / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(data)
+            per_entry.setdefault(entry, []).append(_theory_record(entry, rel, len(data)))
+    tarball.unlink(missing_ok=True)
+
+    return _finalize_stage(stage, per_entry, release)
+
+
+def stage_from_entries(stage: Path, entries: list[str]) -> list[dict]:
+    """Per-entry tarball download path (curated / subset mode)."""
+    import io
+
+    per_entry: dict[str, list[dict]] = {}
+    for entry in entries:
+        url = ENTRY_RELEASE_URL.format(entry=entry)
+        log(f"↓ {url}")
+        try:
+            with urllib.request.urlopen(url, timeout=120) as resp:
+                raw = resp.read()
+        except Exception as exc:  # noqa: BLE001
+            log(f"  ✗ {entry}: {exc}")
+            continue
+        with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as tf:
+            for m in tf.getmembers():
+                if not m.isfile() or not m.name.endswith(".thy"):
+                    continue
+                parts = m.name.split("/", 1)
+                rel = parts[1] if len(parts) == 2 else m.name
+                data = tf.extractfile(m).read()  # type: ignore[union-attr]
+                dest = stage / entry / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(data)
+                per_entry.setdefault(entry, []).append(_theory_record(entry, rel, len(data)))
+    return _finalize_stage(stage, per_entry, release="")
+
+
+def _finalize_stage(stage: Path, per_entry: dict[str, list[dict]], release: str) -> list[dict]:
+    """Write per-entry theories.json + top-level index.json into the stage dir."""
+    index_entries: list[dict] = []
+    for entry, theories in per_entry.items():
+        theories.sort(key=lambda t: t["file"])
+        (stage / entry / "theories.json").write_text(
+            json.dumps({"name": entry, "theories": theories}, indent=2)
+        )
+        index_entries.append({
+            "name": entry,
+            "n_theories": len(theories),
+            "afp_url": ENTRY_PAGE.format(entry=entry),
+        })
+    index_entries.sort(key=lambda e: e["name"].lower())
+    index = {
+        "schema": "afp-mirror/2",
+        "base_url": BASE_URL,
+        "source": "https://www.isa-afp.org/",
+        "release": release,
+        "entries": index_entries,
+    }
+    (stage / "index.json").write_text(json.dumps(index, indent=2))
+    return index_entries
+
+
+# --------------------------------------------------------------------------- #
+# Upload: parallel s3cmd (single-threaded per proc, so we shard across entries) #
+# --------------------------------------------------------------------------- #
+
+def _upload_entry(stage: Path, entry: str, dry_run: bool) -> str:
+    """Upload one entry dir: .thy as text/plain, theories.json as application/json."""
+    src = stage / entry
+    base = [
+        "s3cmd", "put", "--recursive", "--acl-public", "--no-progress",
+        "--no-mime-magic",
+    ]
+    thy = base + [
+        "--mime-type", "text/plain; charset=utf-8", "--exclude", "*.json",
+        f"{src}/", f"s3://{BUCKET}/{PREFIX}/{entry}/",
+    ]
+    js = [
+        "s3cmd", "put", "--acl-public", "--no-progress",
+        "--mime-type", "application/json",
+        str(src / "theories.json"), f"s3://{BUCKET}/{PREFIX}/{entry}/theories.json",
     ]
     if dry_run:
-        log(f"    [dry-run] {' '.join(cmd)}")
-        return
-    subprocess.run(cmd, check=True, capture_output=True, text=True)
+        return entry
+    subprocess.run(thy, check=True, capture_output=True, text=True)
+    subprocess.run(js, check=True, capture_output=True, text=True)
+    return entry
 
 
-def mirror_entry(entry: str, tmp: Path, dry_run: bool) -> dict | None:
-    """Download + extract + upload one entry. Returns its index record."""
-    try:
-        raw = download_tarball(entry)
-    except Exception as exc:  # noqa: BLE001 - report and skip
-        log(f"  ✗ {entry}: download failed: {exc}")
-        return None
+def upload(stage: Path, entries: list[dict], workers: int, dry_run: bool) -> None:
+    names = [e["name"] for e in entries]
+    log(f"↑ uploading {len(names)} entries with {workers} workers "
+        f"(dry_run={dry_run}) …")
+    done = 0
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        futs = {ex.submit(_upload_entry, stage, n, dry_run): n for n in names}
+        for fut in as_completed(futs):
+            name = futs[fut]
+            try:
+                fut.result()
+            except Exception as exc:  # noqa: BLE001
+                log(f"  ✗ {name}: upload failed: {exc}")
+            done += 1
+            if done % 50 == 0 or done == len(names):
+                log(f"  … {done}/{len(names)} entries")
 
-    theories: list[dict] = []
-    with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as tf:
-        for member in tf.getmembers():
-            if not member.isfile() or not member.name.endswith(".thy"):
-                continue
-            # member.name looks like "<Entry>/path/to/Theory.thy"; strip the
-            # leading "<Entry>/" so the object key mirrors the intra-entry path.
-            parts = member.name.split("/", 1)
-            rel = parts[1] if len(parts) == 2 else member.name
-            data = tf.extractfile(member).read()  # type: ignore[union-attr]
-            key = f"{PREFIX}/{entry}/{rel}"
-
-            local = tmp / entry / rel
-            local.parent.mkdir(parents=True, exist_ok=True)
-            local.write_bytes(data)
-            s3_put(local, key, "text/plain; charset=utf-8", dry_run)
-
-            theories.append({
-                "file": rel,                       # e.g. "Regular_Set.thy"
-                "key": key,                        # object key in the bucket
-                "url": f"{BASE_URL}/{key}",        # absolute public URL
-                "bytes": len(data),
-            })
-            log(f"    ↑ {key}  ({len(data)}b)")
-
-    if not theories:
-        log(f"  ✗ {entry}: no .thy files found in tarball")
-        return None
-
-    theories.sort(key=lambda t: t["file"])
-    return {
-        "name": entry,
-        "afp_url": ENTRY_PAGE.format(entry=entry),
-        "theories": theories,
-    }
+    # index.json last, so a partial run never advertises missing entries.
+    idx = [
+        "s3cmd", "put", "--acl-public", "--no-progress",
+        "--mime-type", "application/json",
+        str(stage / "index.json"), f"s3://{BUCKET}/{PREFIX}/index.json",
+    ]
+    if not dry_run:
+        subprocess.run(idx, check=True, capture_output=True, text=True)
+    log(f"index -> {BASE_URL}/index.json")
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--full", action="store_true", help="mirror the entire AFP")
     ap.add_argument("--entry", action="append", dest="entries",
-                    help="mirror only this entry (repeatable); default: CURATED")
-    ap.add_argument("--dry-run", action="store_true",
-                    help="download + plan but do not upload")
+                    help="curated-mode: mirror only this entry (repeatable)")
+    ap.add_argument("--workers", type=int, default=8, help="parallel upload workers")
+    ap.add_argument("--dry-run", action="store_true", help="stage but don't upload")
     args = ap.parse_args()
 
-    entries = args.entries or CURATED
-    log(f"Mirroring {len(entries)} AFP entr{'y' if len(entries) == 1 else 'ies'} "
-        f"-> s3://{BUCKET}/{PREFIX}/  (dry_run={args.dry_run})")
-
-    records: list[dict] = []
     with tempfile.TemporaryDirectory(prefix="afp-mirror-") as td:
-        tmp = Path(td)
-        for entry in entries:
-            log(f"• {entry}")
-            rec = mirror_entry(entry, tmp, args.dry_run)
-            if rec is not None:
-                records.append(rec)
+        stage = Path(td)
+        if args.full:
+            entries = stage_from_full(stage)
+        else:
+            entries = stage_from_entries(stage, args.entries or CURATED)
+        n_thy = sum(e["n_theories"] for e in entries)
+        log(f"staged {len(entries)} entries / {n_thy} theories")
+        upload(stage, entries, max(1, args.workers), args.dry_run)
 
-    records.sort(key=lambda r: r["name"].lower())
-    index = {
-        "schema": "afp-mirror/1",
-        "base_url": BASE_URL,
-        "source": "https://www.isa-afp.org/",
-        "entries": records,
-    }
-    index_bytes = json.dumps(index, indent=2).encode()
-
-    with tempfile.NamedTemporaryFile("wb", suffix=".json", delete=False) as f:
-        f.write(index_bytes)
-        index_local = Path(f.name)
-    s3_put(index_local, f"{PREFIX}/index.json", "application/json", args.dry_run)
-    index_local.unlink()
-
-    log(f"\nDone: {len(records)}/{len(entries)} entries, "
-        f"{sum(len(r['theories']) for r in records)} theories.")
-    log(f"Index: {BASE_URL}/{PREFIX}/index.json")
+    log("done.")
     return 0
 
 

--- a/website/src/App.css
+++ b/website/src/App.css
@@ -147,6 +147,54 @@ button.generate:hover {
   filter: brightness(1.08);
 }
 
+/* AFP importer (issue #113) */
+.afp-toggle {
+  background: var(--pan);
+  color: var(--mut);
+  border: 1px solid var(--bd);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+.afp-toggle:hover {
+  color: var(--fg);
+}
+.afp-toggle.on {
+  color: var(--acc2);
+  border-color: color-mix(in srgb, var(--acc2) 45%, transparent);
+}
+.afp-pickers {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 5px;
+}
+.afp-pickers select {
+  background: var(--pan);
+  color: var(--fg);
+  border: 1px solid var(--bd);
+  border-radius: 6px;
+  padding: 6px 8px;
+  font: inherit;
+  max-width: 220px;
+}
+.afp-note {
+  font-size: 11px;
+  color: var(--mut);
+  text-decoration: none;
+}
+.afp-note:hover {
+  color: var(--fg);
+}
+.afp-err {
+  font-size: 11px;
+  color: var(--red);
+  max-width: 260px;
+}
+
 .advanced {
   padding: 8px 24px;
   border-bottom: 1px solid var(--bd);

--- a/website/src/App.css
+++ b/website/src/App.css
@@ -291,6 +291,12 @@ button.generate:hover {
 .presets button:hover {
   border-color: var(--acc2);
 }
+.presets button.on {
+  background: var(--acc2);
+  color: #1e1e2e;
+  font-weight: 600;
+  border-color: var(--acc2);
+}
 .controls .chk {
   display: flex;
   align-items: flex-start;

--- a/website/src/App.css
+++ b/website/src/App.css
@@ -397,18 +397,40 @@ button.generate:hover {
   color: var(--red);
 }
 
-textarea.source {
+/* Source editor: transparent-text <textarea> over a highlighted <pre>, aligned
+   pixel-for-pixel and scroll-synced (see CodeEditor.tsx). */
+.editor {
+  position: relative;
   flex: 1;
   width: 100%;
   min-height: 340px;
-  resize: none;
   background: var(--pan);
-  color: var(--fg);
+}
+.editor-hl,
+.editor-input {
+  position: absolute;
+  inset: 0;
+  margin: 0;
   border: none;
   padding: 12px 16px;
   font: 13px/1.5 ui-monospace, Menlo, Consolas, monospace;
   tab-size: 2;
   white-space: pre;
+  overflow: auto;
+}
+.editor-hl {
+  color: var(--fg); /* colour for plain (non-token) text */
+  pointer-events: none;
+  scrollbar-width: none; /* scrollbar lives on the textarea; keep them in sync */
+}
+.editor-hl::-webkit-scrollbar {
+  display: none;
+}
+.editor-input {
+  resize: none;
+  background: transparent;
+  color: transparent;
+  caret-color: var(--fg);
   outline: none;
 }
 

--- a/website/src/App.css
+++ b/website/src/App.css
@@ -172,7 +172,8 @@ button.generate:hover {
   flex-wrap: wrap;
   margin-top: 5px;
 }
-.afp-pickers select {
+.afp-pickers select,
+.afp-entry-input {
   background: var(--pan);
   color: var(--fg);
   border: 1px solid var(--bd);
@@ -180,6 +181,13 @@ button.generate:hover {
   padding: 6px 8px;
   font: inherit;
   max-width: 220px;
+}
+.afp-entry-input {
+  min-width: 180px;
+}
+.afp-entry-input:focus {
+  outline: none;
+  border-color: var(--acc2);
 }
 .afp-note {
   font-size: 11px;

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -13,6 +13,7 @@ import {
   type Lang,
 } from './ablators'
 import { SAMPLES } from './lib/samples'
+import { fetchAfpIndex, fetchAfpTheory, type AfpIndex } from './lib/afp'
 import { toRecord, type EvalRecord } from './lib/record'
 import { CodeView } from './components/CodeView'
 import { JsonView } from './components/JsonView'
@@ -81,6 +82,14 @@ export default function App() {
   const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle')
   const [error, setError] = useState('')
 
+  // AFP importer (issue #113): pull a real Archive of Formal Proofs theory from
+  // our world-readable mirror into the source pane. Isabelle-only.
+  const [afp, setAfp] = useState<AfpIndex | null>(null)
+  const [afpOpen, setAfpOpen] = useState(false)
+  const [afpEntry, setAfpEntry] = useState('')
+  const [afpBusy, setAfpBusy] = useState(false)
+  const [afpErr, setAfpErr] = useState('')
+
   const detected = useMemo(() => detectLanguage(debounced), [debounced])
   const lang: Lang = override === 'auto' ? detected : override
   const caps = CAPS[lang]
@@ -131,6 +140,43 @@ export default function App() {
     setOverride(l)
     setSource(SAMPLES[l])
   }
+
+  const openAfp = useCallback(async () => {
+    setAfpOpen((o) => !o)
+    if (afp) return
+    setAfpBusy(true)
+    setAfpErr('')
+    try {
+      const idx = await fetchAfpIndex()
+      setAfp(idx)
+      setAfpEntry(idx.entries[0]?.name ?? '')
+    } catch (e) {
+      setAfpErr(String(e instanceof Error ? e.message : e))
+    } finally {
+      setAfpBusy(false)
+    }
+  }, [afp])
+
+  const loadAfpTheory = useCallback(
+    async (entryName: string, file: string) => {
+      const entry = afp?.entries.find((e) => e.name === entryName)
+      const theory = entry?.theories.find((t) => t.file === file)
+      if (!theory) return
+      setAfpBusy(true)
+      setAfpErr('')
+      try {
+        const text = await fetchAfpTheory(theory)
+        setOverride('isabelle')
+        setSource(text)
+      } catch (e) {
+        setAfpErr(String(e instanceof Error ? e.message : e))
+      } finally {
+        setAfpBusy(false)
+      }
+    },
+    [afp],
+  )
+
   const applyPreset = (i: number) => {
     const p = PRESETS[i]
     up({ rateMode: 'prob', prob: p.prob, minDepth: p.minDepth, maxDepth: p.maxDepth, leavesOnly: p.leavesOnly })
@@ -213,6 +259,62 @@ export default function App() {
               </button>
             ))}
           </div>
+        </div>
+
+        <div className="field afp">
+          <label>Import AFP entry</label>
+          <button className={`afp-toggle${afpOpen ? ' on' : ''}`} onClick={() => void openAfp()}>
+            {afpOpen ? '▾' : '▸'} isabelle · AFP
+          </button>
+          {afpOpen && (
+            <div className="afp-pickers">
+              {afpBusy && !afp ? (
+                <span className="afp-note">loading catalog…</span>
+              ) : afp ? (
+                <>
+                  <select
+                    value={afpEntry}
+                    onChange={(e) => setAfpEntry(e.target.value)}
+                    aria-label="AFP entry"
+                  >
+                    {afp.entries.map((en) => (
+                      <option key={en.name} value={en.name}>
+                        {en.name} ({en.theories.length})
+                      </option>
+                    ))}
+                  </select>
+                  <select
+                    value=""
+                    disabled={afpBusy}
+                    onChange={(e) => {
+                      if (e.target.value) void loadAfpTheory(afpEntry, e.target.value)
+                    }}
+                    aria-label="AFP theory file"
+                  >
+                    <option value="">
+                      {afpBusy ? 'fetching…' : 'pick a theory…'}
+                    </option>
+                    {afp.entries
+                      .find((en) => en.name === afpEntry)
+                      ?.theories.map((t) => (
+                        <option key={t.file} value={t.file}>
+                          {t.file} ({Math.ceil(t.bytes / 1024)}KB)
+                        </option>
+                      ))}
+                  </select>
+                  {(() => {
+                    const en = afp.entries.find((e) => e.name === afpEntry)
+                    return en ? (
+                      <a className="afp-note" href={en.afp_url} target="_blank" rel="noreferrer">
+                        entry page ↗
+                      </a>
+                    ) : null
+                  })()}
+                </>
+              ) : null}
+              {afpErr && <span className="afp-err">{afpErr}</span>}
+            </div>
+          )}
         </div>
       </div>
 

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -13,7 +13,7 @@ import {
   type Lang,
 } from './ablators'
 import { SAMPLES } from './lib/samples'
-import { fetchAfpIndex, fetchAfpTheory, type AfpIndex } from './lib/afp'
+import { fetchAfpIndex, fetchAfpEntryTheories, fetchAfpTheory, type AfpIndex, type AfpTheory } from './lib/afp'
 import { toRecord, type EvalRecord } from './lib/record'
 import { CodeView } from './components/CodeView'
 import { JsonView } from './components/JsonView'
@@ -84,12 +84,14 @@ export default function App() {
 
   // AFP importer (issue #113): pull a real Archive of Formal Proofs theory from
   // our world-readable mirror into the source pane. Isabelle-only.
-  const [afp, setAfp] = useState<AfpIndex | null>(null)
+  const [afp, setAfp] = useState<AfpIndex | null>(null) // lightweight entry list
   const [afpOpen, setAfpOpen] = useState(false)
   const [afpEntry, setAfpEntry] = useState('')
+  const [afpTheories, setAfpTheories] = useState<AfpTheory[] | null>(null) // lazy shard for afpEntry
   const [afpFile, setAfpFile] = useState('') // currently-loaded theory (persists across setting tweaks)
   const [afpBusy, setAfpBusy] = useState(false)
   const [afpErr, setAfpErr] = useState('')
+  const afpCache = useRef<Map<string, AfpTheory[]>>(new Map()) // entry -> theories.json
 
   const detected = useMemo(() => detectLanguage(debounced), [debounced])
   const lang: Lang = override === 'auto' ? detected : override
@@ -149,9 +151,7 @@ export default function App() {
     setAfpBusy(true)
     setAfpErr('')
     try {
-      const idx = await fetchAfpIndex()
-      setAfp(idx)
-      setAfpEntry(idx.entries[0]?.name ?? '')
+      setAfp(await fetchAfpIndex())
     } catch (e) {
       setAfpErr(String(e instanceof Error ? e.message : e))
     } finally {
@@ -159,10 +159,10 @@ export default function App() {
     }
   }, [afp])
 
-  const loadAfpTheory = useCallback(
-    async (entryName: string, file: string) => {
-      const entry = afp?.entries.find((e) => e.name === entryName)
-      const theory = entry?.theories.find((t) => t.file === file)
+  // Pick a specific theory from the currently-loaded entry shard.
+  const pickAfpTheory = useCallback(
+    async (file: string) => {
+      const theory = afpTheories?.find((t) => t.file === file)
       if (!theory) return
       setAfpFile(file) // reflect the selection immediately; survives setting tweaks
       setAfpBusy(true)
@@ -177,19 +177,44 @@ export default function App() {
         setAfpBusy(false)
       }
     },
-    [afp],
+    [afpTheories],
   )
 
-  // Changing entry immediately loads its first theory (keeps the flow live and
-  // the theory dropdown always pointing at real, loaded source).
+  // Selecting an entry (typed/picked in the combobox) lazily fetches its theory
+  // shard and loads the first theory — keeps the flow live and the theory
+  // dropdown always pointing at real, loaded source. Ignores partial typing.
   const selectAfpEntry = useCallback(
-    (name: string) => {
+    async (name: string) => {
       setAfpEntry(name)
-      const first = afp?.entries.find((e) => e.name === name)?.theories[0]
-      if (first) void loadAfpTheory(name, first.file)
-      else setAfpFile('')
+      if (!afp?.entries.some((e) => e.name === name)) {
+        setAfpTheories(null)
+        setAfpFile('')
+        return
+      }
+      setAfpBusy(true)
+      setAfpErr('')
+      try {
+        let ths = afpCache.current.get(name)
+        if (!ths) {
+          ths = await fetchAfpEntryTheories(name)
+          afpCache.current.set(name, ths)
+        }
+        setAfpTheories(ths)
+        const first = ths[0]
+        setAfpFile(first?.file ?? '')
+        if (first) {
+          const text = await fetchAfpTheory(first)
+          setOverride('isabelle')
+          setSource(text)
+        }
+      } catch (e) {
+        setAfpErr(String(e instanceof Error ? e.message : e))
+        setAfpTheories(null)
+      } finally {
+        setAfpBusy(false)
+      }
     },
-    [afp, loadAfpTheory],
+    [afp],
   )
 
   // The L0–L4 presets are probability/depth (selection-mode) difficulty knobs, so
@@ -307,35 +332,37 @@ export default function App() {
                 <span className="afp-note">loading catalog…</span>
               ) : afp ? (
                 <>
-                  <select
+                  <input
+                    className="afp-entry-input"
+                    list="afp-entries"
                     value={afpEntry}
-                    onChange={(e) => selectAfpEntry(e.target.value)}
+                    placeholder={`search ${afp.entries.length} entries…`}
+                    onChange={(e) => void selectAfpEntry(e.target.value)}
                     aria-label="AFP entry"
-                  >
+                  />
+                  <datalist id="afp-entries">
                     {afp.entries.map((en) => (
                       <option key={en.name} value={en.name}>
-                        {en.name} ({en.theories.length})
+                        {en.n_theories} thy
                       </option>
                     ))}
-                  </select>
+                  </datalist>
                   <select
                     value={afpFile}
-                    disabled={afpBusy}
-                    onChange={(e) => void loadAfpTheory(afpEntry, e.target.value)}
+                    disabled={afpBusy || !afpTheories}
+                    onChange={(e) => void pickAfpTheory(e.target.value)}
                     aria-label="AFP theory file"
                   >
                     {afpFile === '' && (
                       <option value="" disabled>
-                        {afpBusy ? 'fetching…' : 'pick a theory…'}
+                        {afpBusy ? 'fetching…' : afpTheories ? 'pick a theory…' : 'pick an entry first'}
                       </option>
                     )}
-                    {afp.entries
-                      .find((en) => en.name === afpEntry)
-                      ?.theories.map((t) => (
-                        <option key={t.file} value={t.file}>
-                          {t.file} ({Math.ceil(t.bytes / 1024)}KB)
-                        </option>
-                      ))}
+                    {afpTheories?.map((t) => (
+                      <option key={t.file} value={t.file}>
+                        {t.file} ({Math.ceil(t.bytes / 1024)}KB)
+                      </option>
+                    ))}
                   </select>
                   {(() => {
                     const en = afp.entries.find((e) => e.name === afpEntry)

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -87,6 +87,7 @@ export default function App() {
   const [afp, setAfp] = useState<AfpIndex | null>(null)
   const [afpOpen, setAfpOpen] = useState(false)
   const [afpEntry, setAfpEntry] = useState('')
+  const [afpFile, setAfpFile] = useState('') // currently-loaded theory (persists across setting tweaks)
   const [afpBusy, setAfpBusy] = useState(false)
   const [afpErr, setAfpErr] = useState('')
 
@@ -139,6 +140,7 @@ export default function App() {
   const loadSample = (l: Lang) => {
     setOverride(l)
     setSource(SAMPLES[l])
+    setAfpFile('') // a built-in sample is now in the pane, not an AFP theory
   }
 
   const openAfp = useCallback(async () => {
@@ -162,6 +164,7 @@ export default function App() {
       const entry = afp?.entries.find((e) => e.name === entryName)
       const theory = entry?.theories.find((t) => t.file === file)
       if (!theory) return
+      setAfpFile(file) // reflect the selection immediately; survives setting tweaks
       setAfpBusy(true)
       setAfpErr('')
       try {
@@ -175,6 +178,18 @@ export default function App() {
       }
     },
     [afp],
+  )
+
+  // Changing entry immediately loads its first theory (keeps the flow live and
+  // the theory dropdown always pointing at real, loaded source).
+  const selectAfpEntry = useCallback(
+    (name: string) => {
+      setAfpEntry(name)
+      const first = afp?.entries.find((e) => e.name === name)?.theories[0]
+      if (first) void loadAfpTheory(name, first.file)
+      else setAfpFile('')
+    },
+    [afp, loadAfpTheory],
   )
 
   const applyPreset = (i: number) => {
@@ -244,9 +259,13 @@ export default function App() {
         )}
 
         <div className="field">
-          <label>&nbsp;</label>
-          <button className="generate" onClick={() => up({ seed: randSeed() })}>
-            ↻ Generate
+          <label>New variant</label>
+          <button
+            className="generate"
+            title="Everything else updates live; this re-rolls the random seed for a different ablation with the current settings."
+            onClick={() => up({ seed: randSeed() })}
+          >
+            ↻ Random
           </button>
         </div>
 
@@ -274,7 +293,7 @@ export default function App() {
                 <>
                   <select
                     value={afpEntry}
-                    onChange={(e) => setAfpEntry(e.target.value)}
+                    onChange={(e) => selectAfpEntry(e.target.value)}
                     aria-label="AFP entry"
                   >
                     {afp.entries.map((en) => (
@@ -284,16 +303,16 @@ export default function App() {
                     ))}
                   </select>
                   <select
-                    value=""
+                    value={afpFile}
                     disabled={afpBusy}
-                    onChange={(e) => {
-                      if (e.target.value) void loadAfpTheory(afpEntry, e.target.value)
-                    }}
+                    onChange={(e) => void loadAfpTheory(afpEntry, e.target.value)}
                     aria-label="AFP theory file"
                   >
-                    <option value="">
-                      {afpBusy ? 'fetching…' : 'pick a theory…'}
-                    </option>
+                    {afpFile === '' && (
+                      <option value="" disabled>
+                        {afpBusy ? 'fetching…' : 'pick a theory…'}
+                      </option>
+                    )}
                     {afp.entries
                       .find((en) => en.name === afpEntry)
                       ?.theories.map((t) => (

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -218,11 +218,21 @@ export default function App() {
   )
 
   // The L0–L4 presets are probability/depth (selection-mode) difficulty knobs, so
-  // a preset must switch off corollary mode — otherwise the corollary/delete-count
-  // path ignores prob/depth and every preset yields the identical ablation.
+  // a preset must (a) switch off corollary mode and (b) clear deleteCount —
+  // otherwise the corollary/delete-count path pins the ablation to a fixed count
+  // (`delete_count` is emitted whenever it's non-null) and every preset yields the
+  // identical result regardless of prob/depth.
   const applyPreset = (i: number) => {
     const p = PRESETS[i]
-    up({ corollary: false, rateMode: 'prob', prob: p.prob, minDepth: p.minDepth, maxDepth: p.maxDepth, leavesOnly: p.leavesOnly })
+    up({
+      corollary: false,
+      deleteCount: null,
+      rateMode: 'prob',
+      prob: p.prob,
+      minDepth: p.minDepth,
+      maxDepth: p.maxDepth,
+      leavesOnly: p.leavesOnly,
+    })
   }
   const activePreset = useMemo(
     () =>

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -16,6 +16,7 @@ import { SAMPLES } from './lib/samples'
 import { fetchAfpIndex, fetchAfpEntryTheories, fetchAfpTheory, type AfpIndex, type AfpTheory } from './lib/afp'
 import { toRecord, type EvalRecord } from './lib/record'
 import { CodeView } from './components/CodeView'
+import { CodeEditor } from './components/CodeEditor'
 import { JsonView } from './components/JsonView'
 
 type Mode = 'challenge' | 'json'
@@ -541,7 +542,7 @@ export default function App() {
             <h2>Source</h2>
             <span className="muted">edit or paste any of the three provers</span>
           </div>
-          <textarea className="source" spellCheck={false} value={source} onChange={(e) => setSource(e.target.value)} />
+          <CodeEditor lang={lang} value={source} onChange={setSource} />
         </section>
 
         <section className="pane">

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -192,10 +192,26 @@ export default function App() {
     [afp, loadAfpTheory],
   )
 
+  // The L0–L4 presets are probability/depth (selection-mode) difficulty knobs, so
+  // a preset must switch off corollary mode — otherwise the corollary/delete-count
+  // path ignores prob/depth and every preset yields the identical ablation.
   const applyPreset = (i: number) => {
     const p = PRESETS[i]
-    up({ rateMode: 'prob', prob: p.prob, minDepth: p.minDepth, maxDepth: p.maxDepth, leavesOnly: p.leavesOnly })
+    up({ corollary: false, rateMode: 'prob', prob: p.prob, minDepth: p.minDepth, maxDepth: p.maxDepth, leavesOnly: p.leavesOnly })
   }
+  const activePreset = useMemo(
+    () =>
+      opts.corollary || opts.rateMode !== 'prob'
+        ? -1
+        : PRESETS.findIndex(
+            (p) =>
+              p.prob === opts.prob &&
+              p.minDepth === opts.minDepth &&
+              p.maxDepth === opts.maxDepth &&
+              p.leavesOnly === opts.leavesOnly,
+          ),
+    [opts.corollary, opts.rateMode, opts.prob, opts.minDepth, opts.maxDepth, opts.leavesOnly],
+  )
 
   const stats = result
     ? { ablated: result.ablated, total: result.total }
@@ -343,7 +359,7 @@ export default function App() {
             <h3>Difficulty preset</h3>
             <div className="presets">
               {['L0', 'L1', 'L2', 'L3', 'L4'].map((l, i) => (
-                <button key={l} onClick={() => applyPreset(i)}>
+                <button key={l} className={activePreset === i ? 'on' : ''} onClick={() => applyPreset(i)}>
                   {l}
                 </button>
               ))}

--- a/website/src/components/CodeEditor.tsx
+++ b/website/src/components/CodeEditor.tsx
@@ -1,0 +1,53 @@
+import { useMemo, useRef } from 'react'
+import type { Lang } from '../ablators/types'
+import { highlight, TOK_CLASS } from '../lib/highlight'
+
+// Editable source pane with live syntax highlighting. A <textarea> with
+// transparent text sits over a <pre> that renders the same highlight() tokens as
+// <CodeView>, aligned pixel-for-pixel (identical font/padding/whitespace) and
+// scroll-synced. Keeps the source editable while showing per-language colours —
+// something a bare <textarea> can't do. Very large inputs fall back to plain
+// (highlight() itself bails >60k) so big AFP theories stay responsive.
+export function CodeEditor({
+  lang,
+  value,
+  onChange,
+}: {
+  lang: Lang
+  value: string
+  onChange: (v: string) => void
+}) {
+  const preRef = useRef<HTMLPreElement>(null)
+  const toks = useMemo(() => highlight(lang, value), [lang, value])
+  return (
+    <div className="editor">
+      <pre className="code editor-hl" ref={preRef} aria-hidden="true">
+        <code>
+          {toks.map((t, i) =>
+            t.cls === 'plain' ? (
+              t.text
+            ) : (
+              <span key={i} className={TOK_CLASS[t.cls]}>
+                {t.text}
+              </span>
+            ),
+          )}
+          {'\n'}
+        </code>
+      </pre>
+      <textarea
+        className="source editor-input"
+        spellCheck={false}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onScroll={(e) => {
+          const pre = preRef.current
+          if (pre) {
+            pre.scrollTop = e.currentTarget.scrollTop
+            pre.scrollLeft = e.currentTarget.scrollLeft
+          }
+        }}
+      />
+    </div>
+  )
+}

--- a/website/src/components/CodeView.tsx
+++ b/website/src/components/CodeView.tsx
@@ -1,16 +1,7 @@
 import { useMemo } from 'react'
 import type { Lang } from '../ablators/types'
-import { highlight } from '../lib/highlight'
+import { highlight, TOK_CLASS as CLS } from '../lib/highlight'
 import { CopyButton } from './CopyButton'
-
-const CLS: Record<string, string> = {
-  comment: 'tok-comment',
-  string: 'tok-string',
-  keyword: 'tok-keyword',
-  hole: 'tok-hole',
-  name: 'tok-name',
-  plain: '',
-}
 
 export function CodeView({ lang, code }: { lang: Lang; code: string }) {
   const toks = useMemo(() => highlight(lang, code), [lang, code])

--- a/website/src/lib/afp.ts
+++ b/website/src/lib/afp.ts
@@ -1,0 +1,53 @@
+// AFP entry importer (issue #113). Fetches a curated, version-pinned set of
+// Archive of Formal Proofs theories that we pre-mirror into a world-readable DO
+// Space (see `website/scripts/mirror-afp.py`). isa-afp.org itself sends no
+// permissive CORS, so a pure-static site can't read it directly — the mirror
+// bucket is CORS-enabled and controlled by us, keeping this a static deploy.
+
+/** Base URL of the mirror prefix (no trailing slash). Overridable for a
+ *  different bucket/CDN via a *non-secret* build env var; reads are anonymous. */
+export const AFP_BASE: string =
+  import.meta.env.VITE_AFP_BASE_URL ??
+  'https://forall-git-evals.nyc3.digitaloceanspaces.com/afp'
+
+export interface AfpTheory {
+  file: string // e.g. "Regular_Set.thy"
+  key: string // object key within the bucket
+  url: string // absolute public URL
+  bytes: number
+}
+
+export interface AfpEntry {
+  name: string // AFP entry short name, e.g. "Regular-Sets"
+  afp_url: string // human-facing entry page on isa-afp.org
+  theories: AfpTheory[]
+}
+
+export interface AfpIndex {
+  schema: string
+  base_url: string
+  source: string
+  entries: AfpEntry[]
+}
+
+/** Fetch the mirror manifest. Throws with a friendly message on failure. */
+export async function fetchAfpIndex(): Promise<AfpIndex> {
+  const url = `${AFP_BASE}/index.json`
+  let res: Response
+  try {
+    res = await fetch(url, { mode: 'cors' })
+  } catch (e) {
+    throw new Error(`Could not reach the AFP mirror (${url}). ${(e as Error).message}`, { cause: e })
+  }
+  if (!res.ok) throw new Error(`AFP mirror index HTTP ${res.status} (${url})`)
+  const idx = (await res.json()) as AfpIndex
+  if (!idx || !Array.isArray(idx.entries)) throw new Error('AFP mirror index is malformed')
+  return idx
+}
+
+/** Fetch one theory's raw `.thy` source. */
+export async function fetchAfpTheory(theory: AfpTheory): Promise<string> {
+  const res = await fetch(theory.url, { mode: 'cors' })
+  if (!res.ok) throw new Error(`AFP theory HTTP ${res.status} (${theory.file})`)
+  return res.text()
+}

--- a/website/src/lib/afp.ts
+++ b/website/src/lib/afp.ts
@@ -1,8 +1,8 @@
-// AFP entry importer (issue #113). Fetches a curated, version-pinned set of
-// Archive of Formal Proofs theories that we pre-mirror into a world-readable DO
-// Space (see `website/scripts/mirror-afp.py`). isa-afp.org itself sends no
-// permissive CORS, so a pure-static site can't read it directly — the mirror
-// bucket is CORS-enabled and controlled by us, keeping this a static deploy.
+// AFP entry importer (issue #113). The full Archive of Formal Proofs is
+// pre-mirrored into a world-readable DO Space (see `website/scripts/mirror-afp.py`)
+// because isa-afp.org sends no permissive CORS. The manifest is split so the
+// site loads fast: a lightweight `index.json` (entry names + counts) up front,
+// then a per-entry `<Entry>/theories.json` fetched lazily on selection.
 
 /** Base URL of the mirror prefix (no trailing slash). Overridable for a
  *  different bucket/CDN via a *non-secret* build env var; reads are anonymous. */
@@ -17,32 +17,44 @@ export interface AfpTheory {
   bytes: number
 }
 
+/** Lightweight per-entry record in index.json (no theory list — that's lazy). */
 export interface AfpEntry {
   name: string // AFP entry short name, e.g. "Regular-Sets"
+  n_theories: number
   afp_url: string // human-facing entry page on isa-afp.org
-  theories: AfpTheory[]
 }
 
 export interface AfpIndex {
   schema: string
   base_url: string
   source: string
+  release: string
   entries: AfpEntry[]
 }
 
-/** Fetch the mirror manifest. Throws with a friendly message on failure. */
-export async function fetchAfpIndex(): Promise<AfpIndex> {
-  const url = `${AFP_BASE}/index.json`
+async function getJson<T>(url: string, what: string): Promise<T> {
   let res: Response
   try {
     res = await fetch(url, { mode: 'cors' })
   } catch (e) {
     throw new Error(`Could not reach the AFP mirror (${url}). ${(e as Error).message}`, { cause: e })
   }
-  if (!res.ok) throw new Error(`AFP mirror index HTTP ${res.status} (${url})`)
-  const idx = (await res.json()) as AfpIndex
+  if (!res.ok) throw new Error(`${what} HTTP ${res.status} (${url})`)
+  return (await res.json()) as T
+}
+
+/** Fetch the lightweight manifest listing all mirrored entries. */
+export async function fetchAfpIndex(): Promise<AfpIndex> {
+  const idx = await getJson<AfpIndex>(`${AFP_BASE}/index.json`, 'AFP mirror index')
   if (!idx || !Array.isArray(idx.entries)) throw new Error('AFP mirror index is malformed')
   return idx
+}
+
+/** Fetch one entry's theory list (lazy shard). */
+export async function fetchAfpEntryTheories(entryName: string): Promise<AfpTheory[]> {
+  const url = `${AFP_BASE}/${encodeURIComponent(entryName)}/theories.json`
+  const shard = await getJson<{ name: string; theories: AfpTheory[] }>(url, 'AFP entry')
+  return Array.isArray(shard?.theories) ? shard.theories : []
 }
 
 /** Fetch one theory's raw `.thy` source. */

--- a/website/src/lib/highlight.ts
+++ b/website/src/lib/highlight.ts
@@ -18,6 +18,16 @@ export interface Tok {
   text: string
 }
 
+/** token class -> CSS class (shared by CodeView + CodeEditor). */
+export const TOK_CLASS: Record<TokClass, string> = {
+  comment: 'tok-comment',
+  string: 'tok-string',
+  keyword: 'tok-keyword',
+  hole: 'tok-hole',
+  name: 'tok-name',
+  plain: '',
+}
+
 const KEYWORDS: Record<Lang, Set<string>> = {
   lean: new Set([
     'theorem', 'lemma', 'def', 'abbrev', 'instance', 'example', 'namespace', 'end',


### PR DESCRIPTION
Closes #113.

Adds an **Import AFP entry** control to the ablation playground (`website/`) that
loads a real [Archive of Formal Proofs](https://www.isa-afp.org/) theory into the
Isabelle source pane. The existing in-browser Isabelle WASM ablator runs unchanged.

## Summary

**Approach — static + full mirror.** isa-afp.org sends no permissive CORS, so a
pure-static site can't fetch it directly. Instead we **pre-mirror the entire AFP**,
version-pinned, into our world-readable DO Space (`forall-git-evals`) and fetch
raw `.thy` text client-side. Keeps the Vercel deploy **fully static — no server,
and no DO credentials on Vercel** (reads are anonymous; objects are public-read).

- **Mirror:** `afp-2026-07-07` release — **1000 entries / ~10.2k theories /
  ~294 MB / 11,242 public objects** under `s3://forall-git-evals/afp/`.
- `scripts/mirror-afp.py --full` — downloads the single release tarball once,
  extracts every `.thy`, uploads via parallel `s3cmd` (sharded across entries).
  Curated/per-entry mode retained for quick refreshes.
- **Split manifest** (schema `afp-mirror/2`) so 1000 entries stay light:
  - `afp/index.json` — `{name, n_theories, afp_url}` per entry (~90 KB), loaded
    once when the panel opens.
  - `afp/<Entry>/theories.json` — per-entry theory list, fetched lazily on select.
- `src/lib/afp.ts` — index + lazy shard + theory fetch; `VITE_AFP_BASE_URL`
  (non-secret) overrides the base URL.
- `App.tsx` / `App.css` — searchable `<datalist>` entry combobox over 1000
  entries → lazy theory load (cached) → `setSource` (forces Isabelle), with an
  AFP entry-page link for provenance.

## UX fixes bundled in

- **Theory selection persists** across live setting tweaks (was a hardcoded
  `value=""` that reset the dropdown to its placeholder on every re-render).
- **"Generate" → "↻ Random"** — clarifies it re-rolls the seed; everything else
  updates live.
- **Difficulty presets L0–L4 now actually change the ablation.** They set
  probability/depth knobs that corollary mode ignores, so a preset now also turns
  corollary mode off (engaging the knobs it configures) and the active preset is
  highlighted. Confirmed on `Regular_Set.thy`: 6/6/6/6/6 before → 7/11/11/13/11.

## Infra state

- Bucket CORS applied (GET/HEAD, any origin) — returns `access-control-allow-origin: *`.
- Index live: `https://forall-git-evals.nyc3.digitaloceanspaces.com/afp/index.json`.

## Test plan

- `cd website && bun run build && bun run lint` — both pass.
- **CORS:** `curl -I -H 'Origin: https://x.vercel.app' \
  https://forall-git-evals.nyc3.digitaloceanspaces.com/afp/index.json` → `access-control-allow-origin: *`.
- **End-to-end (verified, headless):** index → lazy `theories.json` shard → real
  `.thy` → actual Isabelle WASM ablator produces valid challenges with genuine
  lemma deletions, on entries outside the original curated set —
  Abstract-Rewriting (`conversion_sym`), Binomial-Heaps (`empty_iff`), FFT
  (`root_unity`), Group-Ring-Module (283 KB / 354-lemma theory, 37 ablated).
- **UI:** open **Import AFP entry**, type to filter the 1000-entry combobox, pick
  an entry → theory list loads and first theory imports; pick a theory; drag
  difficulty/rate sliders → theory selection persists and ablation updates live;
  **↻ Random** re-rolls; **L0–L4** change the ablated count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)