### PR TITLE
pipeline: thread ablation mode through sample_disjoint.py and eval_sample.sh

### DIFF
--- a/pipeline/eval_sample.sh
+++ b/pipeline/eval_sample.sh
@@ -1,16 +1,49 @@
 #!/usr/bin/env bash
 # Run the agentic baseline over a per-repo sample. `ablate-baseline` takes ONE src tree per
 # invocation, so the sample is grouped by repo and each group runs against its own checkout.
-# Usage: eval_sample.sh <eval-dir> <model> [max_turns] [parallel_repos]
+# Usage: eval_sample.sh <eval-dir> <model> [max_turns] [parallel_repos] [--mode {leaves,whole}]
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-E="$1"; MODEL="$2"; TURNS="${3:-30}"; P="${4:-6}"
-export E MODEL TURNS ROOT
+
+E_RAW="$1"; MODEL="$2"; TURNS="${3:-30}"; P="${4:-6}"
+MODE=leaves
+if [ "${5:-}" = "--mode" ]; then
+  MODE="${6:?--mode requires a value}"
+fi
+
+# We `cd` into baselines/ below, so a relative $E would resolve against the wrong directory and
+# silently break. Resolve it to an absolute path up front, or fail loudly.
+case "$E_RAW" in
+  /*) E="$E_RAW" ;;
+  *)
+    if [ -d "$E_RAW" ]; then
+      E="$(cd "$E_RAW" && pwd)"
+    else
+      echo "error: eval-dir '$E_RAW' is a relative path that does not exist yet" \
+           "(sample_disjoint.py must create it first, or pass an absolute path)" >&2
+      exit 2
+    fi
+    ;;
+esac
+
+export E MODEL TURNS ROOT MODE
 run_one() {   # $1 = "<repo> <src>"
   local repo src
   repo="${1%% *}"; src="${1##* }"
   ( cd "$ROOT/baselines" && uv run ablate-baseline "$E/$repo.jsonl" "$ROOT/$src" \
       --model "$MODEL" --max-turns "$TURNS" --out "$E/res_$repo.jsonl" ) > "$E/log_$repo.txt" 2>&1
+  # tag each result row with the ablation mode, so downstream results are self-describing
+  if [ -s "$E/res_$repo.jsonl" ]; then
+    python3 -c "
+import json
+rows = [json.loads(l) for l in open('$E/res_$repo.jsonl') if l.strip()]
+for r in rows:
+    r['sample_mode'] = '$MODE'
+with open('$E/res_$repo.jsonl', 'w') as f:
+    for r in rows:
+        f.write(json.dumps(r) + '\n')
+"
+  fi
   echo "done $repo ($(grep -c . "$E/res_$repo.jsonl" 2>/dev/null || echo 0) results)"
 }
 export -f run_one
@@ -19,4 +52,4 @@ import json
 for m in json.load(open('$E/manifest.json')): print(m['repo'], m['src'])
 " | xargs -d'\n' -P "$P" -I{} bash -c 'run_one "$@"' _ {}
 cat "$E"/res_*.jsonl > "$E/results.jsonl" 2>/dev/null
-echo "EVAL DONE: $(grep -c . "$E/results.jsonl") results"
+echo "EVAL DONE: $(grep -c . "$E/results.jsonl") results (mode=$MODE)"

--- a/pipeline/run.sh
+++ b/pipeline/run.sh
@@ -4,8 +4,10 @@
 #   run.sh mine     <scratch> [leaves|whole]   ablate every repo (syntactic — no build needed)
 #   run.sh validate <scratch> [leaves|whole]   compile challenge + ground truth; write artifacts
 #   run.sh index    <scratch>                  regenerate artifacts/.../_index.json
-#   run.sh eval     <scratch> <n> [model]      sample n, run the solver, train + test the
-#                                              difficulty model on a disjoint second sample
+#   run.sh eval     <scratch> <n> [model] [--mode leaves|whole]
+#                                              sample n from the given split (default leaves),
+#                                              run the solver, train + test the difficulty model
+#                                              on a disjoint second sample
 #   run.sh all      <scratch>                  mine -> validate -> index -> eval (both modes)
 #
 # Repos come from `repos.tsv` (name, language, url, revision, path, toolchain) — the single
@@ -72,45 +74,69 @@ stage_validate() {
 # the first by challenge TEXT (not challenge_id — an earlier ablator shipped byte-identical
 # challenges under different ids, which leaked problems across the split).
 stage_eval() {
-  local S="$1" n="${2:-100}" model="${3:-$MODEL_DEFAULT}"
-  say "sample A (n=$n) -> $model, max-turns $TURNS"
-  python3 pipeline/sample_disjoint.py "$S/evalA" "$n" --seed 42
-  bash pipeline/eval_sample.sh "$S/evalA" "$model" "$TURNS" 8
-  cat "$S"/evalA/res_*.jsonl > "$S/evalA/results.jsonl" 2>/dev/null
+  local S="$1" n="${2:-100}" model="${3:-$MODEL_DEFAULT}" mode="${4:-leaves}"
+  # leaves is the pre-#125 default, so it keeps the original evalA/evalB dir names for
+  # backwards compatibility; whole (and any future split) gets its own namespace.
+  local sub=""; [ "$mode" != leaves ] && sub="_$mode"
+  local A="$S/evalA$sub" B="$S/evalB$sub" model_out="$S/model$sub.joblib"
+
+  say "sample A (n=$n, mode=$mode) -> $model, max-turns $TURNS"
+  python3 pipeline/sample_disjoint.py "$A" "$n" --seed 42 --mode "$mode"
+  bash pipeline/eval_sample.sh "$A" "$model" "$TURNS" 8 --mode "$mode"
+  cat "$A"/res_*.jsonl > "$A/results.jsonl" 2>/dev/null
 
   say "training the difficulty model on sample A"
-  ( cd baselines && uv run difficulty build-table "$S/evalA/sample.jsonl" "$S/evalA/results.jsonl" \
-      --out-jsonl "$S/evalA/table.jsonl" )
-  ( cd baselines && uv run difficulty train "$S/evalA/table.jsonl" --out "$S/model.joblib" )
+  ( cd baselines && uv run difficulty build-table "$A/sample.jsonl" "$A/results.jsonl" \
+      --out-jsonl "$A/table.jsonl" )
+  ( cd baselines && uv run difficulty train "$A/table.jsonl" --out "$model_out" )
 
-  say "sample B (n=$n, disjoint) -> score FIRST, then solve"
-  python3 pipeline/sample_disjoint.py "$S/evalB" "$n" --exclude "$S/evalA/sample.jsonl" --seed 43
-  ( cd baselines && uv run difficulty score "$S/evalB/sample.jsonl" --model "$S/model.joblib" \
-      --out-jsonl "$S/evalB/scored.jsonl" )
-  bash pipeline/eval_sample.sh "$S/evalB" "$model" "$TURNS" 8
-  cat "$S"/evalB/res_*.jsonl > "$S/evalB/results.jsonl" 2>/dev/null
+  say "sample B (n=$n, disjoint, mode=$mode) -> score FIRST, then solve"
+  python3 pipeline/sample_disjoint.py "$B" "$n" --exclude "$A/sample.jsonl" --seed 43 --mode "$mode"
+  ( cd baselines && uv run difficulty score "$B/sample.jsonl" --model "$model_out" \
+      --out-jsonl "$B/scored.jsonl" )
+  bash pipeline/eval_sample.sh "$B" "$model" "$TURNS" 8 --mode "$mode"
+  cat "$B"/res_*.jsonl > "$B/results.jsonl" 2>/dev/null
 
   say "held-out discrimination (ROC-AUC) + calibration (Brier)"
-  python3 pipeline/score_predictions.py "$S/evalB/scored.jsonl" "$S/evalB/results.jsonl" \
-    | tee "$S/evalB/metrics.txt"
+  python3 pipeline/score_predictions.py "$B/scored.jsonl" "$B/results.jsonl" \
+    | tee "$B/metrics.txt"
 }
 
 cmd="${1:-}"; S="${2:-}"
 [ -z "$cmd" ] || [ -z "$S" ] && { sed -n '2,12p' "$0"; exit 2; }
 mkdir -p "$S"
 
+# Pull a `--mode <leaves|whole>` flag out of the remaining args wherever it appears (used by
+# `eval`); everything else keeps its original positional meaning.
+MODE=leaves
+rest=("${@:3}")
+filtered=()
+i=0
+while [ $i -lt ${#rest[@]} ]; do
+  if [ "${rest[$i]}" = "--mode" ]; then
+    MODE="${rest[$((i + 1))]:?--mode requires a value}"
+    i=$((i + 2))
+  else
+    filtered+=("${rest[$i]}")
+    i=$((i + 1))
+  fi
+done
+set -- "$cmd" "$S" "${filtered[@]}"
+
 case "$cmd" in
   mine)     stage_mine "$S" "${3:-leaves}" ;;
   validate) stage_validate "$S" "${3:-leaves}" ;;
   index)    python3 pipeline/write_index.py ;;
-  eval)     stage_eval "$S" "${3:-100}" "${4:-$MODEL_DEFAULT}" ;;
+  eval)     stage_eval "$S" "${3:-100}" "${4:-$MODEL_DEFAULT}" "$MODE" ;;
   all)
     for mode in leaves whole; do
       stage_mine "$S" "$mode"
       stage_validate "$S" "$mode"
     done
     python3 pipeline/write_index.py
-    stage_eval "$S" "${3:-100}"
+    for mode in leaves whole; do
+      stage_eval "$S" "${3:-100}" "${4:-$MODEL_DEFAULT}" "$mode"
+    done
     ;;
   *) sed -n '2,12p' "$0"; exit 2 ;;
 esac

--- a/pipeline/sample_disjoint.py
+++ b/pipeline/sample_disjoint.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Draw a per-repo sample from the validated leaf ablations, deduplicated by challenge text.
+"""Draw a per-repo sample from the validated ablations, deduplicated by challenge text.
 
 Allocation: 2 problems from every repo that has >=2; repos with fewer contribute what they have;
 the shortfall is made up 1-at-a-time from the repos with the FEWEST remaining problems first.
@@ -8,6 +8,12 @@ Dedup is on the challenge TEXT, not `challenge_id`: an earlier ablator shipped b
 challenges under different ids, which silently leaked problems across a train/test split.
 
 Usage: sample_disjoint.py <out-dir> <n> [--exclude <other-sample.jsonl> ...] [--seed <seed>]
+                           [--mode {leaves,whole}]
+
+`--mode` selects the artifact pool: `leaves` (default, backwards compatible) draws from
+`artifacts/lean-ablate/*/challenges.jsonl` (the "easy" split); `whole` draws from
+`artifacts/lean-ablate-whole/*/challenges.jsonl` (the "hard" split). Every emitted challenge row
+and the manifest are tagged with `sample_mode` so downstream results are self-describing.
 """
 
 from __future__ import annotations
@@ -23,6 +29,11 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 
+MODE_ARTIFACT_DIR = {
+    "leaves": "artifacts/lean-ablate",
+    "whole": "artifacts/lean-ablate-whole",
+}
+
 
 def h(rec: dict) -> str:
     return hashlib.sha256(rec["challenge_file_content"].encode()).hexdigest()
@@ -33,6 +44,7 @@ def main() -> None:
     n_target = int(sys.argv[2])
     excluded: set[str] = set()
     seed = 42  # Default seed
+    mode = "leaves"  # Default mode: backwards compatible with the pre-#125 leaves-only pool
 
     # Parse optional arguments
     if "--exclude" in sys.argv:
@@ -45,24 +57,38 @@ def main() -> None:
         seed_idx = sys.argv.index("--seed")
         seed = int(sys.argv[seed_idx + 1])
 
+    if "--mode" in sys.argv:
+        mode_idx = sys.argv.index("--mode")
+        mode = sys.argv[mode_idx + 1]
+
+    if mode not in MODE_ARTIFACT_DIR:
+        print(
+            f"error: --mode must be one of {sorted(MODE_ARTIFACT_DIR)}, got {mode!r}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
     reg = dict(
         line.rstrip("\n").split("\t")
         for line in open(ROOT / "pipeline/registry_all.tsv")
         if line.strip()
     )
     pool: dict[str, list[str]] = {}
-    for f in sorted(glob.glob(str(ROOT / "artifacts/lean-ablate/*/challenges.jsonl"))):
+    glob_pattern = str(ROOT / MODE_ARTIFACT_DIR[mode] / "*/challenges.jsonl")
+    for f in sorted(glob.glob(glob_pattern)):
         repo = os.path.basename(os.path.dirname(f))
         seen: set[str] = set()
         rows = []
         for line in open(f):
             if not line.strip():
                 continue
