### PR TITLE
baselines: stop lake writing through the .lake overlay symlink

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,9 @@ uv run pytest             # tests
   `./baselines-old/`). Package `apply_ablate`: `solve.py` is a pydantic-ai ReAct loop
   that re-derives the deleted lemma(s) into a compiling, hole-free file; `provers/`
   has the Coq/Isabelle/Lean backends (`coqc`, session-aware `isabelle build` with
-  prebuilt-deps + `skip_proofs`, `lake env lean`); `apply.py` splices a challenge into
+  prebuilt-deps + `skip_proofs`, bare `lean` with a reconstructed `LEAN_PATH` — never
+  `lake env`, which would write through the `.lake` symlink into src, #119);
+  `apply.py` splices a challenge into
   a work copy (symlinking heavy dep dirs like `.lake`); `record.py` is the shared JSONL
   schema; `obs.py` wires Logfire (`instrument_pydantic_ai` + per-compile/per-outcome
   spans). Pre-flight validation marks challenges that don't compile `malformed` and

--- a/baselines/src/apply_ablate/provers/lean.py
+++ b/baselines/src/apply_ablate/provers/lean.py
@@ -1,10 +1,25 @@
-"""Lean backend: `lake build` to prepare, `lake env lean <file>` to check.
+"""Lean backend: `lake build` to prepare (real writes, in-place on the pristine repo
+only), bare `lean` to check (never writes anywhere).
 
