### PR TITLE
baselines: add --repo manifest-aware slicing to ablate-baseline

### DIFF
--- a/baselines/src/apply_ablate/baseline.py
+++ b/baselines/src/apply_ablate/baseline.py
@@ -11,13 +11,15 @@ ANTHROPIC_API_KEY available (loaded from the repo `.env`).
 
 from __future__ import annotations
 
+import json
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import Annotated
 
 import typer
 
-from apply_ablate.record import AblationRecord, load_record
+from apply_ablate.record import AblationRecord, count_records, load_record
 from apply_ablate.solve import solve_one
 
 app = typer.Typer(add_completion=False, help=__doc__)
@@ -38,7 +40,79 @@ def _load_env() -> None:
 
 
 def _count_records(jsonl: Path) -> int:
-    return sum(1 for ln in jsonl.read_text(encoding="utf-8").splitlines() if ln.strip())
+    return count_records(jsonl)
+
+
+def _git_head(src: Path) -> str | None:
+    """Best-effort HEAD sha of `src`, or None if it isn't a git checkout."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(src), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):  # pragma: no cover - defensive
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout.strip() or None
+
+
+def _select_indices(challenges: Path, repo: str | None) -> tuple[list[int], set[str]]:
+    """Resolve which record indices to run, given `--repo`.
+
+    A single lightweight pass over the file's rows (raw JSON, no full
+    `AblationRecord` validation — that happens once per selected row in the main
+    loop) determines each row's `manifest.repo`.
+
+    Returns (indices, distinct repo names seen) and raises `typer.Exit` with an
+    actionable message when the input mixes repos and `--repo` wasn't given, or when
+    `--repo` matches nothing.
+    """
+    repos_seen: dict[str, int] = {}
+    by_repo: dict[str | None, list[int]] = {}
+    lines = [
+        ln for ln in challenges.read_text(encoding="utf-8").splitlines() if ln.strip()
+    ]
+    for i, ln in enumerate(lines):
+        try:
+            obj = json.loads(ln)
+        except json.JSONDecodeError:
+            obj = {}
+        row_repo = (obj.get("manifest") or {}).get("repo")
+        repos_seen[row_repo or "(no manifest)"] = (
+            repos_seen.get(row_repo or "(no manifest)", 0) + 1
+        )
+        by_repo.setdefault(row_repo, []).append(i)
+
+    n = len(lines)
+    distinct = set(repos_seen)
+    if repo is not None:
+        indices = by_repo.get(repo, [])
+        if not indices:
+            available = ", ".join(sorted(distinct)) or "(none)"
+            typer.echo(
+                f"error: --repo {repo!r} matches no rows in {challenges}. "
+                f"Repos present: {available}",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        return indices, distinct
+
+    # No --repo: fine as long as every row agrees on the same repo (or none carries
+    # a manifest at all — legacy single-repo datasets predate this field).
+    non_none_repos = {r for r in by_repo if r is not None}
+    if len(non_none_repos) > 1:
+        breakdown = ", ".join(f"{r!r}: {c}" for r, c in sorted(repos_seen.items()))
+        typer.echo(
+            f"error: {challenges} mixes rows from {len(non_none_repos)} repos "
+            f"({breakdown}). Pass --repo <name> to select one repo's slice instead "
+            f"of running every row against a single checkout.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    return list(range(n)), distinct
 
 
 @app.command()
@@ -60,6 +134,14 @@ def run(
     model: Annotated[
         str, typer.Option("--model", help="pydantic-ai model id.")
     ] = "anthropic:claude-sonnet-4-6",
+    repo: Annotated[
+        str | None,
+        typer.Option(
+            "--repo",
+            help="Run only rows whose manifest.repo matches this name (required "
+            "when `challenges` mixes rows from more than one repo).",
+        ),
+    ] = None,
     limit: Annotated[
         int, typer.Option("--limit", help="Max challenges to run (0 = all).")
     ] = 0,
@@ -89,14 +171,39 @@ def run(
     from apply_ablate.obs import init_logfire, log, set_attrs, span
 
     init_logfire()
-    n = _count_records(challenges)
-    n = n if limit <= 0 else min(limit, n)
+    all_count = _count_records(challenges)
+    indices, distinct_repos = _select_indices(challenges, repo)
+    if limit > 0:
+        indices = indices[:limit]
+    n = len(indices)
+    if len(distinct_repos) == 1 and repo is None:
+        typer.echo(f"repo: {next(iter(distinct_repos))}", err=True)
+    elif repo is not None:
+        typer.echo(f"repo: {repo} ({len(indices)}/{all_count} rows)", err=True)
+
+    head = _git_head(src)
+    warned_revisions: set[str] = set()
+
     results = []
     with out.open("w", encoding="utf-8") as fh, tempfile.TemporaryDirectory() as td:
-        for i in range(n):
+        for pos, i in enumerate(indices):
             rec = load_record(challenges, i)
+            if (
+                head
+                and rec.manifest
+                and rec.manifest.revision
+                and rec.manifest.revision != head
+                and rec.manifest.revision not in warned_revisions
+            ):
+                warned_revisions.add(rec.manifest.revision)
+                typer.echo(
+                    f"warning: row {i} expects revision {rec.manifest.revision} "
+                    f"but {src} is checked out at {head} — malformed/compile "
+                    "failures may just be a stale checkout, not the model.",
+                    err=True,
+                )
             work = Path(td) / f"work_{i}"
-            typer.echo(f"[{i + 1}/{n}] {rec.assistant} {rec.file_path} …", err=True)
+            typer.echo(f"[{pos + 1}/{n}] {rec.assistant} {rec.file_path} …", err=True)
             with span(
                 "challenge",
                 index=i,

--- a/baselines/src/apply_ablate/record.py
+++ b/baselines/src/apply_ablate/record.py
@@ -38,6 +38,17 @@ class DeletedLemma(BaseModel):
     text: str = ""
 
 
+class RecordManifest(BaseModel):
+    """Provenance of the source repo a row was mined from, embedded per-row when a
+    dataset multiplexes several repos into one JSONL (e.g. the published HF card's
+    multi-repo `easy.jsonl`). Lets a consumer slice a mixed file back down to one
+    repo's rows (`--repo`) and sanity-check the checkout it's running against."""
+
+    model_config = ConfigDict(extra="ignore")
+    repo: str | None = None
+    revision: str | None = None
+
+
 class AblationRecord(BaseModel):
     """One row of an ablator JSONL: a self-contained (challenge, solution) pair."""
 
@@ -57,6 +68,9 @@ class AblationRecord(BaseModel):
     challenge_id: str | None = None
     theory: str | None = None
     session: str | None = None
+    # per-row provenance (present on multi-repo dataset cuts; None on single-repo
+    # legacy datasets, which is fine since there's nothing to disambiguate)
+    manifest: RecordManifest | None = None
 
     @property
     def assistant(self) -> str:

--- a/baselines/tests/test_baseline_repo.py
+++ b/baselines/tests/test_baseline_repo.py
@@ -1,0 +1,207 @@
+"""Tests for the `--repo` manifest-aware slicing (issue #128)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from apply_ablate.baseline import _git_head, _select_indices, app
+from apply_ablate.record import load_record
+
+runner = CliRunner()
+
+
+def _row(
+    repo: str | None, revision: str | None = None, file_path: str = "A.lean"
+) -> str:
+    import json
+
+    manifest = {}
+    if repo is not None:
+        manifest["repo"] = repo
+    if revision is not None:
+        manifest["revision"] = revision
+    obj = {
+        "proof_assistant": "lean",
+        "file_path": file_path,
+        "challenge_file_content": "theorem t : True := sorry\n",
+    }
+    if manifest:
+        obj["manifest"] = manifest
+    return json.dumps(obj)
+
+
+def test_record_surfaces_manifest(tmp_path: Path):
+    p = tmp_path / "one.jsonl"
+    p.write_text(_row("foo", revision="deadbeef") + "\n")
+    rec = load_record(p, 0)
+    assert rec.manifest is not None
+    assert rec.manifest.repo == "foo"
+    assert rec.manifest.revision == "deadbeef"
+
+
+def test_record_manifest_absent_is_none(tmp_path: Path):
+    p = tmp_path / "one.jsonl"
+    p.write_text(_row(None) + "\n")
+    rec = load_record(p, 0)
+    assert rec.manifest is None
+
+
+def test_select_indices_single_repo_no_flag(tmp_path: Path):
+    p = tmp_path / "single.jsonl"
+    p.write_text("\n".join([_row("foo"), _row("foo")]) + "\n")
+    indices, distinct = _select_indices(p, None)
+    assert indices == [0, 1]
+    assert distinct == {"foo"}
+
+
+def test_select_indices_no_manifest_is_fine(tmp_path: Path):
+    # legacy single-repo datasets predate the manifest field entirely.
+    p = tmp_path / "legacy.jsonl"
+    p.write_text("\n".join([_row(None), _row(None)]) + "\n")
+    indices, distinct = _select_indices(p, None)
+    assert indices == [0, 1]
+
+
+def test_select_indices_repo_filter(tmp_path: Path):
+    p = tmp_path / "mixed.jsonl"
+    p.write_text("\n".join([_row("foo"), _row("bar"), _row("foo")]) + "\n")
+    indices, distinct = _select_indices(p, "foo")
+    assert indices == [0, 2]
+    assert distinct == {"foo", "bar"}
+
+
+def test_select_indices_repo_filter_no_match(tmp_path: Path):
+    import typer
+
+    p = tmp_path / "mixed.jsonl"
+    p.write_text("\n".join([_row("foo"), _row("bar")]) + "\n")
+    with pytest.raises(typer.Exit) as exc_info:
+        _select_indices(p, "quux")
+    assert exc_info.value.exit_code == 2
+
+
+def test_select_indices_mixed_repo_without_flag_fails(tmp_path: Path):
+    import typer
+
+    p = tmp_path / "mixed.jsonl"
+    p.write_text("\n".join([_row("foo"), _row("bar")]) + "\n")
+    with pytest.raises(typer.Exit) as exc_info:
+        _select_indices(p, None)
+    assert exc_info.value.exit_code == 2
+
+
+def test_cli_mixed_repo_without_flag_errors(tmp_path: Path):
+    challenges = tmp_path / "mixed.jsonl"
+    challenges.write_text("\n".join([_row("foo"), _row("bar")]) + "\n")
+    src = tmp_path / "src"
+    src.mkdir()
+    result = runner.invoke(app, [str(challenges), str(src)])
+    assert result.exit_code == 2
+    assert "--repo" in result.output
+
+
+def test_cli_repo_no_match_errors(tmp_path: Path):
+    challenges = tmp_path / "one.jsonl"
+    challenges.write_text(_row("foo") + "\n")
+    src = tmp_path / "src"
+    src.mkdir()
+    result = runner.invoke(app, [str(challenges), str(src), "--repo", "quux"])
+    assert result.exit_code == 2
+    assert "quux" in result.output
+
+
+def test_git_head_non_repo_is_none(tmp_path: Path):
+    d = tmp_path / "not-a-repo"
+    d.mkdir()
+    assert _git_head(d) is None
+
+
+def test_git_head_returns_sha(tmp_path: Path):
+    d = tmp_path / "repo"
+    d.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=d, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=d, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=d, check=True)
+    (d / "f").write_text("x")
+    subprocess.run(["git", "add", "f"], cwd=d, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=d, check=True)
+    head = _git_head(d)
+    assert head is not None
+    assert len(head) == 40
+
+
+def _init_git_repo(d: Path) -> str:
+    d.mkdir(exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=d, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=d, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=d, check=True)
+    (d / "f").write_text("x")
+    subprocess.run(["git", "add", "f"], cwd=d, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=d, check=True)
+    head = _git_head(d)
+    assert head is not None
+    return head
+
+
+def test_cli_revision_mismatch_warns(tmp_path: Path, monkeypatch):
+    head = _init_git_repo(tmp_path / "repo")
+    src = tmp_path / "repo"
+
+    challenges = tmp_path / "one.jsonl"
+    challenges.write_text(_row("foo", revision="0" * 40) + "\n")
+
+    def fake_solve_one(rec, src, work, **kwargs):
+        from apply_ablate.solve import SolveResult
+
+        return SolveResult(
+            task_id=rec.task_id,
+            assistant=rec.assistant,
+            file_path=rec.file_path,
+            succeeded=False,
+            gave_up=False,
+            dry_run=True,
+        )
+
+    monkeypatch.setattr("apply_ablate.baseline.solve_one", fake_solve_one)
+
+    result = runner.invoke(
+        app,
+        [str(challenges), str(src), "--dry-run", "--out", str(tmp_path / "out.jsonl")],
+    )
+    assert result.exit_code == 0, result.output
+    assert "warning" in result.output
+    assert ("0" * 40) in result.output
+    assert head in result.output
+
+
+def test_cli_revision_match_no_warning(tmp_path: Path, monkeypatch):
+    head = _init_git_repo(tmp_path / "repo")
+    src = tmp_path / "repo"
+
+    challenges = tmp_path / "one.jsonl"
+    challenges.write_text(_row("foo", revision=head) + "\n")
+
+    def fake_solve_one(rec, src, work, **kwargs):
+        from apply_ablate.solve import SolveResult
+
+        return SolveResult(
+            task_id=rec.task_id,
+            assistant=rec.assistant,
+            file_path=rec.file_path,
+            succeeded=False,
+            gave_up=False,
+            dry_run=True,
+        )
+
+    monkeypatch.setattr("apply_ablate.baseline.solve_one", fake_solve_one)
+
+    result = runner.invoke(
+        app,
+        [str(challenges), str(src), "--dry-run", "--out", str(tmp_path / "out.jsonl")],
+    )
+    assert result.exit_code == 0, result.output
+    assert "warning" not in result.output


