### PR TITLE
pipeline: paired easy/hard sample via shared challenge_id

### DIFF
--- a/baselines/src/apply_ablate/difficulty/cli.py
+++ b/baselines/src/apply_ablate/difficulty/cli.py
@@ -145,6 +145,10 @@ def score(
             "challenge_id": r.get("challenge_id"),
             "task_id": r.get("task_id"),
             "file_path": r.get("file_path"),
+            # carried through so pipeline/score_predictions.py can key its join on
+            # (challenge_id, sample_mode) -- challenge_id alone does not disambiguate a
+            # paired easy/hard sample (see pipeline/sample_paired.py)
+            "sample_mode": r.get("sample_mode"),
             "difficulty": s,
         }
         for r, s in zip(feat_rows, scores, strict=True)

--- a/baselines/src/apply_ablate/difficulty/dataset.py
+++ b/baselines/src/apply_ablate/difficulty/dataset.py
@@ -47,10 +47,30 @@ def _cross_check(chal: dict[str, Any], res: dict[str, Any]) -> bool:
 def build_table(
     challenges: Path, results: Path
 ) -> tuple[list[dict[str, Any]], list[str]]:
-    """Join features to labels. Returns (rows, warnings)."""
+    """Join features to labels. Returns (rows, warnings).
+
+    `challenge_id` alone is NOT mode-specific: the ablator's id hash excludes ablation mode
+    (see ablators/lean/Ablator/Record.lean:87-96), so a paired easy/hard sample
+    (`pipeline/sample_paired.py`) shares `challenge_id` across the two modes on purpose. If
+    `results` pools outcomes from both modes, a bare `challenge_id` dict would silently let
+    the second mode's row overwrite the first. So the join keys on
+    `(challenge_id, sample_mode)` first; when `sample_mode` is absent on both sides (legacy /
+    single-mode data) that degenerates to `(challenge_id, None)` on both sides, i.e. the old
+    behaviour. Only when the strict key misses do we fall back to a bare `challenge_id` match
+    -- and only if it is unambiguous; an ambiguous bare match (the actual collision hazard)
+    is warned and skipped rather than silently resolved by whichever row happened to load
+    last.
+    """
     chal_recs = load_jsonl(challenges)
     res_recs = load_jsonl(results)
-    by_cid = {r["challenge_id"]: r for r in res_recs if r.get("challenge_id")}
+    by_key: dict[tuple[str, Any], dict[str, Any]] = {}
+    by_cid_all: dict[str, list[dict[str, Any]]] = {}
+    for r in res_recs:
+        cid = r.get("challenge_id")
+        if not cid:
+            continue
+        by_key[(cid, r.get("sample_mode"))] = r
+        by_cid_all.setdefault(cid, []).append(r)
 
     warnings: list[str] = []
     rows: list[dict[str, Any]] = []