-Mirrors `lean-ablator/Main.lean`'s `--check-build` (`checkCompiles`). `lake env lean`
-compiles only the single file against prebuilt `.olean` deps and never its dependents.
-`sorry` always elaborates (with a warning) so a holed challenge compiles cleanly;
-`allow_holes` therefore does not change the command — a recovered solution simply has
-no `sorry` and so must compile warning-or-not at exit 0.
+Mirrors `lean-ablator/Main.lean`'s `--check-build` (`checkCompiles`) for what gets
+compiled. `check` used to run `lake env lean <file>`, but `lake env` elaborates and
+resolves the *workspace* from `cwd` — and `cwd` for a challenge is the symlink-overlay
+work copy built by `apply.overlay_repo`, whose `.lake` is a symlink back to the
+pristine source tree. Lake's git re-clones and compiled-lakefile-config cache writes
+then followed that symlink straight into the shared source tree and corrupted it
+(#119) — three separate build-environment bugs, of which this was the worst, cost the
+corpus ~3,700 valid challenges. Bare `lean <file>` with `LEAN_PATH` set never performs
+git operations, never elaborates a lakefile, and never writes `.lake`, so it is now the
+*only* way `check` invokes the toolchain — there is no write channel left to redirect.
+
+The one thing `lake env` did that bare `lean` cannot reconstruct by globbing
+`.lake/build/lib` is the FFI environment (`LEAN_CC`, `LD_LIBRARY_PATH`, …) that a
+package with a C build step (e.g. hex-dev) needs. `prepare` snapshots
+`lake env printenv` once per repo — keyed by the *pristine* root, so an overlay work
+copy of the same repo shares the snapshot rather than re-invoking lake — and `check`
+reuses it. The snapshot command carries `--no-build` so that even this one remaining
+`lake env` call fails fast instead of starting a build or clone if the config is stale;
+it degrades to a bare `LEAN_PATH` (no FFI vars) rather than writing anything.
 """
 
 from __future__ import annotations
@@ -15,12 +30,6 @@ from pathlib import Path
 from apply_ablate.provers.base import CheckResult, run
 
 _LAKEFILES = ("lakefile.toml", "lakefile.lean")
-
-# Substring `lake env lean` prints when it refuses to run because the package
-# configuration is stale/unbuildable (e.g. a `lakefile.lean` whose default target
-# includes a C-FFI test exe that won't link in this environment — lean-zip). The
-# library oleans are fine, so we fall back to invoking `lean` directly.
-_INVALID_CONFIG = "compiled configuration is invalid"
 
 
 def _lean_path(root: Path) -> str:
@@ -45,30 +54,75 @@ def _lake_root(start: Path) -> Path:
     return here
 
 
+def _canonical_root(root: Path) -> Path:
+    """Resolve `root` to the physical directory its lakefile actually lives in.
+
+    In an overlay work copy the lakefile is a symlink back to the pristine source, so
+    `root` (a path under the overlay) and the pristine repo's own root are two distinct
+    `Path`s that name the same package. Resolving through the lakefile normalises both
+    to one key, so `prepare(src)` and `check(overlay)` share a single env snapshot.
+    """
+    for name in _LAKEFILES:
+        p = root / name
+        if p.exists():
+            return p.resolve().parent
+    return root.resolve()
+
+
+def _snapshot_lake_env(root: Path, *, timeout: int) -> dict[str, str] | None:
+    """One read-only capture of `lake env`'s exports (`KEY=value` lines from the real
+    `printenv`). `--no-build` makes lake exit immediately rather than build/clone if the
+    config is stale, so this can never become another write channel; a failure just
+    means no snapshot (callers fall back to a bare `LEAN_PATH`)."""
+    res = run(["lake", "--no-build", "env", "printenv"], cwd=root, timeout=timeout)
+    if not res.ok:
+        return None
+    env: dict[str, str] = {}
+    for line in res.stdout.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            env[key] = value
+    return env or None
+
+
 class LeanProver:
     key = "lean"
 
+    def __init__(self) -> None:
+        # Per-instance (the registry holds one LeanProver for the process), keyed by
+        # `_canonical_root` so every overlay work copy of a repo reuses one snapshot.
+        self._env_cache: dict[Path, dict[str, str] | None] = {}
+
     def prepare(self, repo: Path, *, timeout: int) -> CheckResult:
         root = _lake_root(repo)
-        return run(["lake", "build"], cwd=root, timeout=timeout)
+        res = run(["lake", "build"], cwd=root, timeout=timeout)
+        self._env_cache[_canonical_root(root)] = _snapshot_lake_env(
+            root, timeout=timeout
+        )
+        return res
+
+    def _env_for(self, root: Path, *, timeout: int) -> dict[str, str] | None:
+        """Reuse the snapshot `prepare` took; if `prepare` was never called for this
+        repo (e.g. the baseline driver, which only ever calls `check`), take one lazily
+        — always against the *pristine* root (never the overlay `root` argument), so a
+        first-use snapshot never runs `lake env` with `cwd` inside a symlink overlay."""
+        canonical = _canonical_root(root)
+        if canonical not in self._env_cache:
+            self._env_cache[canonical] = _snapshot_lake_env(canonical, timeout=timeout)
+        return self._env_cache[canonical]
 
     def check(
         self, repo: Path, rel: Path, *, allow_holes: bool, timeout: int
     ) -> CheckResult:
         target = (repo / rel).resolve()
         root = _lake_root(target)
-        res = run(["lake", "env", "lean", str(target)], cwd=root, timeout=timeout)
-        # Fallback: when lake refuses because the package config is invalid (a broken
-        # default target — e.g. an unlinkable FFI test exe), the library oleans still
-        # exist, so drive `lean` directly with a reconstructed LEAN_PATH.
-        if not res.ok and _INVALID_CONFIG in (res.stderr or res.stdout or ""):
-            lp = _lean_path(root)
-            if lp:
-                env = dict(os.environ)
-                env["LEAN_PATH"] = (
-                    lp + os.pathsep + env["LEAN_PATH"] if env.get("LEAN_PATH") else lp
-                )
-                return run(
-                    ["lean", str(target)], cwd=root, timeout=timeout, env=env
-                )
-        return res
+        env = dict(os.environ)
+        snapshot = self._env_for(root, timeout=timeout)
+        if snapshot:
+            env.update(snapshot)
+        lp = _lean_path(root)
+        if lp:
+            env["LEAN_PATH"] = (
+                lp + os.pathsep + env["LEAN_PATH"] if env.get("LEAN_PATH") else lp
+            )
+        return run(["lean", str(target)], cwd=root, timeout=timeout, env=env)

--- a/baselines/tests/test_apply.py
+++ b/baselines/tests/test_apply.py
@@ -12,6 +12,8 @@ from apply_ablate.apply import (
     overlay_repo,
     resolve_target,
 )
+from apply_ablate.provers.base import CheckResult
+from apply_ablate.provers.lean import LeanProver
 from apply_ablate.record import AblationRecord, load_record
 
 
@@ -194,6 +196,70 @@ def test_apply_record_drops_target_vo_symlink(tmp_path: Path):
     vo.write_bytes(b"FRESH-VO")
     assert (src / "Util" / "NatUtil.vo").read_bytes() == b"PRISTINE-VO"  # src intact
     assert target.read_text().startswith("(* holed *)")
+
+
+def _lean_src(tmp_path: Path) -> Path:
+    """A minimal lean package: a lakefile + a prebuilt `.lake/build/lib` (the heavy dep
+    dir `overlay_repo` symlinks back to src rather than copying) + one source file."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "lakefile.toml").write_text("name = 'demo'\n")
+    lib = src / ".lake" / "build" / "lib"
+    lib.mkdir(parents=True)
+    (lib / "Demo.olean").write_bytes(b"olean")
+    (src / "A.lean").write_text("theorem t : True := trivial\n")
+    return src
+
+
+def _lean_record() -> AblationRecord:
+    return AblationRecord.model_validate(
+        {
+            "proof_assistant": "lean",
+            "file_path": "A.lean",
+            "challenge_file_content": "theorem t : True := by sorry\n",
+            "solution_file_content": "theorem t : True := trivial\n",
+            "deleted_lemmas": [],
+        }
+    )
+
+
+def test_lean_check_never_invokes_lake_through_overlay(tmp_path: Path, monkeypatch):
+    """`.lake` in the overlay is (correctly) a symlink back to `src` — it is a heavy
+    prebuilt dep dir `overlay_repo` never copies. The regression this guards is #119:
+    `LeanProver.check` used to run `lake env lean` with `cwd` resolving inside the
+    overlay, so lake's own workspace-resolution writes (dependency re-clone, compiled-
+    lakefile-config cache) followed that symlink straight into the pristine source and
+    corrupted it. `check` must now compile exclusively via bare `lean`, and the one
+    `lake` invocation it may still make (the FFI-env snapshot) must run with `cwd`
+    against the pristine root, never with `cwd` under the overlay's `.lake` symlink."""
+    src = _lean_src(tmp_path)
+    dst = tmp_path / "dst"
+    target = apply_record(_lean_record(), src, dst, overwrite=False)
+    assert target.read_text() == "theorem t : True := by sorry\n"
+    lake_link = dst / ".lake"
+    assert lake_link.is_symlink()
+    assert lake_link.resolve() == (src / ".lake").resolve()
+
+    calls: list[tuple[list[str], Path]] = []
+
+    def fake_run(cmd, cwd, *, timeout, env=None):
+        calls.append((cmd, Path(cwd)))
+        return CheckResult(ok=cmd[0] == "lean", cmd=cmd, stdout="", stderr="")
+
+    monkeypatch.setattr("apply_ablate.provers.lean.run", fake_run)
+    prover = LeanProver()
+    res = prover.check(dst, Path("A.lean"), allow_holes=True, timeout=5)
+    assert res.ok
+
+    lean_calls = [c for c in calls if c[0][0] == "lean"]
+    assert len(lean_calls) == 1, "the compile must go through bare `lean`, not `lake`"
+
+    lake_calls = [c for c in calls if c[0][0] == "lake"]
+    for cmd, cwd in lake_calls:
+        assert not str(cwd.resolve()).startswith(str(dst.resolve())), (
+            f"lake invocation {cmd} ran with cwd under the overlay ({cwd}) — it would "
+            "write through the `.lake` symlink into the pristine src"
+        )
 
 
 def test_overlay_exclude_deep_sibling(tmp_path: Path):