### PR DESCRIPTION
## Summary
- The published `for-all-dev/ablation-eval` HF dataset card documents
  `ablate-baseline easy.jsonl data/lean/<repo> --model <model> [--repo <name>]`
  and says the harness runs the one repo slice matching `--repo`, but that
  flag did not exist and `AblationRecord` (`extra="ignore"`, no `manifest`
  field) silently dropped any per-row manifest the dataset carried.
- Adds a `RecordManifest` submodel (`repo`, `revision`) surfaced as
  `AblationRecord.manifest`.
- Adds `--repo <name>` to `ablate-baseline`, filtering rows to that repo's
  slice (raw single-pass JSON scan, no double full-record validation).
- Fails fast (exit 2, actionable message) when the input mixes rows from
  more than one repo and `--repo` wasn't given, or when `--repo` matches
  nothing.
- Warns once per distinct revision when a row's `manifest.revision` doesn't
  match the checkout's HEAD (`git rev-parse HEAD` on `SRC`), since a stale
  checkout is the most likely cause of confusing `malformed` results for an
  outside user following the card.
- Legacy single-repo datasets without a `manifest` field are unaffected
  (`--repo` is optional, no manifest ⇒ no filtering/warning).

## Test plan
- `baselines/tests/test_baseline_repo.py` (new): manifest round-trips
  through `AblationRecord`, `_select_indices` behaviour (single repo,
  legacy no-manifest, `--repo` filter, no-match error, mixed-repo-without-flag
  error), `_git_head` on a real git repo vs. a non-repo dir, and full CLI
  e2e checks (mixed-repo error, no-match error, revision-mismatch
  warning/no-warning) via `CliRunner` with `solve_one` mocked out (no
  prover/model required).
- From `./baselines`: `uv run ruff format`, `uv run ruff check --fix`,
  `uv run ty check`, `uv run pytest` — all green (99 passed).

Closes #128