### PR TITLE
baselines: micro+macro results aggregator (ablate-aggregate)

### DIFF
--- a/baselines/pyproject.toml
+++ b/baselines/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 [project.scripts]
 apply-ablate = "apply_ablate.cli:main"
 ablate-baseline = "apply_ablate.baseline:main"
+ablate-aggregate = "apply_ablate.aggregate:main"
 difficulty = "apply_ablate.difficulty.cli:main"
 
 [build-system]

--- a/baselines/src/apply_ablate/aggregate.py
+++ b/baselines/src/apply_ablate/aggregate.py
@@ -1,0 +1,383 @@
+"""Cross-run aggregator: micro + macro (per-repo mean) PASS over a set of
+`ablate-baseline` result JSONLs, keyed by `(model, mode, max_turns)`.
+
+`docs/contamination.agents.md` requires macro-averaging (mean of per-repo PASS rate)
+for any cross-group comparison — evm-asm alone is 7,323/21,692 rows (34%) of the leaf
+corpus, so a micro (pooled) average is mostly a statement about that one repo. This
+module reports both, plus the full outcome breakdown and bootstrap CIs.
+
+A `SolveResult` row (`apply_ablate.solve.SolveResult`) carries no `model`/`mode`/`repo`
+field — `eval_sample.sh` writes one `res_<repo>.jsonl` per repo per (model, mode,
+max_turns) run, so that association lives in the filesystem, not the JSONL. The input
+to this aggregator is therefore a *manifest*: a JSON list of `{path, model, mode,
+max_turns, repo}` entries (repo/max_turns may be omitted and are inferred — repo from
+the filename stem, max_turns from the majority value of each row's `max_turns` field).
+
+    ablate-aggregate MANIFEST.json [--out-json F] [--out-md F] [--n-boot 2000] [--seed N]
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import statistics
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Annotated, Any
+
+import typer
+from pydantic import BaseModel, ConfigDict
+
+from apply_ablate.difficulty.label import outcome_of
+
+app = typer.Typer(add_completion=False, help=__doc__)
+
+# display order for the outcome taxonomy (baselines/src/apply_ablate/baseline.py:138-158)
+OUTCOME_ORDER: tuple[str, ...] = (
+    "pass",
+    "dry_run",
+    "trivial",
+    "malformed",
+    "context_exceeded",
+    "tampered",
+    "gave_up",
+    "turn_limit",
+    "error",
+    "fail",
+)
+# excluded from the scorable denominator: the challenge is broken (malformed), empty
+# (trivial), or the model never saw it (context_exceeded) — none of these are a wrong
+# answer, so scoring them 0 would blame the model for a harness/dataset artifact.
+NON_SCORABLE: frozenset[str] = frozenset({"malformed", "trivial", "context_exceeded"})
+
+
+class ManifestEntry(BaseModel):
+    """One results file plus the (model, mode, max_turns, repo) it belongs to.
+
+    `repo` and `max_turns` are optional: `repo` defaults to the filename stem (stripping
+    a leading `res_` prefix, matching `pipeline/eval_sample.sh`'s naming), and
+    `max_turns` defaults to the majority `max_turns` value recorded on the file's own
+    rows (present since #124; falls back to `None` -> "unknown" on legacy files).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    path: str
+    model: str
+    mode: str
+    max_turns: int | None = None
+    repo: str | None = None
+
+
+def load_manifest(path: Path) -> list[ManifestEntry]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, list):
+        raise ValueError(f"{path}: manifest must be a JSON list of entries")
+    return [ManifestEntry.model_validate(e) for e in raw]
+
+
+def load_results(path: Path) -> list[dict[str, Any]]:
+    """Load non-blank JSONL rows as dicts (blank padding lines skipped)."""
+    rows: list[dict[str, Any]] = []
+    for ln in path.read_text(encoding="utf-8").splitlines():
+        ln = ln.strip()
+        if ln:
+            rows.append(json.loads(ln))
+    return rows
+
+
+def _infer_repo(entry_path: str) -> str:
+    stem = Path(entry_path).stem
+    return stem[len("res_") :] if stem.startswith("res_") else stem
+
+
+def _infer_max_turns(rows: list[dict[str, Any]]) -> int | None:
+    values = [r["max_turns"] for r in rows if r.get("max_turns") is not None]
+    if not values:
+        return None
+    return Counter(values).most_common(1)[0][0]
+
+
+class RepoRows:
+    """One repo's classified outcomes within a single (model, mode, max_turns) group."""
+
+    def __init__(self, repo: str) -> None:
+        self.repo = repo
+        self.outcomes: list[str] = []
+
+    def add(self, rows: list[dict[str, Any]]) -> None:
+        self.outcomes.extend(outcome_of(r) for r in rows)
+
+    @property
+    def total(self) -> int:
+        return len(self.outcomes)
+
+    @property
+    def scorable_flags(self) -> list[bool]:
+        """One bool per scorable row: True if it passed."""
+        return [o == "pass" for o in self.outcomes if o not in NON_SCORABLE]
+
+    @property
+    def scorable(self) -> int:
+        return len(self.scorable_flags)
+
+    @property
+    def passed(self) -> int:
+        return sum(self.scorable_flags)
+
+    def counts(self) -> dict[str, int]:
+        c = Counter(self.outcomes)
+        return {name: c.get(name, 0) for name in OUTCOME_ORDER}
+
+
+def _mean(xs: list[bool]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def _percentile_ci(
+    samples: list[float], alpha: float
+) -> tuple[float | None, float | None]:
+    if not samples:
+        return (None, None)
+    s = sorted(samples)
+    lo_idx = int((alpha / 2) * len(s))
+    hi_idx = min(len(s) - 1, int((1 - alpha / 2) * len(s)))
+    return (s[lo_idx], s[hi_idx])
+
+
+def bootstrap_micro_ci(
+    per_repo: dict[str, RepoRows],
+    *,
+    n_boot: int,
+    alpha: float,
+    seed: int | None,
+) -> tuple[float | None, float | None]:
+    """Resample all scorable rows pooled across repos, recompute pass/scorable."""
+    pooled: list[bool] = []
+    for r in per_repo.values():
+        pooled.extend(r.scorable_flags)
+    if not pooled:
+        return (None, None)
+    rng = random.Random(seed)
+    n = len(pooled)
+    samples = [_mean(rng.choices(pooled, k=n)) for _ in range(n_boot)]
+    return _percentile_ci(samples, alpha)
+
+
+def bootstrap_macro_ci(
+    per_repo: dict[str, RepoRows],
+    *,
+    n_boot: int,
+    alpha: float,
+    seed: int | None,
+) -> tuple[float | None, float | None]:
+    """Stratified (per-repo) bootstrap: resample each repo's scorable rows within that
+    repo, recompute its pass rate, then average across repos with >=1 scorable row —
+    repeated `n_boot` times. This preserves the repo structure the macro average
+    depends on (unlike pooling, which would just reproduce the micro CI)."""
+    repo_flags = [r.scorable_flags for r in per_repo.values() if r.scorable_flags]
+    if not repo_flags:
+        return (None, None)
+    rng = random.Random(seed)
+    samples = []
+    for _ in range(n_boot):
+        repo_means = [_mean(rng.choices(flags, k=len(flags))) for flags in repo_flags]
+        samples.append(statistics.mean(repo_means))
+    return _percentile_ci(samples, alpha)
+
+
+class GroupResult(BaseModel):
+    model: str
+    mode: str
+    max_turns: int | None
+    total: int
+    outcomes: dict[str, int]
+    scorable: int
+    micro_pass: int
+    micro_rate: float
+    micro_ci_lo: float | None
+    micro_ci_hi: float | None
+    macro_n_repos: int
+    macro_rate: float | None
+    macro_ci_lo: float | None
+    macro_ci_hi: float | None
+    per_repo: dict[str, dict[str, int | float]]
+
+
+def aggregate(
+    entries: list[ManifestEntry],
+    *,
+    n_boot: int = 2000,
+    alpha: float = 0.05,
+    seed: int | None = None,
+    base_dir: Path | None = None,
+) -> list[GroupResult]:
+    """Group manifest entries by (model, mode, max_turns) — inferring max_turns from
+    each file's rows when the manifest omits it — and compute micro + macro stats."""
+    # first pass: load rows + resolve each entry's effective max_turns
+    loaded: list[tuple[ManifestEntry, list[dict[str, Any]], int | None]] = []
+    for e in entries:
+        p = Path(e.path) if base_dir is None else base_dir / e.path
+        rows = load_results(p)
+        turns = e.max_turns if e.max_turns is not None else _infer_max_turns(rows)
+        loaded.append((e, rows, turns))
+
+    groups: dict[tuple[str, str, int | None], dict[str, RepoRows]] = defaultdict(dict)
+    for e, rows, turns in loaded:
+        repo = e.repo or _infer_repo(e.path)
+        key = (e.model, e.mode, turns)
+        per_repo = groups[key]
+        if repo not in per_repo:
+            per_repo[repo] = RepoRows(repo)
+        per_repo[repo].add(rows)
+
+    results: list[GroupResult] = []
+    for (model, mode, turns), per_repo in sorted(
+        groups.items(), key=lambda kv: (kv[0][0], kv[0][1], kv[0][2] or -1)
+    ):
+        total = sum(r.total for r in per_repo.values())
+        outcomes: dict[str, int] = dict.fromkeys(OUTCOME_ORDER, 0)
+        for r in per_repo.values():
+            for name, n in r.counts().items():
+                outcomes[name] += n
+        scorable = sum(r.scorable for r in per_repo.values())
+        micro_pass = sum(r.passed for r in per_repo.values())
+        micro_rate = micro_pass / scorable if scorable else 0.0
+        micro_lo, micro_hi = bootstrap_micro_ci(
+            per_repo, n_boot=n_boot, alpha=alpha, seed=seed
+        )
+        repo_rates = [
+            (repo, r.passed / r.scorable) for repo, r in per_repo.items() if r.scorable
+        ]
+        macro_rate = (
+            statistics.mean(rate for _, rate in repo_rates) if repo_rates else None
+        )
+        macro_lo, macro_hi = bootstrap_macro_ci(
+            per_repo, n_boot=n_boot, alpha=alpha, seed=seed
+        )
+        per_repo_out = {
+            repo: {
+                "total": r.total,
+                "scorable": r.scorable,
+                "pass": r.passed,
+                "rate": (r.passed / r.scorable) if r.scorable else 0.0,
+            }
+            for repo, r in sorted(per_repo.items())
+        }
+        results.append(
+            GroupResult(
+                model=model,
+                mode=mode,
+                max_turns=turns,
+                total=total,
+                outcomes=outcomes,
+                scorable=scorable,
+                micro_pass=micro_pass,
+                micro_rate=micro_rate,
+                micro_ci_lo=micro_lo,
+                micro_ci_hi=micro_hi,
+                macro_n_repos=len(repo_rates),
+                macro_rate=macro_rate,
+                macro_ci_lo=macro_lo,
+                macro_ci_hi=macro_hi,
+                per_repo=per_repo_out,
+            )
+        )
+    return results
+
+
+def _pct(x: float | None) -> str:
+    return f"{100 * x:.1f}%" if x is not None else "n/a"
+
+
+def to_markdown(results: list[GroupResult]) -> str:
+    lines = [
+        "| model | mode | max_turns | n | scorable | micro PASS | micro CI | macro PASS | macro CI | repos |",
+        "|---|---|--:|--:|--:|--:|---|--:|---|--:|",
+    ]
+    for g in results:
+        micro_ci = f"[{_pct(g.micro_ci_lo)}, {_pct(g.micro_ci_hi)}]"
+        macro_ci = (
+            f"[{_pct(g.macro_ci_lo)}, {_pct(g.macro_ci_hi)}]"
+            if g.macro_rate is not None
+            else "n/a"
+        )
+        lines.append(
+            f"| {g.model} | {g.mode} | {g.max_turns if g.max_turns is not None else 'n/a'} "
+            f"| {g.total} | {g.scorable} | {_pct(g.micro_rate)} ({g.micro_pass}/{g.scorable}) "
+            f"| {micro_ci} | {_pct(g.macro_rate)} | {macro_ci} | {g.macro_n_repos} |"
+        )
+    lines.append("")
+    lines.append("Outcome breakdown:")
+    lines.append("")
+    header = "| model | mode | max_turns | " + " | ".join(OUTCOME_ORDER) + " |"
+    sep = "|---|---|--:|" + "--:|" * len(OUTCOME_ORDER)
+    lines.append(header)
+    lines.append(sep)
+    for g in results:
+        counts = " | ".join(str(g.outcomes[name]) for name in OUTCOME_ORDER)
+        lines.append(
+            f"| {g.model} | {g.mode} | {g.max_turns if g.max_turns is not None else 'n/a'} | {counts} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def to_json(results: list[GroupResult]) -> str:
+    return json.dumps([g.model_dump() for g in results], indent=2) + "\n"
+
+
+@app.command()
+def run(
+    manifest: Annotated[
+        Path,
+        typer.Argument(
+            exists=True,
+            dir_okay=False,
+            help="JSON list of {path, model, mode, max_turns?, repo?} entries.",
+        ),
+    ],
+    out_json: Annotated[
+        Path | None, typer.Option("--out-json", help="machine-readable aggregate")
+    ] = None,
+    out_md: Annotated[
+        Path | None, typer.Option("--out-md", help="markdown table for the paper")
+    ] = None,
+    n_boot: Annotated[int, typer.Option("--n-boot", help="bootstrap resamples")] = 2000,
+    alpha: Annotated[
+        float, typer.Option("--alpha", help="CI significance level (0.05 = 95% CI)")
+    ] = 0.05,
+    seed: Annotated[
+        int | None, typer.Option("--seed", help="bootstrap RNG seed (reproducible CIs)")
+    ] = None,
+) -> None:
+    """Aggregate a set of `ablate-baseline` result JSONLs into micro + macro PASS."""
+    entries = load_manifest(manifest)
+    results = aggregate(
+        entries, n_boot=n_boot, alpha=alpha, seed=seed, base_dir=manifest.parent
+    )
+    md = to_markdown(results)
+    typer.echo(md)
+    if out_json:
+        out_json.write_text(to_json(results), encoding="utf-8")
+        typer.echo(f"wrote {out_json}")
+    if out_md:
+        out_md.write_text(md, encoding="utf-8")
+        typer.echo(f"wrote {out_md}")
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = [
+    "GroupResult",
+    "ManifestEntry",
+    "aggregate",
+    "load_manifest",
+    "to_json",
+    "to_markdown",
+]

--- a/baselines/tests/test_aggregate.py
+++ b/baselines/tests/test_aggregate.py
@@ -1,0 +1,183 @@
+"""Tests for the cross-run micro/macro aggregator (apply_ablate.aggregate)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from apply_ablate.aggregate import (
+    ManifestEntry,
+    aggregate,
+    load_manifest,
+    to_json,
+    to_markdown,
+)
+from apply_ablate.aggregate import app as aggregate_app
+
+runner = CliRunner()
+
+
+def _row(**kw) -> dict:
+    """A minimal synthetic SolveResult row; flags default to a plain FAIL."""
+    base = {
+        "task_id": "t",
+        "assistant": "lean",
+        "file_path": "A.lean",
+        "succeeded": False,
+        "gave_up": False,
+        "malformed_challenge": False,
+        "trivial": False,
+        "context_exceeded": False,
+        "tampered": False,
+        "turn_limit": False,
+        "dry_run": False,
+        "error": None,
+        "max_turns": 30,
+    }
+    base.update(kw)
+    return base
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+
+def _fixture(tmp_path: Path) -> Path:
+    """A synthetic two-repo, two-mode results corpus.
+
+    repo `big` (skews the pool: 8 rows) has a LOW pass rate (1/8 scorable).
+    repo `small` (2 rows) has a HIGH pass rate (2/2 scorable) — a macro average must
+    weight `small` equally with `big`, unlike a pooled (micro) average.
+    One malformed + one trivial + one context_exceeded row check the scorable formula.
+    """
+    big_rows = [_row(succeeded=(i == 0)) for i in range(8)]
+    small_rows = [_row(succeeded=True) for _ in range(2)]
+    edge_rows = [
+        _row(malformed_challenge=True),
+        _row(trivial=True),
+        _row(context_exceeded=True),
+    ]
+
+    _write_jsonl(tmp_path / "res_big.jsonl", big_rows)
+    _write_jsonl(tmp_path / "res_small.jsonl", small_rows)
+    _write_jsonl(tmp_path / "res_edge.jsonl", edge_rows)
+
+    manifest = [
+        {"path": "res_big.jsonl", "model": "m1", "mode": "leaves"},
+        {"path": "res_small.jsonl", "model": "m1", "mode": "leaves"},
+        {"path": "res_edge.jsonl", "model": "m1", "mode": "leaves", "repo": "edge"},
+    ]
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    return manifest_path
+
+
+def test_micro_vs_macro_diverge(tmp_path: Path):
+    manifest_path = _fixture(tmp_path)
+    entries = load_manifest(manifest_path)
+    [g] = aggregate(entries, n_boot=200, seed=0, base_dir=tmp_path)
+
+    assert g.model == "m1"
+    assert g.mode == "leaves"
+    assert g.max_turns == 30  # inferred from row max_turns
+
+    # total rows: 8 + 2 + 3 = 13; scorable excludes malformed/trivial/context_exceeded
+    assert g.total == 13
+    assert g.scorable == 10
+
+    # micro: pooled pass/scorable = (1 + 2) / (8 + 2) = 3/10 = 30%
+    assert g.micro_pass == 3
+    assert abs(g.micro_rate - 0.3) < 1e-9
+
+    # macro: mean of per-repo rates = mean(1/8, 2/2) = mean(0.125, 1.0) = 0.5625
+    assert g.macro_n_repos == 2  # `edge` has 0 scorable rows -> excluded
+    assert g.macro_rate is not None
+    assert abs(g.macro_rate - 0.5625) < 1e-9
+
+    # macro pulls the average up relative to micro, which is dominated by `big`
+    assert g.macro_rate > g.micro_rate
+
+    # bootstrap CIs are present and bracket the point estimate
+    assert g.micro_ci_lo is not None and g.micro_ci_hi is not None
+    assert g.micro_ci_lo <= g.micro_rate <= g.micro_ci_hi
+    assert g.macro_ci_lo is not None and g.macro_ci_hi is not None
+    assert g.macro_ci_lo <= g.macro_rate <= g.macro_ci_hi
+
+    # outcome breakdown covers the full taxonomy
+    assert g.outcomes["pass"] == 3
+    assert g.outcomes["malformed"] == 1
+    assert g.outcomes["trivial"] == 1
+    assert g.outcomes["context_exceeded"] == 1
+    assert g.outcomes["fail"] == 7  # the unsuccessful `big` rows (7 of 8)
+
+    per_repo_rates = {r: v["rate"] for r, v in g.per_repo.items()}
+    assert abs(per_repo_rates["big"] - 0.125) < 1e-9
+    assert abs(per_repo_rates["small"] - 1.0) < 1e-9
+
+
+def test_grouping_keys_on_model_mode_max_turns(tmp_path: Path):
+    _write_jsonl(tmp_path / "a.jsonl", [_row(succeeded=True, max_turns=30)])
+    _write_jsonl(tmp_path / "b.jsonl", [_row(succeeded=False, max_turns=50)])
+    manifest = [
+        {"path": "a.jsonl", "model": "m1", "mode": "leaves", "repo": "r1"},
+        {"path": "b.jsonl", "model": "m1", "mode": "leaves", "repo": "r1"},
+        {"path": "a.jsonl", "model": "m2", "mode": "leaves", "repo": "r1"},
+    ]
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    results = aggregate(
+        load_manifest(manifest_path), n_boot=50, seed=1, base_dir=tmp_path
+    )
+    keys = {(g.model, g.mode, g.max_turns) for g in results}
+    assert keys == {("m1", "leaves", 30), ("m1", "leaves", 50), ("m2", "leaves", 30)}
+
+
+def test_repo_inference_strips_res_prefix(tmp_path: Path):
+    entry = ManifestEntry(path="res_evm-asm.jsonl", model="m1", mode="whole")
+    from apply_ablate.aggregate import _infer_repo
+
+    assert _infer_repo(entry.path) == "evm-asm"
+
+
+def test_to_markdown_and_json_roundtrip(tmp_path: Path):
+    manifest_path = _fixture(tmp_path)
+    results = aggregate(
+        load_manifest(manifest_path), n_boot=50, seed=0, base_dir=tmp_path
+    )
+    md = to_markdown(results)
+    assert "micro PASS" in md
+    assert "macro PASS" in md
+    assert "m1" in md and "leaves" in md
+
+    js = json.loads(to_json(results))
+    assert len(js) == 1
+    assert js[0]["model"] == "m1"
+    assert js[0]["scorable"] == 10
+
+
+def test_cli_writes_json_and_md(tmp_path: Path):
+    manifest_path = _fixture(tmp_path)
+    out_json = tmp_path / "out.json"
+    out_md = tmp_path / "out.md"
+    result = runner.invoke(
+        aggregate_app,
+        [
+            str(manifest_path),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--n-boot",
+            "20",
+            "--seed",
+            "0",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert out_json.exists()
+    assert out_md.exists()
+    data = json.loads(out_json.read_text())
+    assert data[0]["model"] == "m1"


### PR DESCRIPTION
## Summary
- New `apply_ablate.aggregate` module: aggregates a set of `ablate-baseline` results JSONLs, keyed by `(model, mode, max_turns)`.
- Reports **both** micro (pooled) and macro (per-repo mean) PASS, since evm-asm alone is 34% of the leaf corpus and the top 3 repos are ~54% — a micro average is mostly a statement about the biggest repos.
- Full outcome breakdown over the taxonomy at `baselines/src/apply_ablate/baseline.py:138-158` (`pass/dry_run/trivial/malformed/context_exceeded/tampered/gave_up/turn_limit/error/fail`), reusing `apply_ablate.difficulty.label.outcome_of`'s existing precedence logic rather than re-deriving it.
- Explicit scorable denominator: `scorable = total - malformed - trivial - context_exceeded`.
- Bootstrap CIs (percentile method) for both averages — pooled resampling for micro, a stratified per-repo resample for macro (resample each repo's scorable rows within that repo, recompute the repo rate, average across repos — this is what actually reflects the macro estimator's uncertainty, unlike pooling which would just reproduce the micro CI).
- Emits both machine-readable JSON (`--out-json`) and a markdown table (`--out-md`) suitable for pasting into the paper.
- New CLI entry point `ablate-aggregate MANIFEST.json [--out-json F] [--out-md F] [--n-boot N] [--seed N]`.

A `SolveResult` row carries no `model`/`mode`/`repo` field — `pipeline/eval_sample.sh` writes one `res_<repo>.jsonl` per repo per (model, mode, max_turns) run, so that grouping lives in the filesystem, not the JSONL. The aggregator therefore takes a manifest JSON of `{path, model, mode, max_turns?, repo?}` entries; `repo` is inferred from the filename stem (stripping a `res_` prefix) and `max_turns` from the majority value already recorded on each row (added by #124) when the manifest omits them.

## Test plan
- [x] `uv run pytest` (91 passed) from `./baselines`, including new `tests/test_aggregate.py` covering: micro vs. macro divergence on a synthetic two-repo fixture (small repo weighted equally with a large repo), grouping by `(model, mode, max_turns)`, repo-name inference, markdown/JSON output shape, and a CLI smoke test via `CliRunner`.
- [x] `uv run ruff format` / `uv run ruff check --fix` — clean
- [x] `uv run ty check` — clean

## Depends on
- #124 "record turns-used and cost per problem" → branch `dispatch/124-turns-used` (https://github.com/for-all-dev/git-history-evals/pull/151)

Closes #127