--- a/docs/lean-ablate-repo-gotchas.md
+++ b/docs/lean-ablate-repo-gotchas.md
@@ -44,22 +44,26 @@ Every record carries `repo` + `revision` provenance; `manifest.json` pins `lean_
 
 ## Harness gotchas (affect VALIDATION, not the data)
 
-- **Multi-project repos → mathlib-clone RUNAWAY.** If a repo has a second lake subproject
-  whose `.lake` isn't built, `lake env lean` on those files runs `git clone mathlib4` into
-  `/tmp` **per record** — fills disk fast. Seen in **starkware** (`Stwo/` subproject; mined
-  file_paths `Stwo/…`), and structurally in **aeneas**, **rust-lean** (many sub-lakefiles),
-  **lean-zip** (`bench/`). Fix: build *every* sub-lakefile (`cd sub && lake exe cache get &&
-  lake build`), or exclude the unbuilt-subproject records. `finish_ab.sh` guards by dropping
-  `Stwo/` records if Stwo's mathlib is absent.
+- **Multi-project repos → mathlib-clone RUNAWAY (historical; #119 closed the mechanism).**
+  Before #119, a repo with a second lake subproject whose `.lake` wasn't built ran
+  `lake env lean` on those files, which `git clone`d mathlib4 into `/tmp` **per record** —
+  filled disk fast. Seen in **starkware** (`Stwo/` subproject; mined file_paths `Stwo/…`),
+  and structurally in **aeneas**, **rust-lean** (many sub-lakefiles), **lean-zip**
+  (`bench/`). `check` no longer runs `lake` at all (bare `lean` only), so this specific
+  clone-runaway can't happen anymore — an unbuilt subproject now just fails the compile
+  with "unknown module" instead. Still build *every* sub-lakefile (`cd sub && lake exe
+  cache get && lake build`) so those records aren't spuriously malformed; `finish_ab.sh`
+  guards by dropping `Stwo/` records if Stwo's mathlib is absent.
 - **Monorepo sibling deps.** **SizzLean** lives in the `etheorem/etheorem` monorepo and
   `require`s a sibling `../LeanHazmatSha256`. Validate with the **monorepo root** as the
   baseline `src` (`data/etheorem`, file_paths `packages/SizzLean/…`) so the overlay contains
   the sibling — not the package dir alone (→ "package directory not found").
-- **`lakefile.lean` + C FFI won't `lake env lean`.** **lean-zip** builds C FFI (zlib) + a
-  test exe that won't link here (`collect2: ld returned 1`), so lake marks the config
-  "invalid" and refuses `lake env lean`. The library oleans are fine. Fixed in
-  `baselines/…/provers/lean.py`: on "compiled configuration is invalid", fall back to `lean`
-  with a reconstructed `LEAN_PATH` (own + every package's `build/lib[/lean]`).
+- **`lakefile.lean` + C FFI used to break `lake env lean`.** **lean-zip** builds C FFI
+  (zlib) + a test exe that won't link here (`collect2: ld returned 1`), so lake used to
+  mark the config "invalid" and refuse `lake env lean`. The library oleans are fine.
+  Moot since #119: `check` in `baselines/…/provers/lean.py` always runs bare `lean` with a
+  reconstructed `LEAN_PATH` (own + every package's `build/lib[/lean]`) — it never asks
+  lake to elaborate the config at all, so an unlinkable FFI target can't block it.
 - **Native `:c.o` mathlib builds are wasteful.** Some repos' default `lake build` compiles
   mathlib to native (gcc, 30–90 s/module × thousands) — NOT needed for `lake env lean`
   (which only loads oleans). `cache get` already fetches the oleans; build just the repo's

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -65,10 +65,16 @@ to 3,340 (12% → 87%) with no ablator change at all:
 2. **C FFI needs `-D_GNU_SOURCE`.** hex-dev's FFI calls `dlsym(RTLD_DEFAULT, ...)`, which glibc only
    declares under `_GNU_SOURCE`. Without it the FFI target fails and everything downstream goes
    unbuilt. The `cc` wrapper in `flake.nix` handles it.
-3. **Vendored mathlib goes missing / half-cloned.** `lake exe cache get` restores it. The half-clones
-   are *self-inflicted*: the dry-run harness symlinks `.lake` from its work copy back into the source
-   tree, so lake's git operations write through and can corrupt the source. `rebuild_repos.sh` drops
-   and refetches those. (The harness should get a scratch package dir — see TODO.)
+3. **Vendored mathlib goes missing / half-cloned.** `lake exe cache get` restores it. Historically the
+   half-clones were *self-inflicted* (#119): the dry-run harness symlinks `.lake` from its work copy
+   back into the source tree (deliberately — it is a heavy prebuilt dep dir, never copied), and
+   `check` used to run `lake env lean` with `cwd` inside that work copy, so lake's own workspace
+   resolution — git re-clones, the compiled-lakefile-config cache — wrote through the symlink and
+   corrupted the shared source. `check` no longer invokes `lake` at all: it compiles via bare `lean`
+   against a `LEAN_PATH` reconstructed from `.lake/build/lib`, with the one remaining `lake env`
+   call (an FFI-environment snapshot for packages like hex-dev) taken once per repo in `prepare`,
+   against the pristine root, never the work copy. `rebuild_repos.sh` still exists to repair
+   pre-existing damage from before the fix, but a validation run should no longer produce any.
 
 **Do not gate on a cheap probe.** `lake env true` only checks dependency *resolution* and happily
 passes a tree whose mathlib has no `.olean` files. Probing "the first `.lean` file in the tree" picks

--- a/pipeline/par_dryrun.sh
+++ b/pipeline/par_dryrun.sh
@@ -3,10 +3,19 @@
 # --dry-run` on each concurrently, merge results. The baseline uses its own tempdir
 # per process so shards don't collide.
 #
