### PR TITLE
fix(pipeline): make eval sample reproducible via --seed flag

### DIFF
--- a/baselines/tests/test_sample_reproducibility.py
+++ b/baselines/tests/test_sample_reproducibility.py
@@ -1,0 +1,133 @@
+"""Test for reproducibility of sample_disjoint.py across separate processes."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+import tempfile
+import hashlib
+
+# Add pipeline to path
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+PIPELINE_DIR = REPO_ROOT / "pipeline"
+
+
+def test_sample_disjoint_seed_reproducibility() -> None:
+    """
+    Test that the same seed produces byte-identical sample.jsonl across two separate processes.
+    This verifies that the seed-based randomness is properly implemented and not affected by
+    PEP 456 PYTHONHASHSEED randomization.
+    """
+    # Use two temporary directories to simulate independent runs
+    with tempfile.TemporaryDirectory() as tmpdir1:
+        with tempfile.TemporaryDirectory() as tmpdir2:
+            tmpdir1_path = Path(tmpdir1)
+            tmpdir2_path = Path(tmpdir2)
+
+            # Create temporary test data that sample_disjoint.py can use
+            # We need to create artifacts/lean-ablate structure with challenges
+            test_repo_name = "test_repo"
+            artifacts_dir = Path(tmpdir1_path.parent) / "artifacts" / "lean-ablate" / test_repo_name
+            artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+            # Create a sample challenges.jsonl file with 10 test challenges
+            challenges_file = artifacts_dir / "challenges.jsonl"
+            test_challenges = []
+            for i in range(10):
+                test_challenges.append({
+                    "challenge_file_content": f"challenge {i} content to be hashed",
+                    "challenge_id": f"ch_{i}",
+                    "solution_file_content": f"solution {i}",
+                })
+
+            with open(challenges_file, "w") as f:
+                for ch in test_challenges:
+                    f.write(json.dumps(ch) + "\n")
+
+            # Create registry file
+            registry_file = PIPELINE_DIR / "registry_all.tsv"
+            # We need to back up the original if it exists
+            registry_backup = None
+            if registry_file.exists():
+                import shutil
+                registry_backup = registry_file.read_text()
+
+            # Create a minimal registry with our test repo
+            with open(registry_file, "w") as f:
+                f.write(f"{test_repo_name}\thttps://test.repo/url\n")
+
+            try:
+                # Run sample_disjoint.py twice with the same seed in separate processes
+                seed = 42
+                out_dir1 = tmpdir1_path / "sample1"
+                out_dir2 = tmpdir2_path / "sample2"
+
+                # First run
+                result1 = subprocess.run(
+                    [
+                        sys.executable,
+                        str(PIPELINE_DIR / "sample_disjoint.py"),
+                        str(out_dir1),
+                        "5",
+                        "--seed",
+                        str(seed),
+                    ],
+                    capture_output=True,
+                    text=True,
+                )
+                assert result1.returncode == 0, f"First run failed: {result1.stderr}"
+
+                # Second run (in a separate process)
+                result2 = subprocess.run(
+                    [
+                        sys.executable,
+                        str(PIPELINE_DIR / "sample_disjoint.py"),
+                        str(out_dir2),
+                        "5",
+                        "--seed",
+                        str(seed),
+                    ],
+                    capture_output=True,
+                    text=True,
+                )
+                assert result2.returncode == 0, f"Second run failed: {result2.stderr}"
+
+                # Read the generated sample.jsonl files
+                sample_file1 = out_dir1 / "sample.jsonl"
+                sample_file2 = out_dir2 / "sample.jsonl"
+
+                assert sample_file1.exists(), f"Sample file 1 not found: {sample_file1}"
+                assert sample_file2.exists(), f"Sample file 2 not found: {sample_file2}"
+
+                # Compare byte-for-byte
+                content1 = sample_file1.read_bytes()
+                content2 = sample_file2.read_bytes()
+
+                assert (
+                    content1 == content2
+                ), f"Sample files differ:\nFile 1 size: {len(content1)}\nFile 2 size: {len(content2)}"
+
+                # Also verify manifest.json contains the seed
+                manifest1 = json.loads((out_dir1 / "manifest.json").read_text())
+                manifest2 = json.loads((out_dir2 / "manifest.json").read_text())
+
+                for entry in manifest1:
+                    assert "seed" in entry, f"Seed not found in manifest entry: {entry}"
+                    assert entry["seed"] == seed, f"Seed mismatch in manifest1: {entry['seed']} != {seed}"
+
+                for entry in manifest2:
+                    assert "seed" in entry, f"Seed not found in manifest entry: {entry}"
+                    assert entry["seed"] == seed, f"Seed mismatch in manifest2: {entry['seed']} != {seed}"
+
+            finally:
+                # Restore registry file
+                if registry_backup is not None:
+                    with open(registry_file, "w") as f:
+                        f.write(registry_backup)
+                elif registry_file.exists():
+                    registry_file.unlink()
+
+                # Clean up artifacts
+                if artifacts_dir.exists():
+                    import shutil
+                    shutil.rmtree(artifacts_dir.parent)

--- a/pipeline/run.sh
+++ b/pipeline/run.sh
@@ -74,7 +74,7 @@ stage_validate() {
 stage_eval() {
   local S="$1" n="${2:-100}" model="${3:-$MODEL_DEFAULT}"
   say "sample A (n=$n) -> $model, max-turns $TURNS"
-  python3 pipeline/sample_disjoint.py "$S/evalA" "$n"
+  python3 pipeline/sample_disjoint.py "$S/evalA" "$n" --seed 42
   bash pipeline/eval_sample.sh "$S/evalA" "$model" "$TURNS" 8
   cat "$S"/evalA/res_*.jsonl > "$S/evalA/results.jsonl" 2>/dev/null
 
@@ -84,7 +84,7 @@ stage_eval() {
   ( cd baselines && uv run difficulty train "$S/evalA/table.jsonl" --out "$S/model.joblib" )
 
   say "sample B (n=$n, disjoint) -> score FIRST, then solve"
-  python3 pipeline/sample_disjoint.py "$S/evalB" "$n" --exclude "$S/evalA/sample.jsonl"
+  python3 pipeline/sample_disjoint.py "$S/evalB" "$n" --exclude "$S/evalA/sample.jsonl" --seed 43
   ( cd baselines && uv run difficulty score "$S/evalB/sample.jsonl" --model "$S/model.joblib" \
       --out-jsonl "$S/evalB/scored.jsonl" )
   bash pipeline/eval_sample.sh "$S/evalB" "$model" "$TURNS" 8

--- a/pipeline/sample_disjoint.py
+++ b/pipeline/sample_disjoint.py
@@ -7,7 +7,7 @@ the shortfall is made up 1-at-a-time from the repos with the FEWEST remaining pr
 Dedup is on the challenge TEXT, not `challenge_id`: an earlier ablator shipped byte-identical
 challenges under different ids, which silently leaked problems across a train/test split.
 
-Usage: sample_disjoint.py <out-dir> <n> [--exclude <other-sample.jsonl> ...]
+Usage: sample_disjoint.py <out-dir> <n> [--exclude <other-sample.jsonl> ...] [--seed <seed>]
 """
 
 from __future__ import annotations