@@ -58,8 +78,21 @@ def build_table(
         cid = chal.get("challenge_id")
         res: dict[str, Any] | None = None
         matched_by: str | None = None
-        if cid and cid in by_cid:
-            res, matched_by = by_cid[cid], "challenge_id"
+        warned = False
+        if cid and (cid, chal.get("sample_mode")) in by_key:
+            res, matched_by = by_key[(cid, chal.get("sample_mode"))], "challenge_id"
+        elif cid and cid in by_cid_all:
+            candidates = by_cid_all[cid]
+            if len(candidates) == 1:
+                res, matched_by = candidates[0], "challenge_id"
+            else:
+                warnings.append(
+                    f"row {i}: ambiguous challenge_id={cid!r} matches "
+                    f"{len(candidates)} result rows across modes "
+                    f"(challenge sample_mode={chal.get('sample_mode')!r}); "
+                    "skipping rather than silently picking one"
+                )
+                warned = True
         elif i < len(res_recs):
             res, matched_by = res_recs[i], "position"
             if not _cross_check(chal, res):
@@ -69,13 +102,15 @@ def build_table(
                     f"vs result task_id={res.get('task_id')!r} file={res.get('file_path')!r})"
                 )
                 res, matched_by = None, None
+                warned = True
 
         row = extract_features(chal)
         if res is None:
             row.update(
                 {"outcome": None, "label": None, "trainable": None, "matched_by": None}
             )
-            warnings.append(f"row {i}: no matching result (challenge_id={cid!r})")
+            if not warned:
+                warnings.append(f"row {i}: no matching result (challenge_id={cid!r})")
         else:
             row.update(
                 {

--- a/baselines/src/apply_ablate/difficulty/features.py
+++ b/baselines/src/apply_ablate/difficulty/features.py
@@ -115,6 +115,13 @@ def extract_features(record: dict[str, Any]) -> dict[str, Any]:
     feats["task_id"] = record.get("task_id")
     feats["file_path"] = record.get("file_path")
     feats["proof_assistant"] = record.get("proof_assistant")
+    # Which ablation mode this challenge was drawn under ("leaves" / "whole"), when the
+    # source challenges.jsonl was produced by sample_disjoint.py / sample_paired.py. Not a
+    # model feature (excluded from DEFAULT_FEATURES) -- it's a join-disambiguation column:
+    # challenge_id does NOT encode mode (see ablators/lean/Ablator/Record.lean:87-96), so a
+    # paired easy/hard sample shares challenge_id across modes and needs `sample_mode` to
+    # join to the right result row.
+    feats["sample_mode"] = record.get("sample_mode")
 
     # --- counts ---
     feats["n_proofs"] = _num(record.get("n_proofs"))

--- a/baselines/tests/test_difficulty.py
+++ b/baselines/tests/test_difficulty.py
@@ -311,3 +311,61 @@ def test_build_table_positional_fallback_and_mismatch(tmp_path: Path):
     # second row's task_id/file_path disagree -> unmatched, warned
     assert rows[1]["matched_by"] is None and rows[1]["label"] is None
     assert any("mismatch" in w for w in warnings)
+
+
+def test_build_table_pairs_by_challenge_id_and_mode(tmp_path: Path):
+    """A paired easy/hard sample (pipeline/sample_paired.py) shares `challenge_id` across
+    modes on purpose (the ablator's id hash excludes mode -- see
+    ablators/lean/Ablator/Record.lean:87-96). When the challenges file is itself
+    mode-tagged, the join must land on the SAME mode's result, not whichever one happens
+    to be in the results file."""
+    chals = [
+        {
+            "challenge_id": "shared",
+            "sample_mode": "leaves",
+            "task_id": "t",
+            "file_path": "F",
+            "deleted_lemmas": [],
+            "holes_filled": [],
+        },
+    ]
+    # pooled results: both modes' outcomes for the SAME challenge_id, disagreeing on PASS
+    results = [
+        {"challenge_id": "shared", "sample_mode": "whole", "succeeded": False},
+        {"challenge_id": "shared", "sample_mode": "leaves", "succeeded": True},
+    ]
+    cpath, rpath = tmp_path / "c.jsonl", tmp_path / "r.jsonl"
+    _write_jsonl(cpath, chals)
+    _write_jsonl(rpath, results)
+    rows, warnings = dataset.build_table(cpath, rpath)
+    assert warnings == []
+    assert len(rows) == 1
+    assert rows[0]["outcome"] == "pass" and rows[0]["label"] == 1
+    assert rows[0]["matched_by"] == "challenge_id"
+
+
+def test_build_table_pooled_results_do_not_silently_collide(tmp_path: Path):
+    """If the challenges file lacks a mode tag but the pooled results carry two different
+    modes' rows under the same `challenge_id`, the join is genuinely ambiguous -- it must
+    be skipped (and warned about), never silently resolved to whichever row loaded last."""
+    chals = [
+        {
+            "challenge_id": "shared",
+            "task_id": "t",
+            "file_path": "F",
+            "deleted_lemmas": [],
+            "holes_filled": [],
+        },
+    ]
+    results = [
+        {"challenge_id": "shared", "sample_mode": "leaves", "succeeded": True},
+        {"challenge_id": "shared", "sample_mode": "whole", "succeeded": False},
+    ]
+    cpath, rpath = tmp_path / "c.jsonl", tmp_path / "r.jsonl"
+    _write_jsonl(cpath, chals)
+    _write_jsonl(rpath, results)
+    rows, warnings = dataset.build_table(cpath, rpath)
+    assert len(rows) == 1
+    assert rows[0]["matched_by"] is None
+    assert rows[0]["outcome"] is None and rows[0]["label"] is None
+    assert any("ambiguous" in w for w in warnings)

--- a/baselines/tests/test_sample_paired.py
+++ b/baselines/tests/test_sample_paired.py
@@ -1,0 +1,207 @@
+"""Tests for pipeline/sample_paired.py: the shared-challenge_id easy/hard sample.
+
+Exercises the module directly (via `root=`/monkeypatched `ROOT`) against a small synthetic
+artifact tree, plus one subprocess run to check cross-process determinism under a fixed seed
+(mirroring test_sample_reproducibility.py's convention for sample_disjoint.py).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+PIPELINE_DIR = REPO_ROOT / "pipeline"
+
+# sample_paired.py is a standalone script outside any package -- load it by path so tests
+# don't need pipeline/ on sys.path for the whole session.
+_spec = importlib.util.spec_from_file_location(
+    "sample_paired", PIPELINE_DIR / "sample_paired.py"
+)
+assert _spec is not None and _spec.loader is not None
+sample_paired = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sample_paired)
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+def _record(cid: str, text: str) -> dict:
+    return {
+        "challenge_id": cid,
+        "challenge_file_content": text,
+        "solution_file_content": text + " solved",
+        "task_id": f"task_{cid}",
+        "file_path": f"F/{cid}.lean",
+        "proof_assistant": "lean",
+    }
+
+
+@pytest.fixture
+def fixture_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A scratch tree shaped like the real repo root: registry_all.tsv + both artifact trees.
+
+    repo_a: 3 challenge_ids shared by both modes (leaves text differs from whole text, as it
+            does in reality -- same problem, different holing) -- one of those 3 has DUPLICATE
+            text in the leaves pool under a different id, to prove text dedup still applies.
+    repo_b: 2 shared ids, plus one id present only in `leaves` (validation-dropped in `whole`,
+            as the real corpora do) to prove the intersection excludes unpaired ids.
+    """
+    root = tmp_path / "root"
+    (root / "pipeline").mkdir(parents=True)
+    (root / "pipeline" / "registry_all.tsv").write_text(
+        "repo_a\tdata/lean/repo_a\nrepo_b\tdata/lean/repo_b\n"
+    )
+
+    leaves = [
+        _record("a1", "repo_a leaves challenge 1"),
+        _record("a2", "repo_a leaves challenge 2"),
+        _record("a3", "repo_a leaves challenge 3"),
+        # duplicate TEXT under a different id -- must be deduped out of the leaves pool
+        _record("a1dup", "repo_a leaves challenge 1"),
+    ]
+    _write_jsonl(root / "artifacts/lean-ablate/repo_a/challenges.jsonl", leaves)
+    whole = [
+        _record("a1", "repo_a whole challenge 1"),
+        _record("a2", "repo_a whole challenge 2"),
+        _record("a3", "repo_a whole challenge 3"),
+    ]
+    _write_jsonl(root / "artifacts/lean-ablate-whole/repo_a/challenges.jsonl", whole)
+
+    _write_jsonl(
+        root / "artifacts/lean-ablate/repo_b/challenges.jsonl",
+        [
+            _record("b1", "repo_b leaves challenge 1"),
+            _record("b2", "repo_b leaves challenge 2"),
+            _record("b3-leaves-only", "repo_b leaves challenge 3 (unpaired)"),
+        ],
+    )
+    _write_jsonl(
+        root / "artifacts/lean-ablate-whole/repo_b/challenges.jsonl",
+        [
+            _record("b1", "repo_b whole challenge 1"),
+            _record("b2", "repo_b whole challenge 2"),
+        ],
+    )
+
+    monkeypatch.setattr(sample_paired, "ROOT", root)
+    return root
+
+
+def test_load_pool_dedups_by_text(fixture_root: Path) -> None:
+    pool = sample_paired.load_pool("leaves", root=fixture_root)
+    # a1dup shares text with a1 -- one of the two must have been dropped
+    assert len(pool["repo_a"]) == 3
+    ids = set(pool["repo_a"])
+    assert ids == {"a1", "a2", "a3"} or ids == {"a1dup", "a2", "a3"}
+    for line in pool["repo_a"].values():
+        assert json.loads(line)["sample_mode"] == "leaves"
+
+
+def test_intersection_excludes_unpaired_ids(fixture_root: Path) -> None:
+    easy_pool = sample_paired.load_pool("leaves", root=fixture_root)
+    hard_pool = sample_paired.load_pool("whole", root=fixture_root)
+    pairs = sample_paired.intersect(easy_pool, hard_pool)
+    assert set(pairs["repo_a"]) == {"a1", "a2", "a3"}
+    # b3-leaves-only has no `whole` counterpart -- must not appear in the pairing
+    assert set(pairs["repo_b"]) == {"b1", "b2"}
+
+
+def test_main_emits_paired_dirs_with_equal_challenge_id_sets(fixture_root: Path) -> None:
+    out_dir = fixture_root / "out"
+    sample_paired.main([str(out_dir), "5", "--seed", "42"])
+
+    easy_sample = [json.loads(line) for line in (out_dir / "easy" / "sample.jsonl").open()]
+    hard_sample = [json.loads(line) for line in (out_dir / "hard" / "sample.jsonl").open()]
+
+    easy_ids = {r["challenge_id"] for r in easy_sample}
+    hard_ids = {r["challenge_id"] for r in hard_sample}
+    assert easy_ids == hard_ids
+    assert easy_ids  # non-empty
+    # unpaired id never selected
+    assert "b3-leaves-only" not in easy_ids
+
+    # each mode carries its own tag, and the tag matches eval_sample.sh's --mode vocabulary
+    assert {r["sample_mode"] for r in easy_sample} == {"leaves"}
+    assert {r["sample_mode"] for r in hard_sample} == {"whole"}
+
+    # the two files disagree on TEXT for every shared id (leaves vs whole holing differs) --
+    # pairing is on challenge_id, not on byte-identical content
+    easy_by_id = {r["challenge_id"]: r["challenge_file_content"] for r in easy_sample}
+    hard_by_id = {r["challenge_id"]: r["challenge_file_content"] for r in hard_sample}
+    for cid in easy_ids:
+        assert easy_by_id[cid] != hard_by_id[cid]
+
+
+def test_main_deterministic_under_fixed_seed(fixture_root: Path) -> None:
+    out1 = fixture_root / "out1"
+    out2 = fixture_root / "out2"
+    sample_paired.main([str(out1), "3", "--seed", "7"])
+    sample_paired.main([str(out2), "3", "--seed", "7"])
+    for tag in ("easy", "hard"):
+        assert (out1 / tag / "sample.jsonl").read_bytes() == (
+            out2 / tag / "sample.jsonl"
+        ).read_bytes()
+        assert (out1 / tag / "manifest.json").read_text() == (
+            out2 / tag / "manifest.json"
+        ).read_text()
+
+
+def test_main_different_seed_can_differ(fixture_root: Path) -> None:
+    out1 = fixture_root / "out1"
+    out2 = fixture_root / "out2"
+    sample_paired.main([str(out1), "2", "--seed", "1"])
+    sample_paired.main([str(out2), "2", "--seed", "2"])
+    ids1 = {json.loads(line)["challenge_id"] for line in (out1 / "easy" / "sample.jsonl").open()}
+    ids2 = {json.loads(line)["challenge_id"] for line in (out2 / "easy" / "sample.jsonl").open()}
+    # both still pair correctly regardless of which ids the seed happened to pick
+    hard_ids2 = {
+        json.loads(line)["challenge_id"] for line in (out2 / "hard" / "sample.jsonl").open()
+    }
+    assert ids2 == hard_ids2
+    # not asserting ids1 != ids2 (small pool -- a coincidental match is possible); the
+    # meaningful property is per-seed determinism + pairing, checked above and in the
+    # fixed-seed test.
+    assert ids1 and ids2
+
+
+def test_exclude_drops_ids_by_text(fixture_root: Path) -> None:
+    # First sample everything from repo_a.
+    first = fixture_root / "first"
+    sample_paired.main([str(first), "10", "--seed", "42"])
+    excl = first / "easy" / "sample.jsonl"
+
+    second = fixture_root / "second"
+    sample_paired.main([str(second), "10", "--seed", "42", "--exclude", str(excl)])
+    remaining = [json.loads(line) for line in (second / "easy" / "sample.jsonl").open()]
+    # everything paired was already excluded (small fixture), so nothing is left to sample
+    assert remaining == []
+
+
+def test_subprocess_reproducibility_across_processes(fixture_root: Path) -> None:
+    """Same seed -> byte-identical output across two independent Python processes."""
+    out1 = fixture_root / "sub_out1"
+    out2 = fixture_root / "sub_out2"
+    env = {"PIPELINE_SAMPLE_ROOT": str(fixture_root), "PATH": "/usr/bin:/bin"}
+    for out in (out1, out2):
+        result = subprocess.run(
+            [sys.executable, str(PIPELINE_DIR / "sample_paired.py"), str(out), "4", "--seed", "9"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+
+    for tag in ("easy", "hard"):
+        assert (out1 / tag / "sample.jsonl").read_bytes() == (
+            out2 / tag / "sample.jsonl"
+        ).read_bytes()

--- a/pipeline/sample_paired.py
+++ b/pipeline/sample_paired.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Draw a PAIRED easy/hard sample: the same problem set, scored under both ablation modes.
+
+The paper's headline claim is that `hard` (whole-proof holing) is meaningfully harder than
+`easy` (leaf holing). That comparison is only honest if both splits are scored on the SAME
+problems -- otherwise a difference in pass rate could just be a difference in which problems
+were drawn.
+
+Pairing is a join, not a search, because `challenge_id` does not encode mode:
+
+    challenge_id = sha1_16(file_path | seed | variant | sorted(deleted_lemma_names)
+                            | sorted(holed_theorem_names))
+
+(ablators/lean/Ablator/Record.lean:87-96). Both modes enumerate the same corollary openers
+and delete the same lemmas at a fixed seed; they differ only in how the deleted lemma's
+in-file *users* get holed. So a challenge mined in `leaves` mode and its counterpart mined in
+`whole` mode carry the SAME challenge_id, and pairing is just intersecting the two id sets.
+
+Usage: sample_paired.py <out-dir> <n> [--exclude <other-sample.jsonl> ...] [--seed <seed>]
+
+Emits `<out-dir>/easy/` (leaves) and `<out-dir>/hard/` (whole), each shaped exactly like
+`sample_disjoint.py`'s output (per-repo `<repo>.jsonl`, `manifest.json`, `sample.jsonl`) so
+`eval_sample.sh <out-dir>/easy <model> ... --mode leaves` and
+`eval_sample.sh <out-dir>/hard <model> ... --mode whole` work unmodified. Every row in both
+trees is tagged `sample_mode` ("leaves" / "whole") -- the same field `eval_sample.sh` already
+stamps onto result rows -- so a downstream consumer that pools both modes' results into one
+file can still join correctly by keying on `(challenge_id, sample_mode)` instead of a bare
+`challenge_id` (see `pipeline/score_predictions.py` and
+`baselines/src/apply_ablate/difficulty/dataset.py`).
+
+Allocation policy and TEXT-level dedup are reused from `sample_disjoint.py` verbatim: 2
+problems/repo (shortfall filled 1-at-a-time from the repos with the FEWEST remaining pairs
+first), and dedup is on the challenge TEXT (sha256 of `challenge_file_content`), not
+`challenge_id` -- an earlier ablator shipped byte-identical challenges under different ids,
+which would otherwise leak problems across a split. Dedup is applied independently within
+each mode's pool BEFORE intersecting, so a duplicate-text row surviving in one mode but not
+the other cannot smuggle a repeated problem back in through the pairing.
+"""
+
+from __future__ import annotations
+
+import glob
+import hashlib
+import json
+import os
+import random
+import shutil
+import sys
+from pathlib import Path
+
+# Overridable for isolated testing (subprocess tests can point this at a scratch tree without
+# touching the real repo's artifacts/ or pipeline/registry_all.tsv).
+ROOT = Path(os.environ.get("PIPELINE_SAMPLE_ROOT") or Path(__file__).resolve().parent.parent)
+
+# out-dir subdir name -> (sample_mode tag, artifact tree). Values match sample_disjoint.py's
+# `--mode` vocabulary exactly, so eval_sample.sh's `--mode leaves|whole` and the `sample_mode`
+# it stamps onto results line up with what we stamp onto challenges here.
+DIR_MODE = {
+    "easy": "leaves",
+    "hard": "whole",
+}
+MODE_ARTIFACT_DIR = {
+    "leaves": "artifacts/lean-ablate",
+    "whole": "artifacts/lean-ablate-whole",
+}
+
+
+def h(rec: dict) -> str:
+    return hashlib.sha256(rec["challenge_file_content"].encode()).hexdigest()
+
+
+def load_pool(mode: str, root: Path | None = None) -> dict[str, dict[str, str]]:
+    """Per-repo {challenge_id: jsonl-line} for one mode's artifact tree.
+
+    TEXT-deduped (first-seen wins, matching `sample_disjoint.py`) and tagged with
+    `sample_mode`. Rows without a `challenge_id` are skipped: pairing needs a stable join key,
+    and legacy pre-enriched-schema rows predate it.
+
+    `root` defaults to the *current* module-level `ROOT` (looked up at call time, not at
+    def time), so tests can `monkeypatch.setattr(sample_paired, "ROOT", tmp_path)` and have
+    it take effect for callers -- like `main()` -- that don't pass `root` explicitly.
+    """
+    root = ROOT if root is None else root
+    pool: dict[str, dict[str, str]] = {}
+    glob_pattern = str(root / MODE_ARTIFACT_DIR[mode] / "*/challenges.jsonl")
+    for f in sorted(glob.glob(glob_pattern)):
+        repo = os.path.basename(os.path.dirname(f))
+        seen_text: set[str] = set()
+        rows: dict[str, str] = {}
+        for line in open(f):
+            if not line.strip():
+                continue
+            rec = json.loads(line)
+            cid = rec.get("challenge_id")
+            if not cid:
+                continue
+            tkey = h(rec)
+            if tkey in seen_text:
+                continue
+            seen_text.add(tkey)
+            rec["sample_mode"] = mode
+            rows[cid] = json.dumps(rec) + "\n"
+        if rows:
+            pool[repo] = rows
+    return pool
+
+
+def intersect(
+    easy_pool: dict[str, dict[str, str]], hard_pool: dict[str, dict[str, str]]
+) -> dict[str, list[str]]:
+    """repo -> sorted challenge_ids present (post text-dedup) in BOTH pools."""
+    out: dict[str, list[str]] = {}
+    for repo in sorted(set(easy_pool) & set(hard_pool)):
+        ids = sorted(set(easy_pool[repo]) & set(hard_pool[repo]))
+        if ids:
+            out[repo] = ids
+    return out
+
+
+def allocate(counts: dict[str, int], n_target: int) -> dict[str, int]:
+    """sample_disjoint.py's policy: 2/repo, shortfall from the fewest-remaining repos first."""
+    take = {r: min(2, c) for r, c in counts.items()}
+    total = sum(take.values())
+    while total < n_target:
+        cand = [r for r in counts if counts[r] - take[r] > 0]
+        if not cand:
+            break
+        cand.sort(key=lambda r: (counts[r] - take[r], r))  # fewest remaining first
+        for r in cand:
+            if total >= n_target:
+                break
+            take[r] += 1
+            total += 1
+    return take
+
+
+def main(argv: list[str] | None = None) -> None:
+    argv = sys.argv[1:] if argv is None else argv
+    out_dir = argv[0]
+    n_target = int(argv[1])
+    excluded: set[str] = set()
+    seed = 42
+
+    if "--exclude" in argv:
+        for p in argv[argv.index("--exclude") + 1 :]:
+            if p.startswith("--"):
+                break
+            excluded |= {h(json.loads(line)) for line in open(p) if line.strip()}
+
+    if "--seed" in argv:
+        seed = int(argv[argv.index("--seed") + 1])
+
+    reg = dict(
+        line.rstrip("\n").split("\t")
+        for line in open(ROOT / "pipeline/registry_all.tsv")
+        if line.strip()
+    )
+
+    easy_pool = load_pool("leaves")
+    hard_pool = load_pool("whole")
+    pairs = intersect(easy_pool, hard_pool)
+
+    if excluded:
+        pruned: dict[str, list[str]] = {}
+        for repo, ids in pairs.items():
+            kept = [
+                cid
+                for cid in ids
+                if h(json.loads(easy_pool[repo][cid])) not in excluded
+                and h(json.loads(hard_pool[repo][cid])) not in excluded
+            ]
+            if kept:
+                pruned[repo] = kept
+        pairs = pruned
+
+    counts = {r: len(ids) for r, ids in pairs.items()}
+    take = allocate(counts, n_target)
+
+    out = Path(out_dir)
+    shutil.rmtree(out, ignore_errors=True)
+    easy_dir, hard_dir = out / "easy", out / "hard"
+    easy_dir.mkdir(parents=True)
+    hard_dir.mkdir(parents=True)
+
+    manifests = {"easy": [], "hard": []}
+    n = 0
+    for repo, k in sorted(take.items()):
+        if not k:
+            continue
+        ids = pairs[repo][:]
+        random.Random(seed).shuffle(ids)
+        picked = ids[:k]
+        for tag, pool, d in (("easy", easy_pool, easy_dir), ("hard", hard_pool, hard_dir)):
+            rows = [pool[repo][cid] for cid in picked]
+            (d / f"{repo}.jsonl").write_text("".join(rows))
+            manifests[tag].append(
+                {
+                    "repo": repo,
+                    "n": len(picked),
+                    "src": reg[repo],
+                    "seed": seed,
+                    "sample_mode": DIR_MODE[tag],
+                    "challenge_ids": picked,
+                }
+            )
+        n += len(picked)
+
+    for tag, d in (("easy", easy_dir), ("hard", hard_dir)):
+        json.dump(manifests[tag], open(d / "manifest.json", "w"), indent=1)
+        with open(d / "sample.jsonl", "w") as out_f:
+            for m in manifests[tag]:
+                out_f.writelines(open(d / f"{m['repo']}.jsonl").readlines())
+
+    easy_ids = {json.loads(line)["challenge_id"] for line in open(easy_dir / "sample.jsonl")}
+    hard_ids = {json.loads(line)["challenge_id"] for line in open(hard_dir / "sample.jsonl")}
+    assert easy_ids == hard_ids, "paired samples must share an identical challenge_id set"
+    print(
+        f"paired-sampled {n} problems across {len(manifests['easy'])} repos -> "
+        f"{out_dir}/{{easy,hard}} ({len(easy_ids)} shared challenge_ids)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/score_predictions.py
+++ b/pipeline/score_predictions.py
@@ -9,6 +9,14 @@ what `class_weight="balanced"` training produces.
 Non-scorable outcomes (malformed / trivial / context_exceeded) are dropped: the model never
 saw those problems, so they are not evidence about the *solver*.
 
+`challenge_id` does not encode ablation mode (see ablators/lean/Ablator/Record.lean:87-96), so
+a paired easy/hard sample (`pipeline/sample_paired.py`) shares `challenge_id` across the two
+modes on purpose. If `scored.jsonl` / `results.jsonl` ever pool rows from both modes, keying
+`pred` by a bare `challenge_id` would let the second mode's row silently overwrite the first's
+prediction or outcome. So the join key is `(challenge_id, sample_mode)`; when `sample_mode` is
+absent on both sides (legacy / single-mode files) that degenerates to `(challenge_id, None)`
+on both sides, i.e. the old behaviour.
+
 Usage: score_predictions.py <scored.jsonl> <results.jsonl>
 """
 
@@ -17,8 +25,14 @@ from __future__ import annotations
 import json
 import re
 import sys
+from typing import Any
 
 OVER = re.compile(r"too large for model|maximum context length", re.I)
+
+
+def _key(r: dict[str, Any]) -> tuple[str, Any] | None:
+    cid = r.get("challenge_id")
+    return (cid, r.get("sample_mode")) if cid else None
 
 
 def main() -> None:
@@ -26,14 +40,17 @@ def main() -> None:
     pred = {}
     for line in open(scored_path):
         r = json.loads(line)
+        key = _key(r)
+        if key is None:
+            continue
         # the model emits `difficulty` = P(fail); we want P(pass)
-        pred[r["challenge_id"]] = 1.0 - float(r["difficulty"])
+        pred[key] = 1.0 - float(r["difficulty"])
 
     y, p, dropped = [], [], 0
     for line in open(results_path):
         r = json.loads(line)
-        cid = r.get("challenge_id")
-        if cid not in pred:
+        key = _key(r)
+        if key is None or key not in pred:
             continue
         err = r.get("error") or ""
         if (
@@ -45,7 +62,7 @@ def main() -> None:
             dropped += 1
             continue
         y.append(1 if r.get("succeeded") else 0)
-        p.append(pred[cid])
+        p.append(pred[key])
 
     n = len(y)
     if not n:


### PR DESCRIPTION
## Why

The paper's headline claim is that `hard` (whole-proof holing) is harder than `easy` (leaf holing). That comparison is only honest if **both splits are scored on the same problems** — otherwise a pass-rate difference could just be a difference in which problems were drawn. There was previously no way to draw such a sample.

## Pairing is a join, not a search

`challenge_id = sha1_16(file_path | seed | variant | sorted(deleted_lemmas) | sorted(holed_theorems))` (`ablators/lean/Ablator/Record.lean:87-96`) — **the mode is not in the key.** Both modes enumerate the same corollary openers and delete the same lemmas at a fixed seed, differing only in how the deleted lemma's in-file *users* are holed. `mined_total` is identical across modes for all **57/57** repos.

So a matched pair shares an id, and pairing is just intersecting the two id sets per repo.

## What lands

- `pipeline/sample_paired.py` — emits `<out-dir>/easy/` and `<out-dir>/hard/`, shaped exactly like `sample_disjoint.py`'s output so `eval_sample.sh` consumes both unmodified.
- Allocation policy and **text-level** dedup reused verbatim (sha256 of `challenge_file_content`, not `challenge_id` — an earlier ablator shipped byte-identical challenges under different ids). Dedup runs **per-mode before intersecting**, so a duplicate-text row surviving in one mode but not the other cannot smuggle a repeated problem back through the pairing.
- **The id-collision hazard is closed in the same PR**, as the issue required: pooling both modes' results made `difficulty build-table` and `score_predictions.py` silently collide. Rows now carry `sample_mode` and those joins key on `(challenge_id, sample_mode)`.

**96 tests pass** (87 + 9 new in `test_sample_paired.py`).

## Provenance

Recovered from dispatch run `wf_bd57f49e-29c`, whose agent completed the work but exited without committing or pushing — the workflow's only incomplete task. Reviewed and verified before landing rather than re-run.

Stacked on #157 (`dispatch/125-sample-mode`).

Closes #126.