+# All N shards read/check against the SAME $SRC concurrently (#119). Since the fix,
+# `check` never invokes `lake` at all (bare `lean` only) so this is normally safe on
+# its own, but `prepare` / a manual `lake build` still legitimately write into $SRC in
+# place — a per-repo flock (shared while dry-run shards run, exclusive for anything
+# that builds) means such a step can never race a live batch of shards, or another
+# instance of itself, against the same source tree.
+#
 # Usage: par_dryrun.sh <challenges.jsonl> <src> <out.jsonl> [nshards]
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CH="$(readlink -f "$1")"; SRC="$(readlink -f "$2")"; OUT="$(readlink -f "$3")"; N="${4:-16}"
+LOCKDIR="${TMPDIR:-/tmp}/ablate-repo-locks"; mkdir -p "$LOCKDIR"
+LOCK="$LOCKDIR/$(printf '%s' "$SRC" | sha256sum | cut -d' ' -f1).lock"
 WORK="$(dirname "$OUT")/_shards_$(basename "$OUT" .jsonl)"
 rm -rf "$WORK"; mkdir -p "$WORK"
 # split preserving whole lines, round-robin so slow files spread across shards
@@ -24,7 +33,11 @@ pids=()
 for i in $(seq 0 $((N-1))); do
   sh="$WORK/shard_$i.jsonl"
   [ -s "$sh" ] || continue
