### PR TITLE
contamination: direct The Stack / SWH membership check per repo

### DIFF
--- a/docs/contamination.agents.md
+++ b/docs/contamination.agents.md
@@ -56,7 +56,73 @@ interlocking lemmas that were never simultaneously absent is not. That curve is 
 methodological contribution in the GSM-Symbolic tradition, not merely a defense. The knob
 already exists (`--count N` over the corollary closure).
 
-## Preliminary evidence (weak, but points the right way)
+## Direct measurement: The Stack / Software Heritage membership check (issue #137)
+
+This replaces the stars/age proxy below as the lead instrument. Ran
+`pipeline/membership_check.py` over all 57 repos in `pipeline/repos.tsv`; output committed at
+`pipeline/membership.tsv`.
+
+**Method.** The Stack v1/v2 aren't full-text searchable without downloading terabytes of
+parquet (v2 is also gated on HuggingFace, so `datasets-server` search 404s without an accepted
+license click-through). But **The Stack v2 is built directly from a dated Software Heritage
+(SWH) graph snapshot** — "3.28B files belonging to 104.2M GitHub repositories were collected by
+traversing the Software Heritage 2023-09-06 graph dataset" (the-stack-v2 dataset card) — and
+SWH's public API records, per origin, the dated history of every crawl ("visit") it has made. So
+instead of a popularity proxy, the script queries SWH directly for each repo's origin and visit
+history and compares the **earliest visit date** against the documented snapshot cutoffs:
+
+- Stack v1 cutoff: **2022-06** (files "downloaded from public GitHub repositories between
+  November 2021 and June 2022" — the-stack v1 dataset card)
+- Stack v2 cutoff: **2023-09-06** (SWH graph snapshot date)
+
+`earliest_visit <= cutoff` is necessary but not sufficient for actual dataset inclusion (SWH
+crawling by that date doesn't guarantee the-stack's own license/dedup filtering kept the repo),
+so the table reports `likely_in` / `too_recent` / `not_in_swh` / `UNKNOWN`, not a hard
+yes/no — still strictly more direct than a variable (stars) that only proxies duplication count
+through a broken chain (see below). `--infinigram` optionally cross-checks the repo's
+`owner/name` slug against AI2's infini-gram API (`v4_dolma-v1_7_llama` index) as a secondary,
+noisier signal (a slug can appear in link lists without the code being duplicated).
+
+**Result, run 2026-08-21 (57/57 repos resolved, zero UNKNOWN):**
+
+| Stack v2 status (SWH visit <= 2023-09-06) | count |
+|---|---|
+| `likely_in` | **2** (`starkware-formal-proofs`, `symcrust`) |
+| `too_recent` (SWH has visited, but only after the cutoff) | 9 |
+| `not_in_swh` (no SWH visit found at all) | 46 |
+| `UNKNOWN` (API failure) | 0 |
+
+Only `symcrust` (the vendored `microsoft/SymCrypt`, earliest visit 2022-03) clears the *Stack
+v1* cutoff too. This corroborates the "Corpus facts" recency skew below through a direct
+instrument rather than an inferred one: **the overwhelming majority of this corpus (55/57 by
+this measure) was never crawled by Software Heritage before either Stack snapshot**, so
+knowledge-level memorization of these specific repos' code from Stack-derived pretraining is
+implausible for all but two of them. infini-gram slug counts (Dolma v1.7) were 0 for every repo
+except `lean-mlir` (2) and `symcrust` (3) — consistent with the SWH picture and too sparse to
+say more than "consistent."
+
+**Correlation with pass rate: not yet run.** The join key is `repo name` (this table's `name`
+column = `challenge["repo"]` in ablator output = the `repo` field in
+`baselines/apply_ablate` result JSONL) against a macro-averaged per-repo pass rate. No baseline
+run currently covers enough of the 57-repo corpus to compute that — see
+`macro_pass_rate_join_hook()` in `pipeline/membership_check.py` for the documented hook
+(raises `NotImplementedError` rather than fabricating numbers) and implementation sketch. Wire
+it up once a corpus-wide baseline exists.
+
+### Reproduce
+
+```bash
+python3 pipeline/membership_check.py --infinigram --out pipeline/membership.tsv
+```
+Network access required; every API call is wrapped so a transient failure records `UNKNOWN`
+rather than crashing the run (SWH unauthenticated rate limit is 120 req/hr — the script
+throttles with `--sleep`, default 0.6s).
+
+## Robustness footnote: repo popularity (stars/age) — weak instrument, do not lead with it
+
+Superseded by the direct SWH/Stack measurement above; kept as a secondary robustness check
+because it was the first thing tried and its qualitative direction (no evidence memorization
+drives pass rate) agrees with the direct measurement.
 
 Joined the per-repo pass rates in `docs/leanstral-baseline-100.md` against GitHub
 popularity/age metadata. If memorization drove performance, pass rate should rise with how
@@ -97,7 +163,7 @@ done > stars.tsv
 Note: `gh` prints a `mise` banner to stdout in this environment — the `grep -E '^[0-9]'`
 filter above is load-bearing.
 
-## Why repo popularity is a WEAK instrument (do not publish on it)
+### Why repo popularity is a WEAK instrument (do not publish on it)
 
 Stars proxy contamination only insofar as they proxy **duplication count in the training
 corpus**, which is the variable that actually drives memorization (Carlini et al.,
@@ -122,7 +188,7 @@ nearly free. See below.
 |---|---|---|
 | **Temporal holdout / live benchmarks** | LiveCodeBench, LiveBench, GSM1K (*A Careful Examination of LLM Performance on Grade School Arithmetic*) | **Yes — cheapest for us of anyone.** Gold standard; needs no corpus access, no logprobs |
 | **N-gram / substring overlap vs. training corpus** | GPT-3 and Llama papers; standard in model cards | Not against closed corpora. Open approximation: AI2 **infini-gram**, **WIMBD** |
-| **Corpus membership check** | The Stack / Software Heritage (documented snapshot dates + inclusion lists) | **Yes — this is the correct version of what stars gesture at.** Direct measurement, ~an afternoon |
+| **Corpus membership check** | The Stack / Software Heritage (documented snapshot dates + inclusion lists) | **Done — see "Direct measurement" above.** `pipeline/membership_check.py` / `pipeline/membership.tsv` |
 | **Membership inference from logprobs** | Min-K% Prob (Shi et al.), Min-K%++, reference-model perplexity | Open-weight models only; most frontier APIs withhold logprobs |
 | **Exchangeability / ordering test** | Oren et al., *Proving Test Set Contamination in Black Box Language Models* | Needs logprobs |
 | **Verbatim-completion / guided prompting** | Golchin & Surdeanu, *Time Travel in LLMs* | **Yes, cheap** |
@@ -140,12 +206,14 @@ nearly free. See below.
    to this project; likely the paper's most interesting figure.
 3. **Verbatim recall probe.** Given the lemma name + surrounding context but not the body,
    can the model state it? Decorrelates memorization from ability.
-4. **The Stack / infini-gram membership check** per repo. Replaces the stars proxy with a
-   direct measurement at comparable cost.
+4. ~~**The Stack / infini-gram membership check** per repo.~~ **Done** — see "Direct
+   measurement" above (`pipeline/membership_check.py`, `pipeline/membership.tsv`). Replaced
+   the stars proxy with a direct measurement; the pass-rate correlation step is still blocked
+   on a corpus-wide baseline run (documented hook, no fabricated numbers).
 5. **Min-K%** on whichever open-weight models are in the grid. Secondary signal.
-6. **Stars / age** → robustness footnote, if included at all.
+6. **Stars / age** → robustness footnote (done, see above), included only for agreement-check.
 
-Items 1–3 are ~3 weeks of runs with tooling that already exists. Item 4 is an afternoon.
+Items 1–3 are ~3 weeks of runs with tooling that already exists. Item 4 took an afternoon.
 
 ## Corpus facts useful for building the temporal split
 

--- a/pipeline/membership.tsv
+++ b/pipeline/membership.tsv
@@ -1,0 +1,58 @@
+name	url	swh_known	earliest_visit_date	latest_visit_date	num_visits	stack_v1_status	stack_v2_status	infinigram_index	infinigram_count	infinigram_approx	notes
+ArkLib	https://github.com/Verified-zkEVM/ArkLib	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+Clear	https://github.com/NethermindEth/Clear	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+CompPoly	https://github.com/Verified-zkEVM/CompPoly	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+CvxLean	https://github.com/verified-optimization/CvxLean	yes	2025-07-08	2025-07-08	1	too_recent	too_recent	v4_dolma-v1_7_llama	0	False	
+FLoPS	https://github.com/rutgers-apl/FLoPS	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+FVIntmax	https://github.com/NethermindEth/FVIntmax	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+Foundation	https://github.com/FormalizedFormalLogic/Foundation	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+LNSym	https://github.com/leanprover/LNSym	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+Lentil	https://github.com/verse-lab/Lentil	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+LeroyCompilerVerificationCourse	https://github.com/leanprover/LeroyCompilerVerificationCourse	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+SampCert	https://github.com/leanprover/SampCert	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+SizzLean	https://github.com/etheorem/etheorem	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+TTBFL	https://github.com/ionathanch/TTBFL	yes	2025-02-09	2026-08-09	11	too_recent	too_recent	v4_dolma-v1_7_llama	0	False	
+TensorLib	https://github.com/leanprover/TensorLib	yes	2024-12-22	2026-08-06	15	too_recent	too_recent	v4_dolma-v1_7_llama	0	False	
+TorchLean	https://github.com/lean-dojo/TorchLean	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+VCV-io	https://github.com/Verified-zkEVM/VCV-io	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+aeneas	https://github.com/AeneasVerif/aeneas	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+btc-verified	https://github.com/ProofOfKeags/btc-verified	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+capless-lean	https://github.com/Linyxus/capless-lean	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+cedar-spec	https://github.com/cedar-policy/cedar-spec.git	yes	2025-07-18	2026-08-15	20	too_recent	too_recent	v4_dolma-v1_7_llama	0	False	
+clean	https://github.com/Verified-zkEVM/clean	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+cslib	https://github.com/leanprover/cslib	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+curve25519-dalek-lean-verify	https://github.com/Beneficial-AI-Foundation/curve25519-dalek-lean-verify	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+dolev-yao	https://github.com/metareflection/dolev-yao	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+evm-asm	https://github.com/Verified-zkEVM/evm-asm	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+formal-snarks-project	https://github.com/BoltonBailey/formal-snarks-project	yes	2026-05-08	2026-05-08	1	too_recent	too_recent	v4_dolma-v1_7_llama	0	False	
+hax-proof-libs-lean	https://github.com/cryspen/hax	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+hex-dev	https://github.com/kim-em/hex-dev	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+iris-lean	https://github.com/leanprover-community/iris-lean	yes	2024-05-01	2026-06-18	24	too_recent	too_recent	v4_dolma-v1_7_llama	0	False	
+jolt-tla	https://github.com/CharlesHoskinson/jolt-tla	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+juvix-lean	https://github.com/anoma/juvix-lean	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+lampe	https://github.com/reilabs/lampe	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+lean-formal-reasoning-program	https://github.com/andaraiwin/lean-formal-reasoning-program	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+lean-mlir	https://github.com/opencompl/lean-mlir	yes	2023-12-29	2026-08-18	41	too_recent	too_recent	v4_dolma-v1_7_llama	2	False	
+lean-yjs	https://github.com/iasakura/lean-yjs	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+lean-zip	https://github.com/kim-em/lean-zip	yes	2026-04-14	2026-08-08	4	too_recent	too_recent	v4_dolma-v1_7_llama	0	False	
+lean4lean	https://github.com/digama0/lean4lean	yes	2026-06-05	2026-06-05	1	too_recent	too_recent	v4_dolma-v1_7_llama	0	False	
+loom	https://github.com/verse-lab/loom	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+nickelean	https://github.com/lexicone42/nickelean	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+proven-zk	https://github.com/reilabs/proven-zk	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+ryu-lean4	https://github.com/lexicone42/ryu-lean4	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+shortest-decimal	https://github.com/lexicone42/shortest-decimal	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+sparkle	https://github.com/Verilean/sparkle	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+splean	https://github.com/verse-lab/splean	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+starkware-formal-proofs	https://github.com/starkware-libs/formal-proofs	yes	2023-05-23	2026-08-12	11	too_recent	likely_in	v4_dolma-v1_7_llama	0	False	
+veil	https://github.com/verse-lab/veil	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+verified-compiler	https://github.com/marcusrossel/verified-compiler	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+verity	https://github.com/lfglabs-dev/verity	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+yul-semantics	https://github.com/powdr-labs/yul-semantics	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+apc-optimizer	https://github.com/powdr-labs/apc-optimizer	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+yul-compiler	https://github.com/powdr-labs/yul-compiler	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+leanda	https://github.com/konnov/leanda	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+verified-consensus	https://github.com/fradamt/verified-consensus	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+posix-parsing	https://github.com/keeganperry7/posix-parsing	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+posix-submatching	https://github.com/keeganperry7/posix-submatching	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+adler-proofs	https://github.com/septract/adler-proofs	no			-1	not_in_swh	not_in_swh	v4_dolma-v1_7_llama	0	False	
+symcrust	https://github.com/microsoft/SymCrypt	yes	2022-03-01	2026-07-24	100	likely_in	likely_in	v4_dolma-v1_7_llama	3	False	

--- a/pipeline/membership_check.py
+++ b/pipeline/membership_check.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Direct training-corpus membership check for every repo in `repos.tsv` (issue #137).
+
+Replaces the stars/age correlation (see `docs/contamination.agents.md`) with a *direct*
+measurement: does this origin URL appear in the corpus a documented training-data snapshot
+was built from?
+
+## Method
+
+The Stack v1/v2 are not full-text searchable without downloading terabytes of parquet (v2 is
+also gated behind a license click-through on HuggingFace, so `datasets-server` search 404s
+without an accepted `HF_TOKEN`). But **The Stack v2 is built directly from a dated Software
+Heritage (SWH) graph snapshot** ("3.28B files belonging to 104.2M GitHub repositories were
+collected by traversing the Software Heritage 2023-09-06 graph dataset" — the-stack-v2 dataset
+card), and SWH's public API records, per origin, the dated history of every crawl ("visit") it
+has made. So instead of approximating membership through popularity (stars/age), we query SWH
+directly for each repo's origin and visit history, and compare the *earliest* visit date against
+the documented snapshot cutoffs:
+
+- The Stack v1 cutoff: **2022-06** (files "downloaded from public GitHub repositories between
+  November 2021 and June 2022" — the-stack v1 dataset card)
+- The Stack v2 cutoff: **2023-09-06** (SWH graph snapshot date — the-stack-v2 dataset card)
+
+`earliest_visit_date <= cutoff` is necessary but not sufficient for actual inclusion (SWH
+crawling the repo by that date does not guarantee the-stack's own filtering/dedup/license
+pipeline kept it), so results are reported as `likely_v1` / `likely_v2` / `not_in_swh` /
+`too_recent` / `unknown`, not a hard yes/no. This is still strictly more direct than the
+stars/age proxy it replaces: it is dated evidence about *this exact origin URL*, not a proxy
+correlated with duplication count.
+
+## Optional cross-check: AI2 infini-gram
+
+`--infinigram` additionally queries api.infini-gram.io for the raw count of the repo's
+`owner/name` slug string inside an open pretraining corpus (default: `v4_dolma-v1_7_llama`).
+This is a weak, noisy secondary signal (a slug can appear in READMEs/link lists without the
+*code* being duplicated, and non-appearance doesn't prove non-membership) — kept optional and
+clearly labeled as such in the output, per the issue's "optionally cross-check" framing.
+
+## Usage
+
+    uv run --no-project python3 pipeline/membership_check.py [--infinigram] [--out membership.tsv]
+
+Network access required. Every API call is wrapped so a transient failure records `UNKNOWN`
+rather than crashing the run — see `_get_json`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+REPOS_TSV = ROOT / "pipeline" / "repos.tsv"
+DEFAULT_OUT = ROOT / "pipeline" / "membership.tsv"
+
+SWH_API = "https://archive.softwareheritage.org/api/1"
+INFINIGRAM_API = "https://api.infini-gram.io/"
+INFINIGRAM_DEFAULT_INDEX = "v4_dolma-v1_7_llama"
+
+STACK_V1_CUTOFF = date(2022, 6, 30)
+STACK_V2_CUTOFF = date(2023, 9, 6)
+
+USER_AGENT = "for-all-dev-git-history-evals-membership-check/1.0"
+
+
+def _get_json(url: str, *, timeout: float = 20.0, method: str = "GET", data: bytes | None = None) -> tuple[dict | list | None, str | None]:
+    """GET/POST `url`, return (parsed_json, None) on success or (None, error_str) on failure.
+
+    Never raises — every caller treats a failure as UNKNOWN, per the issue's robustness
+    requirement ("record UNKNOWN rather than crashing").
+    """
+    headers = {"User-Agent": USER_AGENT}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read()
+        return json.loads(body), None
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None, "not_found"
+        return None, f"http_error_{e.code}"
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as e:
+        return None, f"{type(e).__name__}: {e}"
+
+
+def _normalize_github_url(url: str) -> str:
+    """SWH indexes origins by exact URL. Strip `.git` suffix and trailing slash — the two
+    variants that actually appear in repos.tsv (`cedar-spec` has `.git`)."""
+    u = url.strip()
+    if u.endswith(".git"):
+        u = u[: -len(".git")]
+    return u.rstrip("/")
+
+
+@dataclass
+class MembershipResult:
+    name: str
+    url: str
+    swh_known: str = "UNKNOWN"  # yes / no / UNKNOWN
+    earliest_visit_date: str = ""  # ISO date of the first full SWH visit, or ""
+    latest_visit_date: str = ""
+    num_visits: int = -1
+    stack_v1_status: str = "UNKNOWN"  # likely_in / too_recent / not_in_swh / UNKNOWN
+    stack_v2_status: str = "UNKNOWN"
+    infinigram_index: str = ""
+    infinigram_count: int = -1  # -1 = not queried / failed
+    infinigram_approx: str = ""
+    notes: list[str] = field(default_factory=list)
+
+    def note(self, msg: str) -> None:
+        self.notes.append(msg)
+
+
+def check_swh(name: str, url: str, *, sleep: float) -> MembershipResult:
+    r = MembershipResult(name=name, url=url)
+    norm = _normalize_github_url(url)
+
+    origin, err = _get_json(f"{SWH_API}/origin/{norm}/get/")
+    time.sleep(sleep)
+    if err == "not_found":
+        r.swh_known = "no"
+        r.stack_v1_status = "not_in_swh"
+        r.stack_v2_status = "not_in_swh"
+        return r
+    if err is not None:
+        r.swh_known = "UNKNOWN"
+        r.stack_v1_status = "UNKNOWN"
+        r.stack_v2_status = "UNKNOWN"
+        r.note(f"origin lookup failed: {err}")
+        return r
+
+    r.swh_known = "yes"
+    assert isinstance(origin, dict)
+
+    visits, verr = _get_json(f"{SWH_API}/origin/{norm}/visits/?per_page=1000")
+    time.sleep(sleep)
+    if verr is not None:
+        r.note(f"visits lookup failed: {verr}")
+        r.stack_v1_status = "UNKNOWN"
+        r.stack_v2_status = "UNKNOWN"
+        return r
+    assert isinstance(visits, list)
+
+    dates: list[date] = []
+    for v in visits:
+        d = v.get("date")
+        if not d:
+            continue
+        try:
+            dates.append(datetime.fromisoformat(d.replace("Z", "+00:00")).date())
+        except ValueError:
+            continue
+
+    r.num_visits = len(dates)
+    if not dates:
+        # known origin, but SWH has never completed a visit we could date (e.g. pending/failed)
+        r.stack_v1_status = "not_in_swh"
+        r.stack_v2_status = "not_in_swh"
+        return r
+
+    earliest, latest = min(dates), max(dates)
+    r.earliest_visit_date = earliest.isoformat()
+    r.latest_visit_date = latest.isoformat()
+
+    r.stack_v1_status = "likely_in" if earliest <= STACK_V1_CUTOFF else "too_recent"
+    r.stack_v2_status = "likely_in" if earliest <= STACK_V2_CUTOFF else "too_recent"
+    return r
+
+
+_SLUG_RE = re.compile(r"github\.com/([^/]+/[^/.]+)")
+
+
+def check_infinigram(r: MembershipResult, *, index: str, sleep: float) -> None:
+    m = _SLUG_RE.search(r.url)
+    if not m:
+        r.note("could not extract owner/name slug for infini-gram query")
+        return
+    slug = m.group(1)
+    r.infinigram_index = index
+    payload = json.dumps({"index": index, "query_type": "count", "query": slug}).encode()
+    resp, err = _get_json(INFINIGRAM_API, method="POST", data=payload, timeout=30.0)
+    time.sleep(sleep)
+    if err is not None:
+        r.note(f"infini-gram query failed: {err}")
+        return
+    assert isinstance(resp, dict)
+    if "error" in resp:
+        r.note(f"infini-gram error: {resp['error']}")
+        return
+    r.infinigram_count = int(resp.get("count", -1))
+    r.infinigram_approx = str(resp.get("approx", ""))
+
+
+def load_repos(tsv_path: Path) -> list[tuple[str, str]]:
+    repos = []
+    with open(tsv_path, newline="") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            repos.append((row["name"], row["url"]))
+    return repos
+
+
+def macro_pass_rate_join_hook(membership_tsv: Path, results_jsonl: Path) -> dict[str, tuple[str, float]]:
+    """TODO(#137 follow-up): correlate membership against pass rate, macro-averaged per repo.
+
+    Blocked on a baseline run over enough of the 57-repo corpus to compute a per-repo macro
+    pass rate (the only baseline we have today, `docs/leanstral-baseline-100.md`, covers 47
+    repos at 2 problems each — noted in `docs/contamination.agents.md` as "a hint, not a
+    result"; fabricating a wider table here is out of scope for this issue).
+
+    Join key once such a run exists: `repo name` (the `name` column in `pipeline/repos.tsv` /
+    this script's `membership.tsv`, which is also `challenge["repo"]` in ablator output and the
+    `repo` field of `baselines/apply_ablate` result JSONL) -> macro-averaged pass rate for that
+    repo (mean of per-challenge PASS/fail over that repo's *evaluated* challenges; "macro" so a
+    repo with many challenges, e.g. `evm-asm`, does not dominate the correlation the way it does
+    the raw corpus size, per the "macro-averaged per repo" warning in
+    `docs/contamination.agents.md`'s "Corpus facts" section).
+
+    Implementation sketch, once `results_jsonl` exists (one JSON object per solved challenge,
+    with `repo` and an outcome field, matching `baselines/apply_ablate/record.py`):
+
+        from collections import defaultdict
+        outcomes = defaultdict(list)
+        for line in open(results_jsonl):
+            rec = json.loads(line)
+            outcomes[rec["repo"]].append(1.0 if rec["outcome"] == "PASS" else 0.0)
+        macro_pass_rate = {repo: sum(v) / len(v) for repo, v in outcomes.items()}
+        # then join macro_pass_rate[name] against the stack_v1_status/stack_v2_status columns
+        # of membership_tsv (e.g. Pearson r of pass_rate vs. an is-member indicator, or a
+        # two-sample comparison of pass rate for likely_in vs. not_in_swh repos) and report
+        # both counts per bucket (n is small - most of the 57 repos are post-2024, see
+        # docs/contamination.agents.md's "Corpus facts") alongside the correlation.
+
+    Returns {} today — intentionally not fabricated. Raises if called before a results file
+    exists, so accidental use in a report script fails loudly instead of silently reporting
+    zeros.
+    """
+    if not results_jsonl.exists():
+        raise FileNotFoundError(
+            f"{results_jsonl} does not exist yet — no baseline run covers enough of the "
+            "57-repo corpus to compute a per-repo macro pass rate. See this function's "
+            "docstring for the join key and implementation sketch once one does."
+        )
+    raise NotImplementedError("wire up once a corpus-wide baseline run exists")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--repos-tsv", type=Path, default=REPOS_TSV)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--infinigram", action="store_true", help="also cross-check AI2 infini-gram (slug substring count)")
+    ap.add_argument("--infinigram-index", default=INFINIGRAM_DEFAULT_INDEX)
+    ap.add_argument("--sleep", type=float, default=0.6, help="delay between API calls (SWH unauthenticated: 120/hr)")
+    ap.add_argument("--limit", type=int, default=None, help="only process the first N repos (debugging)")
+    args = ap.parse_args()
+
+    repos = load_repos(args.repos_tsv)
+    if args.limit:
+        repos = repos[: args.limit]
+
+    results: list[MembershipResult] = []
+    for i, (name, url) in enumerate(repos, 1):
+        print(f"[{i}/{len(repos)}] {name} ({url})", file=sys.stderr)
+        r = check_swh(name, url, sleep=args.sleep)
+        if args.infinigram:
+            check_infinigram(r, index=args.infinigram_index, sleep=args.sleep)
+        results.append(r)
+
+    fields = [
+        "name",
+        "url",
+        "swh_known",
+        "earliest_visit_date",
+        "latest_visit_date",
+        "num_visits",
+        "stack_v1_status",
+        "stack_v2_status",
+        "infinigram_index",
+        "infinigram_count",
+        "infinigram_approx",
+        "notes",
+    ]
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w", newline="") as f:
+        w = csv.writer(f, delimiter="\t")
+        w.writerow(fields)
+        for r in results:
+            w.writerow(
+                [
+                    r.name,
+                    r.url,
+                    r.swh_known,
+                    r.earliest_visit_date,
+                    r.latest_visit_date,
+                    r.num_visits,
+                    r.stack_v1_status,
+                    r.stack_v2_status,
+                    r.infinigram_index,
+                    r.infinigram_count,
+                    r.infinigram_approx,
+                    "; ".join(r.notes),
+                ]
+            )
+
+    v2_in = sum(1 for r in results if r.stack_v2_status == "likely_in")
+    v2_unknown = sum(1 for r in results if r.stack_v2_status == "UNKNOWN")
+    print(
+        f"\nwrote {len(results)} rows to {args.out}\n"
+        f"Stack v2 (SWH <= {STACK_V2_CUTOFF}): likely_in={v2_in} "
+        f"too_recent={sum(1 for r in results if r.stack_v2_status == 'too_recent')} "
+        f"not_in_swh={sum(1 for r in results if r.stack_v2_status == 'not_in_swh')} "
+        f"UNKNOWN={v2_unknown}",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `pipeline/membership_check.py`: for each of the 57 repos in `pipeline/repos.tsv`, queries the Software Heritage API for the origin's crawl ("visit") history and compares the earliest visit date against the documented Stack v1 (2022-06) and Stack v2 (2023-09-06, the SWH graph snapshot the-stack-v2 is built from) cutoffs — a direct measurement, since neither Stack dataset is full-text searchable without downloading terabytes of (gated) parquet. Optional `--infinigram` cross-checks AI2 infini-gram slug counts. Every network call is wrapped so a failure records `UNKNOWN` rather than crashing.
- Ran it and committed the result table as `pipeline/membership.tsv` (57/57 repos resolved, zero `UNKNOWN`; only `starkware-formal-proofs` and `symcrust` plausibly predate the Stack v2 snapshot).
- Placed under `pipeline/` rather than `experiments/` per the dispatch note — `experiments/` is being removed by the parallel #144 task.
- Updates `docs/contamination.agents.md` to lead with this direct instrument, demoting the stars/age correlation to a "robustness footnote" section (kept, not deleted, since its qualitative conclusion agrees).
- The pass-rate correlation step from the issue's acceptance criteria is left as a documented hook (`macro_pass_rate_join_hook()` in `membership_check.py`, with the exact join key and an implementation sketch) rather than fabricated — no baseline run yet covers enough of the 57-repo corpus to compute a per-repo macro pass rate.

## Test plan
- [x] `python3 -m py_compile pipeline/membership_check.py`
- [x] Ran against a 4-repo `--limit` slice first to sanity-check output shape
- [x] Ran the full 57-repo pass with `--infinigram`; verified 57/57 rows resolved with zero `UNKNOWN`, spot-checked a few SWH lookups (`torvalds/linux`, `mathlib4`, `symcrust`) by hand against the raw API
- [x] Re-read the updated `docs/contamination.agents.md` end-to-end for heading/section consistency after the reorder

Closes #137