@@ -32,11 +32,18 @@ def main() -> None:
     out_dir = sys.argv[1]
     n_target = int(sys.argv[2])
     excluded: set[str] = set()
+    seed = 42  # Default seed
+
+    # Parse optional arguments
     if "--exclude" in sys.argv:
         for p in sys.argv[sys.argv.index("--exclude") + 1 :]:
             if p.startswith("--"):
                 break
             excluded |= {h(json.loads(line)) for line in open(p) if line.strip()}
+
+    if "--seed" in sys.argv:
+        seed_idx = sys.argv.index("--seed")
+        seed = int(sys.argv[seed_idx + 1])
 
     reg = dict(
         line.rstrip("\n").split("\t")
@@ -80,11 +87,11 @@ def main() -> None:
         if not k:
             continue
         rows = pool[repo][:]
-        random.Random(hash(out_dir) & 0xFFFF).shuffle(rows)
+        random.Random(seed).shuffle(rows)
         pick = rows[:k]
         with open(f"{out_dir}/{repo}.jsonl", "w") as f:
             f.writelines(pick)
-        manifest.append({"repo": repo, "n": len(pick), "src": reg[repo]})
+        manifest.append({"repo": repo, "n": len(pick), "src": reg[repo], "seed": seed})
         n += len(pick)
     json.dump(manifest, open(f"{out_dir}/manifest.json", "w"), indent=1)
     with open(f"{out_dir}/sample.jsonl", "w") as out:


### PR DESCRIPTION
## Summary

Replace PYTHONHASHSEED-dependent `hash(out_dir)` seeding with explicit `--seed` flag (default 42). This ensures eval samples are reproducible across runs without requiring environment variables.

- Add `--seed` CLI argument to `pipeline/sample_disjoint.py` (default 42)
- Record seed in emitted `manifest.json` for each sample
- Thread `--seed` through `pipeline/run.sh` eval command (42 for evalA, 43 for evalB)
- Add cross-process reproducibility test

Fixes: #120

## Test plan

- [x] Syntax validation of modified Python files
- [x] Test file created with subprocess-based reproducibility check
- [ ] Full test suite (pending uv run pytest completion)
- [ ] Manual verification of seed recording in manifest.json