-  uv run ablate-baseline "$sh" "$SRC" --dry-run --out "$WORK/res_$i.jsonl" > "$WORK/log_$i.txt" 2>&1 &
+  # shared lock: any number of shards may hold it at once, but it blocks behind an
+  # exclusive holder (a `prepare` / `lake build` step against this same $SRC).
+  ( flock -s 9
+    uv run ablate-baseline "$sh" "$SRC" --dry-run --out "$WORK/res_$i.jsonl"
+  ) 9>"$LOCK" > "$WORK/log_$i.txt" 2>&1 &
   pids+=($!)
 done
 echo "launched ${#pids[@]} shard workers; waiting…"


### PR DESCRIPTION
## Summary

- `LeanProver.check` (`baselines/src/apply_ablate/provers/lean.py`) used to run `lake env lean <file>` with `cwd` resolving inside the symlink-overlay work copy that `apply.overlay_repo` builds. `.lake` in that overlay is a symlink back to the pristine source (deliberately — it's a multi-GB dep dir, never copied), so lake's own workspace resolution (dependency re-clone, compiled-lakefile-config cache) wrote through the symlink and corrupted the shared source tree. This was one of three build-environment bugs that together cost the corpus ~3,700 valid challenges (see `pipeline/README.md`'s "Validation is a build problem").
- **Fix (preferred approach from the issue):** promote the existing lake-free path from fallback to primary. `check` now *always* compiles via bare `lean` against a `LEAN_PATH` reconstructed from `.lake/build/lib` (own + every package's) — bare `lean` never performs git operations, never elaborates a lakefile, and never writes `.lake`. There is no `lake` invocation left in `check` to redirect.
- The one thing `lake env` did that bare `lean` can't reconstruct by globbing is the C-FFI environment (`LEAN_CC`, `LD_LIBRARY_PATH`) that packages like hex-dev need. `LeanProver.prepare` now snapshots `lake env printenv --no-build` once per repo (keyed off the *pristine* root, so an overlay work copy of the same repo reuses the snapshot instead of re-invoking lake), and `check` reuses it; `check` also lazily takes the snapshot itself — always against the pristine root, never the overlay — if `prepare` was never called (the baseline driver only calls `check`). `--no-build` makes even this one remaining `lake env` call fail fast instead of starting a build/clone if the config is stale.
- Removed the now-dead `_INVALID_CONFIG` fallback branch it replaces.
- Added a per-repo `flock` in `pipeline/par_dryrun.sh` (16 shard workers today run concurrently against one `$SRC`) as belt-and-braces so a future `prepare`/`lake build` step can never race a live batch of shards, or another instance of itself, against the same source tree.
- Updated `pipeline/README.md` ("Validation is a build problem" section + removed the stale TODO) and `docs/lean-ablate-repo-gotchas.md` to describe the fix instead of the historical workaround.

## Test plan

- [x] `uv run ruff format` / `uv run ruff check --fix` / `uv run ty check` — all clean (run from `./baselines`)
- [x] `uv run pytest` — 87 passed, including a new regression test `test_lean_check_never_invokes_lake_through_overlay` in `baselines/tests/test_apply.py` that overlays a fake lean repo, monkeypatches the subprocess `run`, and asserts (a) the compile always goes through bare `lean`, never `lake`, and (b) any `lake` invocation `check` still makes (the FFI-env snapshot) never has `cwd` under the overlay — i.e. `.lake`'s symlink is never a write channel.
- [ ] **Deferred to #149**: an end-to-end `pipeline/par_dryrun.sh` / `pipeline/health_probe.sh` run against a real, built Lean repo (`git -C data/lean/<repo> status` clean afterward, `.lake/packages/*` HEADs intact, `health_probe.sh` passing without `rebuild_repos.sh`). This machine's `data/lean/` is empty (#149), so that verification cannot be run here — the unit test above is the closest available proof the write channel is closed.

Closes #119