-            k = h(json.loads(line))
+            rec = json.loads(line)
+            k = h(rec)
             if k in excluded or k in seen:
                 continue
             seen.add(k)
-            rows.append(line)
+            rec["sample_mode"] = mode
+            rows.append(json.dumps(rec) + "\n")
         if rows:
             pool[repo] = rows
 
@@ -91,7 +117,9 @@ def main() -> None:
         pick = rows[:k]
         with open(f"{out_dir}/{repo}.jsonl", "w") as f:
             f.writelines(pick)
-        manifest.append({"repo": repo, "n": len(pick), "src": reg[repo], "seed": seed})
+        manifest.append(
+            {"repo": repo, "n": len(pick), "src": reg[repo], "seed": seed, "mode": mode}
+        )
         n += len(pick)
     json.dump(manifest, open(f"{out_dir}/manifest.json", "w"), indent=1)
     with open(f"{out_dir}/sample.jsonl", "w") as out:
@@ -99,7 +127,7 @@ def main() -> None:
             out.writelines(open(f"{out_dir}/{m['repo']}.jsonl").readlines())
     uniq = {h(json.loads(line)) for line in open(f"{out_dir}/sample.jsonl")}
     print(
-        f"sampled {n} problems across {len(manifest)} repos -> {out_dir} "
+        f"sampled {n} problems (mode={mode}) across {len(manifest)} repos -> {out_dir} "
         f"({len(uniq)} unique, {len(uniq & excluded)} overlap with excluded)"
     )
 


### PR DESCRIPTION
## Summary
- Add `--mode {leaves,whole}` to `pipeline/sample_disjoint.py` (default `leaves`, backwards compatible) selecting between the `artifacts/lean-ablate` (easy) and `artifacts/lean-ablate-whole` (hard) pools.
- Tag every emitted sample row (`sample_mode`), manifest entry (`mode`), and eval result row (`sample_mode`, added in `eval_sample.sh`) with the mode, so downstream results are self-describing.
- Thread `--mode` through `pipeline/run.sh eval` (parsed as a flag anywhere after the positional args, defaulting to `leaves`) and `pipeline/eval_sample.sh`. `run.sh all` now evaluates both `leaves` and `whole` splits, matching what it already does for mine/validate. Non-`leaves` modes get their own `evalA_<mode>`/`evalB_<mode>`/`model_<mode>.joblib` namespace under the scratch dir so a `leaves` run's outputs aren't clobbered.
- Harden `pipeline/eval_sample.sh`: it `cd`s into `baselines/` before using `$E`, so a relative `$E` silently broke. It now resolves `$E` to an absolute path up front (if the dir already exists) or fails loudly with a clear error otherwise.

## Test plan
- [x] `bash -n pipeline/run.sh` / `bash -n pipeline/eval_sample.sh` / `python3 -c "import ast; ast.parse(...)"` on `sample_disjoint.py`
- [x] Manual smoke test: fabricated `artifacts/lean-ablate{,-whole}/repoA/challenges.jsonl` pools; `sample_disjoint.py --mode whole` draws only from the whole pool and tags rows/manifest with `mode: "whole"`; default (no `--mode`) still draws from the leaves pool; `--mode bogus` exits 2 with a clear error.
- [x] Manual smoke test: `eval_sample.sh relative/nonexistent-dir some-model` exits 2 with a clear "pass an absolute path" error instead of silently misbehaving.
- [x] From `./baselines`: `uv run ruff format`, `uv run ruff check --fix`, `uv run ty check` (all clean on the changed files; two pre-existing lint findings in files this branch does not touch — `provers/lean.py`, `tests/test_sample_reproducibility.py` — are unchanged from the `dispatch/120-sample-seed` base and out of scope here), `uv run pytest` — 87 passed.

## Depends on
- #120 "make eval sample reproducible via --seed" → branch `dispatch/120-sample-seed` (https://github.com/for-all-dev/git-history-evals/pull/152)

Closes #125