### PR TITLE
comms(vericode): draft the workshop paper — outline, method, dataset, related work, limitations

### DIFF
--- a/comms/vericode-workshop/OUTLINE.md
+++ b/comms/vericode-workshop/OUTLINE.md
@@ -1,0 +1,182 @@
+# VeriCodeGen workshop paper — outline, claim map, figure list
+
+Companion to `neurips_2026_vericode_workshop.tex`. Deadlines: **abstract Sept 11, paper Sept 13
+(2026)**. This file is the planning artifact; the `.tex` is the deliverable. Keep them in sync —
+if a claim moves, move it in both.
+
+**Rule for everyone working on this paper: never write a number that has not been produced by a
+committed run.** Every results slot in the `.tex` is a `\todo{}` naming the issue that will fill
+it. A `\todo{}` left in at submission time is a section we cut, not a section we guess at.
+
+---
+
+## 1. The claims
+
+Five claims, nothing beyond them. Each is stated in the abstract, restated as a contribution
+bullet in §1, and discharged by exactly one experiment issue.
+
+| # | Claim | Where it lands | Produced by | Status |
+|---|---|---|---|---|
+| C1 | A compile-validated proof-repair corpus at scale: 43,410 challenges from 57 real Lean 4 repos, **both** challenge and ground truth compiled against pinned `.olean` closures. The validation discipline is the contribution. | §3 Method, §4 Dataset, Table 1 | Already done — `artifacts/lean-ablate-whole/_index.json` | **Ready** |
+| C2 | Two holing strategies, **measured** rather than assumed: leaf-step vs whole-body, on a matched problem set sharing `challenge_id`. | §5.2, Fig. 3 | **#129** (needs #126 sample, #127 aggregator, #119 harness) | Blocked on run |
+| C3 | A contamination argument that is **measured**, structured by the instance- vs knowledge-level memorization distinction. | §5.3, Figs. 4–6 | **#132** temporal holdout, **#133** deletion-count sweep, **#134** recall probe | Blocked on runs |
+| C4 | A **calibrated** difficulty model — held-out ROC-AUC, Brier, Murphy decomposition, reliability diagram, feature coefficients. Rare in benchmark papers. | §5.4, Fig. 7 | **#135** (needs #130 grid) | Blocked on run |
+| C5 | Reward hacking under a **verified** reward: tamper rate rising with turn budget. | §5.5, Fig. 8 | **#136** (reuses #131 logs, no new spend) | Cheapest; blocked on #131 |
+
+Claims we are **not** making, and must not drift into:
+
+- Not "models cannot do proof engineering." Pass rates here are budget-dependent (see L2).
+- Not "this corpus is contamination-free." Instance-level memorization is defeated by
+  construction; knowledge-level is not, and §5.3 says so explicitly.
+- Not "this generalizes across proof assistants." The corpus is Lean-only (L1).
+- Not "we beat baseline X." There is no competing repair benchmark on real-repo Lean to beat;
+  the positioning in §2 is about *task shape and validation*, not leaderboard position.
+
+---
+
+## 2. Section-by-section outline
+
+### §1 Introduction (~1 page)
+- The gap: proof-synthesis evaluation is dominated by competition mathematics, where a problem is
+  a self-contained statement with no surrounding library. Real proof engineering is *repair inside
+  an existing development*.
+- The instrument: syntactic ablation. Delete a lemma from a theorem's in-file dependency closure,
+  hole its users, ask for re-derivation, score by the compiler.
+- Why the validation discipline matters: an extracted benchmark whose ground truth was never
+  compiled in the extracted context can ship unwinnable problems, and nobody notices because the
+  scorer never runs on the gold answer.
+- Contributions = the five claims above, each with a forward reference.
+
+### §2 Related work (~0.75 page) — **drafted, no results needed**
+Three groups:
+1. **Competition-math benchmarks** — miniF2F, ProofNet, PutnamBench, FIMO. Self-contained
+   statements, formalized from natural-language competition problems; no ambient repository, no
+   downstream users of the theorem being proved. Our problems come with the library they live in.
+2. **Repository-scale extraction** — LeanDojo/LeanStep, Mathlib-derived tactic-prediction corpora,
+   CoqGym/PRISM on the Rocq side. These do operate on real developments, but the extracted
+   *state–tactic* pairs are not validated as standalone compilable artifacts, and the task is
+   next-tactic prediction rather than whole-lemma repair.
+3. **Repair / agentic software benchmarks** — SWE-bench and descendants. Right task shape (repair
+   inside a repository, execution-based scoring), wrong oracle: tests admit false positives, a
+   kernel does not.
+4. **Contamination methodology** — LiveCodeBench / GSM1K (temporal holdout), GSM-Symbolic
+   (perturbation robustness), Carlini et al. (memorization scales with duplication), Golchin &
+   Surdeanu (guided prompting / verbatim recall). §5.3 is built out of these instruments.
+
+**The differentiator, in one sentence:** real-repository proofs, posed as a repair task, with the
+compiler run on *both* the challenge and the ground truth before either ships.
+
+### §3 Method (~1.5 pages) — **drafted, no results needed**
+- §3.1 Ablation as proof repair. Corollary → in-file transitive dependency closure → delete one
+  lemma → hole its in-file users. Solver must produce a hole-free file that compiles.
+- §3.2 The two holing strategies. `corollary-leaves` (only the leaf tactic steps citing the lemma
+  are `sorry`ed; the rest of each user's proof survives as scaffolding) vs `corollary-whole` (each
+  user's entire proof body is replaced). Same deletion, same slice, different amount of surviving
+  structure — the reason a matched comparison is possible at all.
+- §3.3 Corollary-anchored slicing. Why the slice is anchored on the corollary and not on the
+  holes (anchoring on holes made the corollary invisible and shipped byte-identical challenges
+  under distinct ids — ~50% duplication). Dedup is on `(challenge, solution)` **text**.
+- §3.4 `challenge_id` and matched selections. `sha1_16(file | seed | variant | deleted names |
+  holed names)` — invariant to the holing strategy, which is exactly what makes the paired design
+  in §5.2 valid.
+- §3.5 Two-sided compile validation. Challenge must compile *with* holes; ground truth must
+  compile *hole-free*. Drop `malformed` and `sol_BAD`. Note that validation is a **build** problem
+  — an incompletely-built tree reports everything malformed (this understated one repo by 2,881
+  challenges before it was caught).
+- §3.6 Scoring and the outcome taxonomy. PASS / fail / turn-limit / gave-up / tampered /
+  malformed / trivial / context-exceeded, and which are excluded from the denominator and why.
+- §3.7 The tamper check. Statement-preservation guard; Lean compares exact statement text up to
+  `:=`; Coq/Isabelle degrade to name-presence. Our corpus is Lean, so the strong version applies.
+
+### §4 Dataset (~1 page) — **drafted, no results needed**
+- Composition: Table 1. 57 repos, 26,157 mined candidates per strategy, 21,692 / 21,718 validated.
+- Provenance and pinning: `repos.tsv` (url + revision + toolchain); every manifest records the
+  repo+revision pair.
+- Licensing: survey at each repo's *pinned revision*, not default-branch HEAD; mixed corpus →
+  aggregate `license: other` with a per-repo table; 5 of 57 flagged and pending an explicit
+  keep/drop decision.
+- Skew: `evm-asm` 33.8% of leaf rows, top three 53.4%. **All headline numbers macro-averaged per
+  repo.** Stated as a dataset property, and again in Limitations.
+- Splits and distribution: `easy` / `hard` on the Hub; scoring requires a built checkout.
+
+### §5 Experiments (~2 pages) — **results pending, all `\todo{}`**
+- §5.1 Setup: ReAct agent with `list_proof_files` / `read_file` / `search` / `submit_solution` /
+  `give_up`; compile feedback returned on each submission; fixed turn budget; the corpus's own
+  prebuilt `.olean` closures. Reference run: Leanstral 1.5, 100-problem leaf sample, 38/91
+  scorable (42%), modal outcome turn-limit (44). Reported as the *motivating* run, not a headline.
+- §5.2 Easy vs hard (**#129**) — macro/micro PASS per strategy, bootstrap CIs, full outcome mix,
+  McNemar on the paired sample.
+- §5.3 Contamination (**#132/#133/#134**) — three instruments, framed by the instance- vs
+  knowledge-level split.
+- §5.4 Difficulty model (**#135**) — held-out AUC, Brier + Murphy decomposition, reliability
+  diagram, feature coefficients; budget-dependence caveat inline.
+- §5.5 Reward hacking (**#136**) — tamper rate vs budget, broken out by tamper reason.
+
+### §6 Limitations (~0.5 page) — **drafted**
+The five that must be stated, not buried:
+- **L1 Lean-only.** l4v is partially mined (19,018 challenges) but the flagship `Refine` sessions —
+  14,594 of them — are blocked on seL4's *generated* design spec. The Rocq corpus is unmined.
+- **L2 Budget-dependent pass rates.** Turn-limit was the modal outcome in the first baseline
+  (44 vs 38 PASS); raising 30→50 turns moved the rate and the curve had not flattened. Every
+  reported pass rate is a pass rate *at budget B*, including the difficulty model's labels.
+- **L3 Scoring requires a built checkout.** Only a subset of prebuilt closures is published (#143);
+  ~5–7 GB per mathlib-dependent repo, ~1 TB for the full corpus.
+- **L4 Corpus skew.** One repo is a third of the rows; three are half. Macro-averaging mitigates
+  but does not remove this.
+- **L5 Context.** ~10% of challenges exceed a 262k-token window even after minimal slicing; they
+  are excluded from the denominator, which is honest but also means the hardest-to-fit problems
+  are systematically unmeasured.
+
+### §7 Conclusion (~0.2 page)
+
+### Appendix (no page limit)
+- A: outcome taxonomy in full, with the exact exclusion rules.
+- B: per-repo license table (from `pipeline/LICENSE_SURVEY.md`).
+- C: per-repo challenge counts.
+- D: agent system prompt and tool schemas.
+- E: NeurIPS checklist (`checklist.tex`, already `\input`).
+
+---
+
+## 3. Figure and table list
+
+Every float is mapped to the issue that produces it. Floats with no issue are already
+producible from committed artifacts.
+
+| Float | Content | Produced by | Ready? |
+|---|---|---|---|
+| **Fig. 1** | Pipeline schematic: repo @ pinned revision → corollary closure → delete + hole → two-sided compile validation → split. | none (schematic) | Ready to draw |
+| **Fig. 2** | Worked example: one file, the same deletion under leaf vs whole-body holing, side by side. Makes §3.2 concrete in one glance. | none (corpus excerpt) | Ready to draw |
+| **Fig. 3** | Paired easy-vs-hard: PASS macro/micro with bootstrap CIs **plus the stacked outcome mix** — the hypothesis predicts mass shifting to turn-limit/fail, not just PASS dropping. | **#129** | Pending |
+| **Fig. 4** | Deletion-count decay curve, `--count` ∈ {1,2,3,5}, CIs, problem distribution held fixed across depths. The shape is the finding. | **#133** | Pending |
+| **Fig. 5** | Temporal holdout: pinned-corpus vs post-cutoff pass rate, macro-averaged per repo, per split, with CIs. | **#132** | Pending |
+| **Fig. 6** | Recall-vs-solve: verbatim recall score against solve outcome on the same problems, per split. | **#134** | Pending |
+| **Fig. 7** | Reliability diagram (deciles) + held-out AUC/Brier inset; companion bar of feature coefficients. | **#135** | Pending |
+| **Fig. 8** | Tamper rate vs turn budget, stacked by tamper reason (statement deleted vs weakened). | **#136** | Pending |
+| **Table 1** | Corpus composition: repos, mined, validated, per strategy; top-3 share. | none | **Ready** |
+| **Table 2** | Outcome taxonomy: each outcome, its meaning, in/out of the PASS denominator. | none | **Ready** |
+| **Table 3** | License summary: SPDX distribution across 57 repos + the 5 flagged. | none | **Ready** |
+| **Table 4** | Main results table: per-strategy, per-model PASS with CIs. | **#129**, **#130** | Pending |
+
+Priority if the page budget bites: Figs. 1, 3, 4, 8 and Tables 1, 2 are the core. Figs. 5–7 move
+to the appendix before anything in §3 gets cut.
+
+---
+
+## 4. Open decisions before submission
+
+1. **Page limit.** Confirm the VeriCodeGen workshop limit (the stock NeurIPS template says nine;
+   workshops usually say four to eight). The section budgets above assume ~8 pages of content.
+   **As drafted the paper runs ~10 content pages** (measured with a substitute font that sets
+   wider than Times, so ~9 is the realistic figure) before any results text or figures are added.
+   Assume it must shrink. The trim order is the float priority at the end of §3 above, then §3.3
+   and §3.7 compress into a single "construction details" paragraph with the rest moved to the
+   appendix; §5.3's three subsubsections merge into one running paragraph per instrument. §6
+   does not get cut.
+2. **Anonymization.** The Hub dataset id de-anonymizes the authors. The `.tex` currently uses an
+   anonymized-URL placeholder; swap for camera-ready only.
+3. **The 5 flagged repos** (`pipeline/LICENSE_SURVEY.md`): keep with justification or drop. This
+   changes the headline row count, so it must be settled *before* Table 1 is final.
+4. **Which models go in the grid** (#130) — determines Table 4 and the temporal-holdout cutoffs.
+5. Whether §5.3's three instruments all land in time; if only one does, it is **#133**
+   (deletion-count sweep), which is the distinctive one.

--- a/comms/vericode-workshop/checklist.tex
+++ b/comms/vericode-workshop/checklist.tex
@@ -1,38 +1,11 @@
 \section*{NeurIPS Paper Checklist}
 
-%%% BEGIN INSTRUCTIONS %%%
-The checklist is designed to encourage best practices for responsible machine learning research, addressing issues of reproducibility, transparency, research ethics, and societal impact. Do not remove the checklist: {\bf The papers not including the checklist will be desk rejected.} The checklist should follow the references and follow the (optional) supplemental material.  The checklist does NOT count towards the page
-limit. 
-
-Please read the checklist guidelines carefully for information on how to answer these questions. For each question in the checklist:
-\begin{itemize}
-    \item You should answer \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item \answerNA{} means either that the question is Not Applicable for that particular paper or the relevant information is Not Available.
-    \item Please provide a short (1--2 sentence) justification right after your answer (even for \answerNA). 
-   % \item {\bf The papers not including the checklist will be desk rejected.}
-\end{itemize}
-
-{\bf The checklist answers are an integral part of your paper submission.} They are visible to the reviewers, area chairs, senior area chairs, and ethics reviewers. You will also be asked to include it (after eventual revisions) with the final version of your paper, and its final version will be published with the paper.
-
-The reviewers of your paper will be asked to use the checklist as one of the factors in their evaluation. While \answerYes{} is generally preferable to \answerNo{}, it is perfectly acceptable to answer \answerNo{} provided a proper justification is given (e.g., error bars are not reported because it would be too computationally expensive'' or ``we were unable to find the license for the dataset we used''). In general, answering \answerNo{} or \answerNA{} is not grounds for rejection. While the questions are phrased in a binary way, we acknowledge that the true answer is often more nuanced, so please just use your best judgment and write a justification to elaborate. All supporting evidence can appear either in the main paper or the supplemental material, provided in appendix. If you answer \answerYes{} to a question, in the justification please point to the section(s) where related material for the question can be found.
-
-IMPORTANT, please:
-\begin{itemize}
-    \item {\bf Delete this instruction block, but keep the section heading ``NeurIPS Paper Checklist"},
-    \item  {\bf Keep the checklist subsection headings, questions/answers and guidelines below.}
-    \item {\bf Do not modify the questions and only use the provided macros for your answers}.
-\end{itemize} 
- 
-
-%%% END INSTRUCTIONS %%%
-
-
 \begin{enumerate}
 
 \item {\bf Claims}
     \item[] Question: Do the main claims made in the abstract and introduction accurately reflect the paper's contributions and scope?
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerYes{}
+    \item[] Justification: The abstract and Section~\ref{sec:intro} state exactly five claims, each with a forward reference to the section that discharges it (Sections~\ref{sec:method}--\ref{sec:tamper}), and Section~\ref{sec:limitations} states the scope conditions on each. Claims whose supporting runs have not yet completed are marked in the text rather than asserted.
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that the abstract and introduction do not include the claims made in the paper.
@@ -43,8 +16,8 @@ IMPORTANT, please:
 
 \item {\bf Limitations}
     \item[] Question: Does the paper discuss the limitations of the work performed by the authors?
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerYes{}
+    \item[] Justification: Section~\ref{sec:limitations} is a dedicated Limitations section covering the single-prover scope, the budget-dependence of every reported pass rate, the built-checkout requirement for scoring, corpus concentration, context-window exclusions, and unresolved licensing on part of the corpus.
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that the paper has no limitation while the answer \answerNo{} means that the paper has limitations, but those are not discussed in the paper. 
@@ -59,8 +32,8 @@ IMPORTANT, please:
 
 \item {\bf Theory assumptions and proofs}
     \item[] Question: For each theoretical result, does the paper provide the full set of assumptions and a complete (and correct) proof?
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerNA{}
+    \item[] Justification: The paper contains no theoretical results; the contribution is a dataset, a construction method, and empirical measurements.
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that the paper does not include theoretical results. 
@@ -73,8 +46,8 @@ IMPORTANT, please:
 
     \item {\bf Experimental result reproducibility}
     \item[] Question: Does the paper fully disclose all the information needed to reproduce the main experimental results of the paper to the extent that it affects the main claims and/or conclusions of the paper (regardless of whether the code and data are provided or not)?
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerYes{}
+    \item[] Justification: Section~\ref{sec:method} gives the full construction (corollary closure, deletion, holing strategy, corollary-anchored slicing, deterministic seed, and the two-sided compile-validation criteria), Section~\ref{sec:dataset} gives the pinned (repository, revision, toolchain) provenance for all 57 sources, and Section~\ref{sec:setup} plus Appendix~D give the solver loop, tools and scoring invocation. Section~\ref{sec:validation} additionally documents the build-environment failure modes that silently invalidate this kind of pipeline.
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that the paper does not include experiments.
@@ -93,8 +66,8 @@ IMPORTANT, please:
 
 \item {\bf Open access to data and code}
     \item[] Question: Does the paper provide open access to the data and code, with sufficient instructions to faithfully reproduce the main experimental results, as described in supplemental material?
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerYes{}
+    \item[] Justification: The mined corpus, the ablation tooling, the evaluation harness and the pipeline scripts are released, with an anonymized artifact link given in Section~\ref{sec:dataset}. Section~\ref{sec:limitations} (L3) is explicit that scoring additionally requires a built checkout of the source repository and that prebuilt closures are published only for a demo subset.
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that paper does not include experiments requiring code.
@@ -110,8 +83,8 @@ IMPORTANT, please:
 
 \item {\bf Experimental setting/details}
     \item[] Question: Does the paper specify all the training and test details (e.g., data splits, hyperparameters, how they were chosen, type of optimizer) necessary to understand the results?
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerYes{}
+    \item[] Justification: Section~\ref{sec:setup} specifies the solver loop, the tool set, the turn-budget parameter and the sample-construction rule (macro-balanced per repository, fixed seed), and each experiment subsection states its own design. \todo{fill the exact model list, budgets and seeds of the main grid once \#130 lands}
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that the paper does not include experiments.
@@ -121,8 +94,8 @@ IMPORTANT, please:
 
 \item {\bf Experiment statistical significance}
     \item[] Question: Does the paper report error bars suitably and correctly defined or other appropriate information about the statistical significance of the experiments?
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerYes{}
+    \item[] Justification: Every reported rate is accompanied by bootstrap confidence intervals over problems, the paired holing-strategy comparison uses McNemar's test on a matched \texttt{challenge\_id} set (Section~\ref{sec:easyhard}), and the calibration analysis reports the Murphy decomposition rather than a point score (Section~\ref{sec:difficulty}). \todo{confirm the intervals are in the tables once the runs land}
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that the paper does not include experiments.
@@ -138,8 +111,8 @@ IMPORTANT, please:
 
 \item {\bf Experiments compute resources}
     \item[] Question: For each experiment, does the paper provide sufficient information on the computer resources (type of compute workers, memory, time of execution) needed to reproduce the experiments?
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerTODO{}
+    \item[] Justification: \todo{report per-run wall-clock time, request counts and total inference spend, plus the CPU-only compilation cost of mining and two-sided validation across the corpus, once \#130/\#131 complete. All compilation runs on a single workstation; no accelerators are used.}
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that the paper does not include experiments.
@@ -150,8 +123,8 @@ IMPORTANT, please:
     
 \item {\bf Code of ethics}
     \item[] Question: Does the research conducted in the paper conform, in every respect, with the NeurIPS Code of Ethics \url{https://neurips.cc/public/EthicsGuidelines}?
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerYes{}
+    \item[] Justification: The work uses only publicly available source repositories, redistributes them under a per-repository license survey conducted at each pinned revision (Section~\ref{sec:licensing}), involves no human subjects and no personal data, and flags rather than silently includes sources whose terms do not clearly permit redistribution.
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that the authors have not reviewed the NeurIPS Code of Ethics.
@@ -162,8 +135,8 @@ IMPORTANT, please:
 
 \item {\bf Broader impacts}
     \item[] Question: Does the paper discuss both potential positive societal impacts and negative societal impacts of the work performed?
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerYes{}
+    \item[] Justification: Appendix~E discusses both the intended benefit (making machine-assisted proof engineering measurable on realistic work, as a prerequisite for cheaper formal verification of critical software) and the risks (statement-level reward hacking, which Section~\ref{sec:tamper} measures directly, and redistribution of work whose authors did not release it as an evaluation set).
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that there is no societal impact of the work performed.
@@ -176,8 +149,8 @@ IMPORTANT, please:
     
 \item {\bf Safeguards}
     \item[] Question: Does the paper describe safeguards that have been put in place for responsible release of data or models that have a high risk for misuse (e.g., pre-trained language models, image generators, or scraped datasets)?
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerNA{}
+    \item[] Justification: The release is proof source code from public repositories and a scoring harness; it contains no personal data, no generative model weights, and no capability that carries a high risk of misuse. The one release-specific hazard we identified --- benchmark gaming by weakening the target statement --- is addressed by the tamper guard described in Section~\ref{sec:tampercheck}.
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that the paper poses no such risks.
@@ -188,8 +161,8 @@ IMPORTANT, please:
 
 \item {\bf Licenses for existing assets}
     \item[] Question: Are the creators or original owners of assets (e.g., code, data, models), used in the paper, properly credited and are the license and terms of use explicitly mentioned and properly respected?
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerYes{}
+    \item[] Justification: All 57 source repositories are credited with their URL and exact revision, and Section~\ref{sec:licensing} plus Appendix~B give the per-repository SPDX classification derived from the license text at that pinned revision (not at default-branch HEAD, which we show is the wrong thing to trust). Five repositories whose terms are restrictive or absent are flagged rather than quietly redistributed. \todo{record the final keep/drop decision on those five}
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that the paper does not use existing assets.
@@ -204,8 +177,8 @@ IMPORTANT, please:
 
 \item {\bf New assets}
     \item[] Question: Are new assets introduced in the paper well documented and is the documentation provided alongside the assets?
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerYes{}
+    \item[] Justification: The released corpus ships per-repository manifests recording source repository, revision, toolchain, mined/validated/dropped counts and blob checksums, together with a dataset card documenting the construction, the outcome taxonomy, the aggregate license position and the known limitations.
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that the paper does not release new assets.
@@ -216,8 +189,8 @@ IMPORTANT, please:
 
 \item {\bf Crowdsourcing and research with human subjects}
     \item[] Question: For crowdsourcing experiments and research with human subjects, does the paper include the full text of instructions given to participants and screenshots, if applicable, as well as details about compensation (if any)? 
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerNA{}
+    \item[] Justification: The work involves no crowdsourcing and no human subjects; all data is mined automatically from public source repositories.
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that the paper does not involve crowdsourcing nor research with human subjects.
@@ -227,8 +200,8 @@ IMPORTANT, please:
 
 \item {\bf Institutional review board (IRB) approvals or equivalent for research with human subjects}
     \item[] Question: Does the paper describe potential risks incurred by study participants, whether such risks were disclosed to the subjects, and whether Institutional Review Board (IRB) approvals (or an equivalent approval/review based on the requirements of your country or institution) were obtained?
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerNA{}
+    \item[] Justification: The work involves no human subjects, so no IRB or equivalent review was required.
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that the paper does not involve crowdsourcing nor research with human subjects.
@@ -240,8 +213,8 @@ IMPORTANT, please:
 \item {\bf Declaration of LLM usage}
     \item[] Question: Does the paper describe the usage of LLMs if it is an important, original, or non-standard component of the core methods in this research? Note that if the LLM is used only for writing, editing, or formatting purposes and does \emph{not} impact the core methodology, scientific rigor, or originality of the research, declaration is not required.
     %this research? 
-    \item[] Answer: \answerTODO{} % Replace by \answerYes{}, \answerNo{}, or \answerNA{}.
-    \item[] Justification: \justificationTODO{}
+    \item[] Answer: \answerYes{}
+    \item[] Justification: Large language models are a core, declared component: they are the subject of evaluation, and the solver of Section~\ref{sec:setup} is an LLM-driven ReAct agent whose tool loop and compile-feedback design are part of the method. Section~\ref{sec:contamination} additionally treats the models' training data as an object of measurement.
     \item[] Guidelines:
     \begin{itemize}
         \item The answer \answerNA{} means that the core method development in this research does not involve LLMs as any important, original, or non-standard components.

--- a/comms/vericode-workshop/neurips_2026_vericode_workshop.tex
+++ b/comms/vericode-workshop/neurips_2026_vericode_workshop.tex
@@ -1,11 +1,7 @@
 \documentclass{article}
 
-% if you need to pass options to natbib, use, e.g.:
-%     \PassOptionsToPackage{numbers, compress}{natbib}
-% before loading neurips_2026
+\PassOptionsToPackage{numbers, compress}{natbib}
 
-% The authors should use one of these tracks.
-% Before accepting by the NeurIPS conference, select one of the options below.
 % "default" for submission
 \usepackage{neurips_2026_vericode}
 
@@ -13,452 +9,723 @@
 % \usepackage[main, final]{neurips_2026_vericode}
 
 % "preprint" option is used for arXiv or other preprint submissions
- % \usepackage[preprint]{neurips_2026_vericode}
-
-% to avoid loading the natbib package, add option nonatbib:
-%    \usepackage[nonatbib]{neurips_2026_vericode}
+% \usepackage[preprint]{neurips_2026_vericode}
 
 \usepackage[utf8]{inputenc} % allow utf-8 input
 \usepackage[T1]{fontenc}    % use 8-bit T1 fonts
 \usepackage{hyperref}       % hyperlinks
 \usepackage{url}            % simple URL typesetting
 \usepackage{booktabs}       % professional-quality tables
+\usepackage{amsmath}        % \text in math mode, display math environments
 \usepackage{amsfonts}       % blackboard math symbols
 \usepackage{nicefrac}       % compact symbols for 1/2, etc.
 \usepackage{microtype}      % microtypography
 \usepackage{xcolor}         % colors
 
-% Note. For the workshop paper template, both \title{} and \workshoptitle{} are required, with the former indicating the paper title shown in the title and the latter indicating the workshop title displayed in the footnote. 
-\title{Formatting Instructions For NeurIPS 2026}
+% ---------------------------------------------------------------------------
+% Placeholder macro for results that experiments #129--#136 will produce.
+% RULE: no number enters this paper that was not produced by a committed run.
+% A \todo{} left standing at submission time is a section we cut, not guess at.
+% ---------------------------------------------------------------------------
+\newcommand{\todo}[1]{\textcolor{red}{\textbf{[TODO: #1]}}}
+% Anonymized artifact URL; swap for the real dataset id at camera-ready only.
+\newcommand{\anonurl}{\texttt{[anonymized dataset]}}
 
+\title{Ablating Real Proof Developments: A Compile-Validated Proof-Repair
+Benchmark over 57 Lean~4 Repositories}
 
-% The \author macro works with any number of authors. There are two commands
-% used to separate the names and addresses of multiple authors: \And and \AND.
-%
-% Using \And between authors leaves it to LaTeX to determine where to break the
-% lines. Using \AND forces a line break at that point. So, if LaTeX puts 3 of 4
-% authors names on the first line, and the last on the second line, try using
-% \AND instead of \And before the third author name.
-
+\workshoptitle{NeurIPS 2026 Workshop on Verified Code Generation (VeriCodeGen)}
 
 \author{%
-  David S.~Hippocampus\thanks{Use footnote for providing further information
-    about author (webpage, alternative address)---\emph{not} for acknowledging
-    funding agencies.} \\
-  Department of Computer Science\\
-  Cranberry-Lemon University\\
-  Pittsburgh, PA 15213 \\
-  \texttt{hippo@cs.cranberry-lemon.edu} \\
-  % examples of more authors
-  % \And
-  % Coauthor \\
-  % Affiliation \\
-  % Address \\
-  % \texttt{email} \\
-  % \AND
-  % Coauthor \\
-  % Affiliation \\
-  % Address \\
-  % \texttt{email} \\
-  % \And
-  % Coauthor \\
-  % Affiliation \\
-  % Address \\
-  % \texttt{email} \\
-  % \And
-  % Coauthor \\
-  % Affiliation \\
-  % Address \\
-  % \texttt{email} \\
+  Anonymous Author(s) \\
+  Affiliation \\
+  Address \\
+  \texttt{email} \\
 }
-
 
 \begin{document}
 
-
 \maketitle
 
-
 \begin{abstract}
-  The abstract paragraph should be indented \nicefrac{1}{2}~inch (3~picas) on both the left- and right-hand margins. Use 10~point type, with a vertical spacing (leading) of 11~points. The word \textbf{Abstract} must be centered, bold, and in point size 12. Two line spaces precede the abstract. The abstract must be limited to one paragraph.
+  Benchmarks for machine proof synthesis are dominated by competition mathematics, where a
+  problem is a self-contained statement with no surrounding development. Real proof engineering
+  is not that: it is repair inside an existing library, where a lemma must be re-derived so that
+  everything downstream of it still goes through. We construct such a task by syntactic ablation
+  of real repositories --- pick a theorem, take its in-file transitive dependency closure, delete
+  one lemma from that closure, and hole the proofs that used it --- and we validate every problem
+  by running the compiler on \emph{both} sides: the challenge must compile with its holes, and
+  the recorded ground truth must compile hole-free, each against a pinned \texttt{.olean} closure.
+  The result is 43{,}410 challenges mined from 57 public Lean~4 repositories under two holing
+  strategies over matched selections. We report (i)~a measured comparison of the two holing
+  strategies on a paired sample, (ii)~a contamination analysis built from three standard
+  instruments rather than an assertion, organised around the distinction between instance-level
+  and knowledge-level memorization, (iii)~a calibrated difficulty model reported with reliability
+  rather than discrimination alone, and (iv)~a measurement of reward hacking under a verified
+  reward, where the rate at which a solver ``solves'' a problem by weakening the theorem rises
+  with its turn budget. \todo{one-sentence headline result once \#129--\#136 land}
 \end{abstract}
 
+\section{Introduction}
+\label{sec:intro}
 
+The public benchmarks that drive work on machine proof synthesis are overwhelmingly competition
+mathematics: miniF2F, ProofNet, PutnamBench. A problem in those benchmarks is a formal statement
+standing on its own, formalized from a natural-language competition problem, to be proved from a
+general-purpose library. That is a real task, and progress on it is real progress. It is not,
+however, the task that proof engineers spend their time on. A proof engineer works inside a
+development that already exists, where lemmas have downstream users, where a change to one
+statement propagates, and where ``done'' means the build is green.
 
-\section{Submission of papers to NeurIPS 2026}
+We construct a benchmark for that second task by \emph{ablating} real developments. Given a
+theorem in a real repository --- we call it the \emph{corollary} --- we compute its transitive
+in-file dependency closure, delete one lemma from that closure, and replace with holes the proof
+steps that cited it. A solver is handed the resulting file and must produce a version that
+compiles with no holes. The deleted lemma's original text is the recorded ground truth, but it is
+not the only acceptable answer: the oracle is the kernel, not string equality.
 
+The discipline that makes this trustworthy, and which we regard as the main methodological
+contribution, is \textbf{two-sided compile validation}. Every shipped problem has been compiled
+twice before release: once as the challenge, to confirm it elaborates with its holes in place,
+and once as the ground truth, to confirm the recorded solution actually closes them. Extraction
+pipelines that skip the second check can ship unwinnable problems indefinitely without anyone
+noticing, because the scorer is never run on the gold answer. In our own pipeline the check is
+load-bearing in a way we did not anticipate: it is only as trustworthy as the build environment
+behind it, and three environment bugs cost us roughly 3{,}700 valid challenges before they were
+found --- one repository went from 459 to 3{,}340 validated challenges with no change to the
+ablation logic at all.
 
-Please read the instructions below carefully and follow them faithfully.
+\paragraph{Contributions.}
+\begin{enumerate}
+  \item \textbf{A compile-validated proof-repair corpus at scale} (\S\ref{sec:method},
+    \S\ref{sec:dataset}): 43{,}410 challenges from 57 real Lean~4 repositories, every one of them
+    with challenge and ground truth compiled against pinned \texttt{.olean} closures.
+  \item \textbf{Two holing strategies, measured rather than assumed} (\S\ref{sec:easyhard}):
+    leaf-step holing and whole-body holing, compared on a matched problem set.
+  \item \textbf{A contamination analysis that is measured} (\S\ref{sec:contamination}): temporal
+    holdout, a deletion-count sweep, and a verbatim recall probe, organised around the
+    instance-level versus knowledge-level memorization distinction.
+  \item \textbf{A calibrated difficulty model} (\S\ref{sec:difficulty}): held-out discrimination
+    \emph{and} calibration, with the Murphy decomposition and a reliability diagram, not an
+    AUC alone.
+  \item \textbf{Reward hacking under a verified reward} (\S\ref{sec:tamper}): the rate at which a
+    solver makes the file compile by deleting or weakening the theorem it was asked to re-prove,
+    as a function of turn budget.
+\end{enumerate}
 
+\section{Related work}
+\label{sec:related}
 
-\subsection{Style}
+\paragraph{Competition-mathematics benchmarks.} miniF2F \citep{zheng2022minif2f}, ProofNet
+\citep{azerbayev2023proofnet}, PutnamBench \citep{tsoukalas2024putnambench} and FIMO
+\citep{liu2023fimo} formalize competition and textbook problems as standalone theorem statements.
+The statements are self-contained by construction: there is no ambient development, no
+downstream user of the theorem, and no build to keep green. This makes them clean instruments for
+measuring proving ability and poor instruments for measuring the ability to work inside an
+existing library. Our problems arrive with the library attached, and success is defined by what
+the surrounding file requires, not by the target statement alone.
 
+\paragraph{Repository-scale extraction.} LeanDojo \citep{yang2023leandojo} and LeanStep
+\citep{han2022proof} extract training and evaluation data from Mathlib at repository scale, and
+CoqGym \citep{yang2019coqgym} does the analogous thing for Rocq. These do operate on real
+developments, which is the property we want. Two things differ. First, the extracted unit is
+typically a proof \emph{state} paired with the next tactic, so the task is next-step prediction
+rather than re-deriving a whole lemma and repairing its users. Second, and more importantly for
+our purposes, the extracted artifacts are generally not validated as standalone compilable
+objects on both sides: the environment can replay a proof, but the released problem is not itself
+a file that has been shown to compile with holes and to compile hole-free once solved. That
+two-sided guarantee is what we add.
 
-Papers to be submitted to NeurIPS 2026 must be prepared according to the
-instructions presented here. Papers may only be up to {\bf nine} pages long, including figures. \textbf{Papers that exceed the page limit will not be reviewed (or in any other way considered) for presentation at the conference.}
-Additional pages \emph{containing acknowledgments, references, checklist, and optional technical appendices} do not count as content pages. 
+\paragraph{Repair benchmarks with execution-based scoring.} SWE-bench
+\citep{jimenez2024swebench} and its descendants have the task shape we want --- repair inside a
+real repository, scored by execution --- and they established that this shape is both tractable
+and discriminative. The oracle differs in kind. A test suite admits false positives: a patch can
+satisfy the tests and be wrong. A proof kernel does not, which is why a memorized proof that
+compiles is simply a correct proof, and why reward hacking in our setting takes the specific form
+of attacking the \emph{statement} rather than the proof (\S\ref{sec:tamper}).
 
+\paragraph{Contamination methodology.} Our \S\ref{sec:contamination} is assembled from
+established instruments rather than invented ones: temporal holdout, as in LiveCodeBench
+\citep{jain2025livecodebench} and GSM1K \citep{zhang2024careful}; perturbation robustness, as in
+GSM-Symbolic \citep{mirzadeh2025gsmsymbolic}; verbatim-recall probing under guided prompting
+\citep{golchin2024timetravel}; and the finding that memorization scales with duplication count in
+the training corpus \citep{carlini2023quantifying}, which is why we do not use repository
+popularity as a contamination proxy.
 
-The margins in 2026 are the same as those in previous years.
+\paragraph{The differentiator.} In one sentence: \emph{real-repository proofs, posed as a repair
+task, with the compiler run on both the challenge and the ground truth before either ships}.
+Competition benchmarks have the compiler but not the repository; extraction corpora have the
+repository but not the two-sided validation; software-repair benchmarks have both but not a sound
+oracle.
 
+\section{Method}
+\label{sec:method}
 
-Authors are required to use the NeurIPS \LaTeX{} style files obtainable at the NeurIPS website as indicated below. Please make sure you use the current files and not previous versions. Tweaking the style files may be grounds for desk rejection.
+\subsection{Ablation as proof repair}
 
+Fix a source file $F$ from a repository pinned at a specific revision. For each theorem
+$c \in F$ that has a non-empty in-file dependency closure --- we call $c$ the \emph{corollary} ---
+let $\mathrm{cl}(c)$ be the transitive closure of the lemmas in $F$ that $c$'s proof depends on.
+We draw a lemma $\ell \in \mathrm{cl}(c)$, delete $\ell$'s declaration entirely, and replace with
+holes (\texttt{sorry}) the proof material in $F$ that cited $\ell$. The \emph{challenge} is the
+resulting file; the \emph{solution} is $F$ with $\ell$ restored. Files whose theorems cite only
+out-of-file lemmas produce nothing, since there is nothing in-file to delete.
 
-\subsection{Retrieval of style files}
+The solver's task is to emit a version of the challenge file that compiles with no remaining
+holes. It is not asked to reproduce $\ell$ verbatim, and typically cannot: any re-derivation that
+discharges the holes is accepted. Scoring is by compilation against the repository's prebuilt
+\texttt{.olean} closure at the pinned revision, plus a hole check and the statement-preservation
+guard of \S\ref{sec:tampercheck}.
 
+\subsection{Two holing strategies}
+\label{sec:strategies}
 
-The style files for NeurIPS and other conference information are available on the website at
-\begin{center}
-  \url{https://neurips.cc}.
-\end{center}
-% The file \verb+neurips_2026.pdf+ contains these instructions and illustrates the various formatting requirements your NeurIPS paper must satisfy.
+The two strategies differ in exactly one respect: how much of each \emph{user} of $\ell$
+survives.
 
-
-The only supported style file for NeurIPS 2026 is \verb+neurips_2026.sty+, rewritten for \LaTeXe{}. \textbf{Previous style files for \LaTeX{} 2.09,  Microsoft Word, and RTF are no longer supported.}
-
-
-The \LaTeX{} style file contains three optional arguments: 
 \begin{itemize}
-\item \verb+final+, which creates a camera-ready copy, 
-\item \verb+preprint+, which creates a preprint for submission to, e.g., arXiv, \item \verb+nonatbib+, which will not load the \verb+natbib+ package for you in case of package clash.
+  \item \textbf{Leaf holing} (\texttt{corollary-leaves}). Only the leaf tactic steps that cited
+    $\ell$ are replaced. The rest of each user's proof survives, so the solver sees a proof
+    skeleton with gaps in it and can read the surrounding structure as a constraint on what the
+    missing lemma must have said.
+  \item \textbf{Whole-body holing} (\texttt{corollary-whole}). Each user's entire proof body is
+    replaced. The solver sees the statements and nothing else, and must reconstruct both $\ell$
+    and every proof that used it from the statements alone.
 \end{itemize}
 
+Whole-body holing is intended to be strictly harder. That is a hypothesis, not a fact, and
+\S\ref{sec:easyhard} tests it; the two published splits differ by 26 rows in count and by nothing
+else we can currently point at. Because both strategies are applied to the same deletion under
+the same seed, the comparison can be paired (\S\ref{sec:matched}).
 
-\paragraph{Preprint option}
-If you wish to post a preprint of your work online, e.g., on arXiv, using the NeurIPS style, please use the \verb+preprint+ option. This will create a nonanonymized version of your work with the text ``Preprint. Work in progress.'' in the footer. This version may be distributed as you see fit, as long as you do not say which conference it was submitted to. Please \textbf{do not} use the \verb+final+ option, which should \textbf{only} be used for papers accepted to NeurIPS.
+\subsection{Corollary-anchored slicing}
 
+Both strategies slice $F$ down to a minimal dependency closure so that the emitted context stays
+small. The slice is anchored on the \emph{corollary}, not on the holes. This is a subtle point
+with a large consequence. The holes are the in-file users of $\ell$ --- a property of $\ell$, not
+of the corollary that motivated selecting it. Anchoring the slice on the holes makes the
+corollary invisible in the output, so two distinct corollaries whose closures both contain $\ell$
+emit a \emph{byte-identical} challenge under two different identifiers: the same problem shipped
+twice. In an earlier release this duplicated roughly half the mined corpus. Anchoring on the
+corollary makes each record the question it claims to be --- \emph{delete $\ell$, then rebuild it
+so that \textbf{this} corollary still goes through} --- with context cut to what that corollary
+actually depends on. Records are additionally deduplicated on the \texttt{(challenge, solution)}
+text, which is what a solver actually sees.
 
-At submission time, please omit the \verb+final+ and \verb+preprint+ options. This will anonymize your submission and add line numbers to aid review. Please do \emph{not} refer to these line numbers in your paper as they will be removed during generation of camera-ready copies.
+\subsection{Matched selections and the challenge identifier}
+\label{sec:matched}
 
+Each record carries a stable identifier
+\[
+  \mathtt{challenge\_id} \;=\; \mathrm{sha1}_{16}\bigl(\,
+    \text{file path} \mid \text{seed} \mid \text{variant} \mid
+    \text{deleted lemma names} \mid \text{holed theorem names}\,\bigr),
+\]
+truncated to 16 hex characters. The key deliberately omits the holing strategy, so the same
+deletion under leaf and whole-body holing carries the \emph{same} identifier. This is what makes
+the two published splits a matched pair rather than two independent samples, and it is why
+\S\ref{sec:easyhard} can use a paired test. It also joins outcomes to features exactly, which the
+difficulty model of \S\ref{sec:difficulty} depends on.
 
-The file \verb+neurips_2026.tex+ may be used as a ``shell'' for writing your paper. All you have to do is replace the author, title, abstract, and text of the paper with your own.
+\subsection{Two-sided compile validation}
+\label{sec:validation}
 
+Every mined record is run through a pre-flight check that splices it into a work copy of the
+built repository and compiles it. A record is kept only if:
+\begin{enumerate}
+  \item the \textbf{challenge} compiles with its holes in place --- it elaborates, so the solver
+    is looking at a well-formed file and any error it sees is one it introduced; and
+  \item the \textbf{ground truth} compiles \emph{hole-free} and axiom-free --- the problem is
+    winnable, and we have exhibited one winning answer.
+\end{enumerate}
+Records failing (1) are recorded as \texttt{malformed} and dropped; records failing (2) --- the
+recorded solution already contained a \texttt{sorry} or an axiom, so the problem is unwinnable ---
+are recorded as \texttt{sol\_BAD} and dropped. Both counts are published per repository alongside
+the kept records.
 
-The formatting instructions contained in these style files are summarized in Sections \ref{gen_inst}, \ref{headings}, and \ref{others} below.
+\paragraph{Validation is a build problem.} A challenge counts as valid only if it really
+compiles, so this check is only as trustworthy as the environment behind it, and \emph{a broken
+environment reports every challenge as malformed, which reads as bad data rather than as a broken
+environment}. Three distinct causes bit us: a build command that silently compiles only the root
+module and its imports, leaving sibling modules without object files; a C~FFI target that fails
+to compile without a specific preprocessor definition, taking everything downstream with it; and
+a vendored dependency that goes missing or half-cloned. Together these cost roughly 3{,}700 valid
+challenges, 2{,}881 of them in a single repository. We report this because it is a
+reproducibility hazard for anyone building a compile-validated corpus, and because it means a
+low validation yield should be treated as a symptom to investigate rather than a property of the
+data.
 
+\subsection{Scoring and the outcome taxonomy}
+\label{sec:outcomes}
 
-\section{General formatting instructions}
-\label{gen_inst}
+Solvers are scored by real compilation, and the outcome taxonomy distinguishes failures of the
+solver from failures of the harness or of the problem--model pairing (Table~\ref{tab:outcomes}).
+Three outcome classes are excluded from the PASS denominator: \texttt{malformed} and
+\texttt{trivial} are properties of the problem, and \texttt{context\_exceeded} is a property of
+the (problem, model) pair --- the provider rejects the prompt, so the model never sees the
+problem, and scoring it zero would blame the solver for a challenge it was never shown. In our
+first baseline this affected 9\% of the sample and, before it was flagged, silently depressed the
+reported rate.
 
-
-The text must be confined within a rectangle 5.5~inches (33~picas) wide and
-9~inches (54~picas) long. The left margin is 1.5~inch (9~picas).  Use 10~point
-type with a vertical spacing (leading) of 11~points.  Times New Roman is the
-preferred typeface throughout, and will be selected for you by default.
-Paragraphs are separated by \nicefrac{1}{2}~line space (5.5 points), with no
-indentation.
-
-
-The paper title should be 17~point, initial caps/lower case, bold, centered
-between two horizontal rules. The top rule should be 4~points thick and the
-bottom rule should be 1~point thick. Allow \nicefrac{1}{4}~inch space above and
-below the title to rules. All pages should start at 1~inch (6~picas) from the
-top of the page.
-
-
-For the final version, authors' names are set in boldface, and each name is
-centered above the corresponding address. The lead author's name is to be listed
-first (left-most), and the co-authors' names (if different address) are set to
-follow. If there is only one co-author, list both author and co-author side by
-side.
-
-
-Please pay special attention to the instructions in Section \ref{others}
-regarding figures, tables, acknowledgments, and references.
-
-\section{Headings: first level}
-\label{headings}
-
-
-All headings should be lower case (except for first word and proper nouns),
-flush left, and bold.
-
-
-First-level headings should be in 12-point type.
-
-
-\subsection{Headings: second level}
-
-
-Second-level headings should be in 10-point type.
-
-
-\subsubsection{Headings: third level}
-
-
-Third-level headings should be in 10-point type.
-
-
-\paragraph{Paragraphs}
-
-
-There is also a \verb+\paragraph+ command available, which sets the heading in
-bold, flush left, and inline with the text, with the heading followed by 1\,em
-of space.
-
-
-\section{Citations, figures, tables, references}
-\label{others}
-
-
-These instructions apply to everyone.
-
-
-\subsection{Citations within the text}
-
-
-The \verb+natbib+ package will be loaded for you by default.  Citations may be
-author/year or numeric, as long as you maintain internal consistency.  As to the
-format of the references themselves, any style is acceptable as long as it is
-used consistently.
-
-
-The documentation for \verb+natbib+ may be found at
-\begin{center}
-  \url{http://mirrors.ctan.org/macros/latex/contrib/natbib/natnotes.pdf}
-\end{center}
-Of note is the command \verb+\citet+, which produces citations appropriate for
-use in inline text.  For example,
-\begin{verbatim}
-   \citet{hasselmo} investigated\dots
-\end{verbatim}
-produces
-\begin{quote}
-  Hasselmo, et al.\ (1995) investigated\dots
-\end{quote}
-
-
-If you wish to load the \verb+natbib+ package with options, you may add the
-following before loading the \verb+neurips_2026+ package:
-\begin{verbatim}
-   \PassOptionsToPackage{options}{natbib}
-\end{verbatim}
-
-
-If \verb+natbib+ clashes with another package you load, you can add the optional
-argument \verb+nonatbib+ when loading the style file:
-\begin{verbatim}
-   \usepackage[nonatbib]{neurips_2026_vericode}
-\end{verbatim}
-
-
-As submission is double blind, refer to your own published work in the third
-person. That is, use ``In the previous work of Jones et al.\ [4],'' not ``In our
-previous work [4].'' If you cite your other papers that are not widely available
-(e.g., a journal paper under review), use anonymous author names in the
-citation, e.g., an author of the form ``A.\ Anonymous'' and include a copy of the anonymized paper in the supplementary material.
-
-
-\subsection{Footnotes}
-
-
-Footnotes should be used sparingly.  If you do require a footnote, indicate
-footnotes with a number\footnote{Sample of the first footnote.} in the
-text. Place the footnotes at the bottom of the page on which they appear.
-Precede the footnote with a horizontal rule of 2~inches (12~picas).
-
-
-Note that footnotes are properly typeset \emph{after} punctuation
-marks.\footnote{As in this example.}
-
-
-\subsection{Figures}
-
-
-\begin{figure}
+\begin{table}[t]
+  \caption{Outcome taxonomy. Only the first four rows enter the PASS denominator; the exclusions
+  in the lower block are properties of the problem or of the (problem, model) pair, not of the
+  solver. \texttt{tampered} is counted as a scorable non-pass, not an exclusion --- it is a
+  solver behaviour and \S\ref{sec:tamper} measures it directly.}
+  \label{tab:outcomes}
   \centering
-  \fbox{\rule[-.5cm]{0cm}{4cm} \rule[-.5cm]{4cm}{0cm}}
-  \caption{Sample figure caption. Explain what the figure shows and add a key take-away message to the caption.}
-\end{figure}
-
-
-All artwork must be neat, clean, and legible. Lines should be dark enough for
- reproduction purposes. The figure number and caption always appear after the
-figure. Place one line space before the figure caption and one line space after
-the figure. The figure caption should be lower case (except for the first word and proper nouns); figures are numbered consecutively.
-
-
-You may use color figures.  However, it is best for the figure captions and the
-paper body to be legible if the paper is printed in either black/white or in
-color.
-
-
-\subsection{Tables}
-
-
-All tables must be centered, neat, clean, and legible.  The table number and
-title always appear before the table.  See Table~\ref{sample-table}.
-
-
-Place one line space before the table title, one line space after the
-table title, and one line space after the table. The table title must
-be lower case (except for the first word and proper nouns); tables are
-numbered consecutively.
-
-
-Note that publication-quality tables \emph{do not contain vertical rules}. We
-strongly suggest the use of the \verb+booktabs+ package, which allows for
-typesetting high-quality, professional tables:
-\begin{center}
-  \url{https://www.ctan.org/pkg/booktabs}
-\end{center}
-This package was used to typeset Table~\ref{sample-table}.
-
-
-\begin{table}
-  \caption{Sample table caption. Explain what the table shows and add a key take-away message to the caption.}
-  \label{sample-table}
-  \centering
-  \begin{tabular}{lll}
+  \begin{tabular}{llc}
     \toprule
-    \multicolumn{2}{c}{Part}                   \\
-    \cmidrule(r){1-2}
-    Name     & Description     & Size ($\mu$m) \\
+    Outcome & Meaning & In denominator \\
     \midrule
-    Dendrite & Input terminal  & $\approx$100     \\
-    Axon     & Output terminal & $\approx$10      \\
-    Soma     & Cell body       & up to $10^6$  \\
+    \texttt{PASS}             & compiles, hole-free, statements preserved & yes \\
+    \texttt{fail}             & submitted a final answer that does not compile & yes \\
+    \texttt{turn\_limit}      & request budget exhausted while still working & yes \\
+    \texttt{gave\_up}         & solver invoked the give-up tool & yes \\
+    \texttt{tampered}         & compiled by deleting or weakening a holed theorem & yes \\
+    \midrule
+    \texttt{malformed}        & challenge does not compile (should not ship) & no \\
+    \texttt{trivial}          & challenge and solution are identical & no \\
+    \texttt{context\_exceeded}& prompt rejected; the model never saw the problem & no \\
+    \texttt{harness\_err}     & infrastructure failure & no \\
     \bottomrule
   \end{tabular}
 \end{table}
 
-\subsection{Math}
-Note that display math in bare TeX commands will not create correct line numbers for submission. Please use LaTeX (or AMSTeX) commands for unnumbered display math. (You really shouldn't be using \$\$ anyway; see \url{https://tex.stackexchange.com/questions/503/why-is-preferable-to} and \url{https://tex.stackexchange.com/questions/40492/what-are-the-differences-between-align-equation-and-displaymath} for more information.)
+\subsection{The tamper check}
+\label{sec:tampercheck}
 
-\subsection{Final instructions}
+A compile-and-no-holes oracle has one exploit: make the file compile by removing or weakening the
+theorem you were asked to re-prove. We guard against this with a statement-preservation check. For
+Lean, the guard compares the exact statement text of each holed theorem up to the \texttt{:=}
+proof delimiter, so a weakened hypothesis or a deleted declaration is caught. For Rocq and
+Isabelle the proof delimiter is less uniform and the guard degrades to name-presence, which
+catches deletion but not weakening. Our corpus is Lean-only, so the strong version of the guard
+applies throughout; the weaker guarantee is flagged here for cross-prover extensions.
 
-Do not change any aspects of the formatting parameters in the style files.  In
-particular, do not modify the width or length of the rectangle the text should
-fit into, and do not change font sizes. Please note that pages should be
-numbered.
+\section{Dataset}
+\label{sec:dataset}
 
+\subsection{Composition}
 
-\section{Preparing PDF files}
+The corpus is mined from 57 public Lean~4 repositories, each pinned to a specific revision and
+toolchain. Table~\ref{tab:corpus} gives the totals. Of 26{,}157 mined candidate ablations per
+holing strategy, 21{,}692 survive two-sided validation under leaf holing and 21{,}718 under
+whole-body holing, for a total of 43{,}410 released challenges. The two strategies are applied to
+the same set of candidate selections, so the released splits are a matched pair in the sense of
+\S\ref{sec:matched}; the small difference in count arises because a deletion can validate under
+one holing strategy and not the other.
 
+\begin{table}[t]
+  \caption{Corpus composition. Both holing strategies run over the same 26{,}157 candidate
+  selections across 57 repositories; the released corpus is what survives two-sided compile
+  validation. Concentration is high: a single repository supplies a third of the rows, which is
+  why every headline number in this paper is macro-averaged per repository.}
+  \label{tab:corpus}
+  \centering
+  \begin{tabular}{lrrr}
+    \toprule
+    & Leaf holing & Whole-body holing & Total \\
+    \midrule
+    Repositories                  & 57     & 57     & 57 \\
+    Mined candidates              & 26{,}157 & 26{,}157 & --- \\
+    Validated (released)          & 21{,}692 & 21{,}718 & 43{,}410 \\
+    Validation yield              & 82.9\%  & 83.0\%  & --- \\
+    \midrule
+    Largest repository share      & 33.8\%  & 33.7\%  & --- \\
+    Top-3 repository share        & 53.4\%  & 53.3\%  & --- \\
+    \bottomrule
+  \end{tabular}
+\end{table}
 
-Please prepare submission files with paper size ``US Letter,'' and not, for
-example, ``A4.''
+\subsection{Provenance and pinning}
 
+A single tab-separated manifest is the source of truth for the corpus: repository name, language,
+URL, revision, checkout path, and toolchain. Source repositories are materialised from that
+manifest rather than vendored --- they are multi-gigabyte once built --- and every dataset
+manifest records the same (repository, revision) pair that was ablated, so any released row
+traces back to an exact tree. The ablator additionally stamps the git remote and HEAD SHA onto
+each record.
 
-Fonts were the main cause of problems in the past years. Your PDF file must only
-contain Type 1 or Embedded TrueType fonts. Here are a few instructions to
-achieve this.
+\subsection{Licensing}
+\label{sec:licensing}
 
+Licenses were surveyed at each repository's \emph{pinned revision} rather than at default-branch
+HEAD. This distinction is not pedantic: the platform API's license-detection metadata only runs
+against the default branch, and silently degrades to a no-assertion value when queried at a
+specific commit, so trusting that field would have mis-surveyed every repository whose license
+file has ever changed. Our survey classifies the pinned-revision license text directly.
 
-\begin{itemize}
+The corpus is genuinely mixed --- Apache-2.0, MIT, BSD-3-Clause, LGPL-2.1, LGPL-3.0, Zlib, one
+non-standard non-commercial-only license, and four repositories with no license file at the
+pinned revision --- so no single SPDX identifier is accurate in aggregate. The release carries
+\texttt{other} at the dataset level with a mandatory per-repository table (Appendix~B). Five of
+the 57 repositories (8.8\%) are flagged pending an explicit keep-or-drop decision: one under a
+non-commercial-only grant, and four with no license file at all, where absent an explicit grant
+default copyright applies and redistribution is not authorized.
+\todo{state the final keep/drop decision and, if any repos are dropped, the revised row counts in
+Table~\ref{tab:corpus}}
 
+\subsection{Skew}
+\label{sec:skew}
 
-\item You should directly generate PDF files using \verb+pdflatex+.
+The corpus is heavily concentrated. The largest repository contributes 33.8\% of leaf rows and
+the three largest contribute 53.4\%. Micro-averaged statistics over this corpus are therefore
+substantially statements about one repository. \textbf{All headline numbers in this paper are
+macro-averaged per repository}, and any per-repository comparison --- especially the temporal
+analysis in \S\ref{sec:contamination}, where repository age and repository size are correlated
+--- is reported macro-averaged with the micro-average shown alongside for transparency.
 
+\subsection{Distribution and use}
 
-\item You can check which fonts a PDF files uses.  In Acrobat Reader, select the
-  menu Files$>$Document Properties$>$Fonts and select Show All Fonts. You can
-  also use the program \verb+pdffonts+ which comes with \verb+xpdf+ and is
-  available out-of-the-box on most Linux machines.
+The corpus is released as two splits corresponding to the two holing strategies, keyed so that a
+consumer can join them on \texttt{challenge\_id} to recover matched pairs. Each row carries its
+challenge text, ground-truth solution, deleted lemma and holed theorem names, provenance, and the
+proof-complexity features described in \S\ref{sec:difficulty}. Browsing the data requires nothing;
+\emph{scoring} a prediction requires a built checkout of the source repository at its pinned
+revision, which is a real adoption barrier (\S\ref{sec:limitations}, L3). Artifacts: \anonurl.
 
+\section{Experiments}
+\label{sec:experiments}
 
-\item \verb+xfig+ ``patterned'' shapes are implemented with bitmap fonts.  Use
-  "solid" shapes instead.
+\subsection{Setup}
+\label{sec:setup}
 
+The solver is a ReAct-style agent with five tools: list the proof files in the work copy, read a
+file range, search the repository, submit a candidate solution, and give up. A submission is
+compiled immediately and the compiler's output is returned to the agent as the tool result, so
+the loop is grounded in real feedback rather than self-assessment; every tool result also reports
+the remaining request budget. Runs are parameterised by a turn (request) budget, which
+\S\ref{sec:limitations} argues is a first-class experimental variable rather than an
+implementation detail.
 
-\item The \verb+\bbold+ package almost always uses bitmap fonts.  You should use
-  the equivalent AMS Fonts:
-\begin{verbatim}
-   \usepackage{amsfonts}
-\end{verbatim}
-followed by, e.g., \verb+\mathbb{R}+, \verb+\mathbb{N}+, or \verb+\mathbb{C}+
-for $\mathbb{R}$, $\mathbb{N}$ or $\mathbb{C}$.  You can also use the following
-workaround for reals, natural and complex:
-\begin{verbatim}
-   \newcommand{\RR}{I\!\!R} %real numbers
-   \newcommand{\Nat}{I\!\!N} %natural numbers
-   \newcommand{\CC}{I\!\!\!\!C} %complex numbers
-\end{verbatim}
-Note that \verb+amsfonts+ is automatically loaded by the \verb+amssymb+ package.
+\paragraph{Reference run.} The one baseline that exists at the time of writing --- reported here
+to motivate the experimental design, not as a headline --- used a small open-weight Lean-tuned
+model on a 100-problem leaf-holing sample drawn two per repository across 49 repositories, at a
+50-turn budget. It scored 38/91 scorable (42\%), solving at least one problem in 24 of 49
+repositories. The outcome mix is the interesting part: \texttt{turn\_limit} occurred 44 times,
+more often than PASS. The model was usually still working when its budget ran out rather than
+producing confidently wrong proofs, and raising the budget from 30 to 50 turns moved the rate
+without flattening the curve. Nine problems (9\%) exceeded the model's 262{,}144-token context
+even after minimal slicing.
 
+\todo{full grid setup from \#130 --- models, budgets, seeds, sample construction, and total
+compute}
 
-\end{itemize}
+\subsection{Do the two holing strategies differ? (\#129)}
+\label{sec:easyhard}
 
+We publish leaf and whole-body holing as separate splits on the premise that the second is
+strictly harder: with no surviving proof skeleton, the solver must re-derive from the statement
+alone. \S\ref{sec:strategies} states that premise; this section tests it. We draw a paired sample
+macro-balanced across repositories with a fixed seed, run one model at a fixed budget over
+\emph{both} splits on an identical \texttt{challenge\_id} set, and report macro and micro PASS
+with bootstrap confidence intervals, the full outcome breakdown, and a paired significance test
+(McNemar) --- the sample is matched, so a paired test is the correct one.
 
-If your file contains type 3 fonts or non embedded TrueType fonts, we will ask
-you to fix it.
+The outcome \emph{mix} matters as much as the rate. The hypothesis predicts that whole-body
+holing shifts probability mass toward \texttt{turn\_limit} and \texttt{fail} rather than simply
+lowering PASS; a drop in PASS with an unchanged mix would be a different phenomenon.
 
+\todo{\#129: paired macro/micro PASS per strategy with CIs, stacked outcome mix (Fig.~3), McNemar
+result. Report the null explicitly if that is the outcome --- a null means one split is wearing
+two hats and we should say so.}
 
-\subsection{Margins in \LaTeX{}}
+\subsection{Contamination, measured}
+\label{sec:contamination}
 
+Every source repository is public, so contamination is the objection this dataset must answer
+directly. We structure the answer around a distinction the literature tends to merge.
 
-Most of the margin problems come from figures positioned by hand using
-\verb+\special+ or other commands. We suggest using the command
-\verb+\includegraphics+ from the \verb+graphicx+ package. Always specify the
-figure width as a multiple of the line width as in the example below:
-\begin{verbatim}
-   \usepackage[pdftex]{graphicx} ...
-   \includegraphics[width=0.8\linewidth]{myfile.pdf}
-\end{verbatim}
-See Section 4.4 in the graphics bundle documentation
-(\url{http://mirrors.ctan.org/macros/latex/required/graphics/grfguide.pdf})
+\paragraph{Instance-level memorization} --- the model saw \emph{this exact problem} --- is
+defeated by construction. The sliced file, with these specific lemmas deleted and these specific
+downstream uses holed, never existed as a document. This is a stronger claim than a
+git-history-mining approach can make, where the challenge is a real historical commit and the
+solution is the literal next commit, both present in training data \emph{as a pair}.
 
+\paragraph{Knowledge-level memorization} --- the model knows \emph{this lemma} --- is not
+defeated, and we do not claim otherwise. What we can do is measure where the first stops mattering
+and the second takes over, with three instruments.
 
-A number of width problems arise when \LaTeX{} cannot properly hyphenate a
-line. Please give LaTeX hyphenation hints using the \verb+\-+ command when
-necessary.
+\subsubsection{Temporal holdout by lemma introduction date (\#132)}
+
+We re-mine the corpus at current HEAD and partition challenges by the date the \emph{deleted
+lemma} first appeared in git history --- not by repository creation date, since a repository from
+2021 can contain a lemma from 2026, and conflating the two is the main way this analysis goes
+wrong. For each model in the grid we build a post-cutoff slice using that model's stated training
+cutoff and compare pass rates against the pinned corpus, macro-averaged per repository
+(\S\ref{sec:skew}). The corpus skews recent, which makes this slice unusually cheap to construct.
+Either outcome is informative: a small gap means the full corpus is trustworthy as an eval; a
+large gap means we have measured something real, and the post-cutoff slice becomes the headline
+eval with the remainder repurposed as a training pool. We state in advance the hypothesis that
+the gap should be \emph{larger} under whole-body holing, which leans more on knowledge-level
+memorization.
+
+\todo{\#132: post-cutoff slice size per repo; macro-averaged pass-rate gap with CIs, per split
+(Fig.~5); confounds addressed (repo skew, tail sample size, differing lemma difficulty)}
+
+\subsubsection{Deletion-count sweep (\#133)}
+
+Deletion count is the dial that separates the two kinds of memorization. Reconstructing one lemma
+is plausibly retrieval; reconstructing five interlocking lemmas that were \emph{never
+simultaneously absent} from any document is not. We sweep the number of deleted lemmas over
+$\{1,2,3,5\}$ on a fixed problem set, holding the corollary and repository distribution constant
+across depths so that the curve is about depth rather than about which problems were drawn, and
+report the pass-rate decay with confidence intervals. The shape is the finding: a sharp cliff
+between one and two deletions would indicate that retrieval was carrying the single-deletion case.
+This is a perturbation-robustness measurement in the GSM-Symbolic tradition, and a methodological
+contribution rather than merely a defense.
+
+\todo{\#133: decay curve over $\ge 4$ depths with CIs (Fig.~4), verification that the problem
+distribution is constant across depths, interpretation in instance- vs knowledge-level terms}
+
+\subsubsection{Verbatim recall probe (\#134)}
+
+The correlational tests above cannot separate \emph{memorization} from \emph{ability}: a model
+that solves more might simply be better. A recall probe can. For each deleted lemma in the paired
+sample we prompt the model with the lemma name and surrounding file context, body removed, and
+ask it to state the lemma; we score by exact match, normalised match, and a token-level score
+(exact match alone will be near-zero and misleading). The payoff is the correlation between recall
+score and solve outcome on the \emph{same} problems: if solve rate is high where recall is high,
+memorization is doing work; if they are uncorrelated, it is not. Broken out per split, since the
+hypothesis above predicts whole-body holing depends more on recall.
+
+\todo{\#134: recall scores for every deleted lemma in the paired sample; correlation with solve
+outcome with CIs, per split (Fig.~6)}
+
+\subsubsection{What we do not use}
+
+We deliberately do not use repository popularity as a contamination proxy. Popularity proxies
+contamination only insofar as it proxies duplication count in the training corpus, which is the
+variable memorization actually scales with \citep{carlini2023quantifying}, and in this corpus that
+chain is broken: the corpus skews sharply recent, and a substantial number of high-star
+repositories postdate plausible training cutoffs, so ``popular'' and ``plausibly in the training
+set'' are substantially decoupled. Popularity is also not a standard instrument in the
+contamination literature. We report the popularity correlation as a robustness footnote only.
+\todo{decide whether the popularity footnote survives the page limit; if kept, report $r$ from a
+committed join, not the preliminary one}
+
+\subsection{A calibrated difficulty model (\#135)}
+\label{sec:difficulty}
+
+Benchmark papers rarely ship a predictor of their own difficulty. We do, and we report it
+honestly, which means reporting calibration and not only discrimination.
+
+Features are computed \emph{inside} the ablator, so they are visible in the released rows rather
+than being a post-hoc artifact of our analysis code: size and shape (line count, tactic count,
+cyclomatic complexity, fan-in of the deleted lemma), what the proof \emph{does} (counts of
+automation, rewriting and structural steps, an automation-only flag, maximum nesting depth), and
+what the corollary rests on (direct and transitive dependency counts). Size alone cannot
+distinguish a one-line \texttt{simp} call from a forty-line induction with the same step count,
+and that distinction is most of what decides whether a lemma can be re-derived.
+
+The model is trained on outcomes from the main grid, then evaluated on a \textbf{disjoint} second
+sample that is scored \emph{before} its outcomes exist --- a discipline the pipeline enforces
+rather than merely recommends. We report held-out ROC-AUC for discrimination and the Brier score
+with the Murphy decomposition (reliability, resolution, uncertainty) plus a decile reliability
+diagram for calibration, and the per-feature coefficients, since ``fan-in and tactic count predict
+difficulty, file size does not'' is a more useful statement to this audience than an AUC.
+
+\paragraph{Two caveats the numbers carry.} First, the labels are budget-dependent: this is
+difficulty \emph{at budget $B$}, and with \texttt{turn\_limit} as the modal outcome that is a
+substantive qualification rather than a footnote. Second, the scorer counts \texttt{tampered} and
+\texttt{turn\_limit} as failures while dropping \texttt{malformed}, \texttt{trivial} and
+\texttt{context\_exceeded}, matching Table~\ref{tab:outcomes}.
+
+\todo{\#135: held-out AUC, Brier with Murphy decomposition, reliability diagram (Fig.~7), feature
+coefficients; cross-mode transfer (train on leaf, score whole-body) attempted or explicitly
+deferred with a reason}
+
+\subsection{Reward hacking under a verified reward (\#136)}
+\label{sec:tamper}
+
+A verified reward has no false positives on the proof: a memorized proof that compiles is a
+correct proof. It does have an attack surface on the \emph{statement}. In the reference run, four
+attempts made the file compile by deleting or weakening the theorem they were asked to re-prove,
+up from two at a lower budget --- more budget means more opportunities to find the exploit. The
+guard of \S\ref{sec:tampercheck} caught them and excluded them from PASS, which is precisely the
+point: the check is load-bearing rather than decorative.
+
+We report tamper rate as a function of turn budget, extracted from existing run logs at no
+additional inference cost, broken down by tamper reason (statement deleted versus statement
+weakened). This is on-thesis for verified code generation: it is a direct measurement of reward
+hacking scaling with compute in an environment where the reward is a kernel, and it is an
+argument for the corpus as a reinforcement-learning environment, since it demonstrates which
+guards a verified-reward environment actually needs.
+
+\todo{\#136: tamper rate vs budget with underlying counts (Fig.~8), breakdown by tamper reason}
+
+\section{Limitations}
+\label{sec:limitations}
+
+\paragraph{L1: Lean only.} Every released challenge is Lean~4. The ablator exists for Rocq and
+Isabelle and the record schema is shared, but the Rocq corpus is unmined and the Isabelle corpus
+is only partially mined: of 19{,}018 challenges mined from the seL4 verification development,
+14{,}594 sit under the refinement proof, whose Isabelle sessions require a design specification
+that is \emph{generated} from seL4's Haskell model and is absent from a plain checkout. Until that
+generation step runs in our pipeline, only sessions below the design spec can be validated, and we
+ship none of them here. Nothing in this paper should be read as a claim about cross-prover
+generality.
+
+\paragraph{L2: Pass rates are budget-dependent.} \texttt{turn\_limit} was the \emph{modal} outcome
+in our first baseline --- more common than PASS --- and raising the budget moved the rate without
+flattening the curve. Every pass rate we report is therefore a pass rate at a stated budget, and
+should be read as a lower bound at that budget rather than as a property of the model. This
+propagates: the difficulty model of \S\ref{sec:difficulty} predicts difficulty-at-budget, and any
+contamination gap measured on top of a budget-limited baseline inherits the same confound, which
+is why we pair the contamination sweeps with a budget curve.
+
+\paragraph{L3: Scoring requires a built checkout.} The data can be browsed by anyone; scoring a
+prediction requires the repository's prebuilt \texttt{.olean} closure at the pinned revision, at
+roughly 5--7\,GB per Mathlib-dependent repository and on the order of a terabyte for all 57. We
+publish prebuilt closures for a small demo subset sufficient for a quickstart, not for the full
+corpus. This is the single largest adoption barrier we know of, and it is a property of the
+release, not of the method.
+\todo{state exactly which repositories have published closures once \#143 lands, or state that it
+did not land}
+
+\paragraph{L4: Corpus skew.} One repository supplies 33.8\% of leaf rows and the top three supply
+53.4\%. We macro-average everywhere, which mitigates the problem but does not remove it: the tail
+repositories contribute few problems each, so per-repository estimates in the tail are noisy, and
+any analysis correlated with repository size inherits that noise structure.
+
+\paragraph{L5: Context overflow.} Roughly 10\% of challenges exceed a 262{,}144-token context
+window even after minimal slicing. We flag these \texttt{context\_exceeded} and exclude them from
+the denominator, since the provider rejects the prompt and the model never sees the problem.
+Excluding them is the honest accounting, but it also means the largest problems --- plausibly
+among the hardest --- are systematically unmeasured, and the exclusion set varies by model, so
+cross-model comparisons are over slightly different problem sets. We report the exclusion count
+per model alongside every pass rate.
+
+\paragraph{L6: Unresolved licensing on part of the corpus.} Five of 57 repositories are flagged in
+\S\ref{sec:licensing} pending an explicit keep-or-drop decision. Until that is settled, the exact
+released row count is provisional.
+
+\section{Conclusion}
+
+Proof repair inside a real development is a different task from proving a competition statement,
+and it is closer to what proof engineering actually is. We show it can be posed at scale by
+syntactic ablation, and that the resulting problems can be validated on both sides by the
+compiler --- 43{,}410 of them, from 57 pinned Lean~4 repositories. The validation discipline is
+the part we would most like to see adopted elsewhere: it is cheap relative to the mining, it
+catches unwinnable problems that no amount of downstream evaluation would surface, and it turns
+``is this benchmark well-formed?'' from an assertion into a build artifact.
+\todo{one or two sentences of takeaway once the results land}
 
 \begin{ack}
-Use unnumbered first level headings for the acknowledgments. All acknowledgments
-go at the end of the paper before the list of references. Moreover, you are required to declare
-funding (financial activities supporting the submitted work) and competing interests (related financial activities outside the submitted work).
-More information about this disclosure can be found at: \url{https://neurips.cc/Conferences/2026/PaperInformation/FundingDisclosure}.
-
-
-Do {\bf not} include this section in the anonymized submission, only in the final paper. You can use the \texttt{ack} environment provided in the style file to automatically hide this section in the anonymized submission.
+\todo{funding and competing-interest disclosure --- final version only, omitted from the
+anonymized submission}
 \end{ack}
 
 \section*{References}
 
-
-References follow the acknowledgments in the camera-ready paper. Use unnumbered first-level heading for
-the references. Any choice of citation style is acceptable as long as you are
-consistent. It is permissible to reduce the font size to \verb+small+ (9 point)
-when listing the references.
-Note that the Reference section does not count towards the page limit.
 \medskip
-
-
 {
 \small
 
+\begin{thebibliography}{99}
 
-[1] Alexander, J.A.\ \& Mozer, M.C.\ (1995) Template-based algorithms for
-connectionist rule extraction. In G.\ Tesauro, D.S.\ Touretzky and T.K.\ Leen
-(eds.), {\it Advances in Neural Information Processing Systems 7},
-pp.\ 609--616. Cambridge, MA: MIT Press.
+\bibitem{azerbayev2023proofnet}
+Azerbayev, Z., Piotrowski, B., Schoelkopf, H., Ayers, E.W., Radev, D.\ \& Avigad, J.\ (2023)
+ProofNet: Autoformalizing and formally proving undergraduate-level mathematics.
+{\it arXiv:2302.12433}.
 
+\bibitem{carlini2023quantifying}
+Carlini, N., Ippolito, D., Jagielski, M., Lee, K., Tramer, F.\ \& Zhang, C.\ (2023) Quantifying
+memorization across neural language models. In {\it International Conference on Learning
+Representations (ICLR)}.
 
-[2] Bower, J.M.\ \& Beeman, D.\ (1995) {\it The Book of GENESIS: Exploring
-  Realistic Neural Models with the GEneral NEural SImulation System.}  New York:
-TELOS/Springer--Verlag.
+\bibitem{golchin2024timetravel}
+Golchin, S.\ \& Surdeanu, M.\ (2024) Time travel in LLMs: Tracing data contamination in large
+language models. In {\it International Conference on Learning Representations (ICLR)}.
 
+\bibitem{han2022proof}
+Han, J.M., Rute, J., Wu, Y., Ayers, E.W.\ \& Polu, S.\ (2022) Proof artifact co-training for
+theorem proving with language models. In {\it International Conference on Learning
+Representations (ICLR)}.
 
-[3] Hasselmo, M.E., Schnell, E.\ \& Barkai, E.\ (1995) Dynamics of learning and
-recall at excitatory recurrent synapses and cholinergic modulation in rat
-hippocampal region CA3. {\it Journal of Neuroscience} {\bf 15}(7):5249-5262.
+\bibitem{jain2025livecodebench}
+Jain, N., Han, K., Gu, A., Li, W.-D., Yan, F., Zhang, T., Wang, S., Solar-Lezama, A., Sen, K.\ \&
+Stoica, I.\ (2025) LiveCodeBench: Holistic and contamination-free evaluation of large language
+models for code. In {\it International Conference on Learning Representations (ICLR)}.
+
+\bibitem{jimenez2024swebench}
+Jimenez, C.E., Yang, J., Wettig, A., Yao, S., Pei, K., Press, O.\ \& Narasimhan, K.\ (2024)
+SWE-bench: Can language models resolve real-world GitHub issues? In {\it International Conference
+on Learning Representations (ICLR)}.
+
+\bibitem{liu2023fimo}
+Liu, C., Shen, J., Xin, H., Liu, Z., et al.\ (2023) FIMO: A challenge formal dataset for
+automated theorem proving. {\it arXiv:2309.04295}.
+
+\bibitem{mirzadeh2025gsmsymbolic}
+Mirzadeh, I., Alizadeh, K., Shahrokhi, H., Tuzel, O., Bengio, S.\ \& Farajtabar, M.\ (2025)
+GSM-Symbolic: Understanding the limitations of mathematical reasoning in large language models.
+In {\it International Conference on Learning Representations (ICLR)}.
+
+\bibitem{tsoukalas2024putnambench}
+Tsoukalas, G., Lee, J., Jennings, J., Xin, J., Ding, M., Jennings, M., Thakur, A.\ \& Chaudhuri,
+S.\ (2024) PutnamBench: Evaluating neural theorem-provers on the Putnam mathematical competition.
+In {\it Advances in Neural Information Processing Systems (NeurIPS) Datasets and Benchmarks
+Track}.
+
+\bibitem{yang2019coqgym}
+Yang, K.\ \& Deng, J.\ (2019) Learning to prove theorems via interacting with proof assistants.
+In {\it International Conference on Machine Learning (ICML)}.
+
+\bibitem{yang2023leandojo}
+Yang, K., Swope, A.M., Gu, A., Chalamala, R., Song, P., Yu, S., Godil, S., Prenger, R.\ \&
+Anandkumar, A.\ (2023) LeanDojo: Theorem proving with retrieval-augmented language models. In
+{\it Advances in Neural Information Processing Systems (NeurIPS) Datasets and Benchmarks Track}.
+
+\bibitem{zhang2024careful}
+Zhang, H., Da, J., Lee, D., Robinson, V., Wu, C., Song, W., Zhao, T., Raja, P., Slack, D., Lyu,
+Q., Hendryx, S., Kaplan, R., Lunati, M.\ \& Yue, S.\ (2024) A careful examination of large
+language model performance on grade school arithmetic. {\it arXiv:2405.00332}.
+
+\bibitem{zheng2022minif2f}
+Zheng, K., Han, J.M.\ \& Polu, S.\ (2022) miniF2F: A cross-system benchmark for formal
+Olympiad-level mathematics. In {\it International Conference on Learning Representations (ICLR)}.
+
+\end{thebibliography}
 }
-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \appendix
 
 \section{Technical appendices and supplementary material}
-Technical appendices with additional results, figures, graphs, and proofs may be submitted with the paper submission before the full submission deadline (see above). You can upload a ZIP file for videos or code, but do not upload a separate PDF file for the appendix. There is no page limit for the technical appendices. 
 
-Note: Think of the appendix as ``optional reading'' for reviewers. The paper must be able to stand alone without the appendix; for example, adding critical experiments that support the main claims to an appendix is inappropriate. 
+\paragraph{A. Outcome taxonomy in full.} Table~\ref{tab:outcomes} in condensed form, plus the
+exact predicate each outcome is decided by and the order in which they are checked.
+\todo{expand}
+
+\paragraph{B. Per-repository license table.} The full survey at each repository's pinned revision,
+with the license file URL at that revision and the SPDX classification, including the five flagged
+entries discussed in \S\ref{sec:licensing}. \todo{paste the generated table}
+
+\paragraph{C. Per-repository challenge counts.} Mined, malformed, unwinnable-ground-truth, and
+validated counts per repository per holing strategy. \todo{paste the generated table}
+
+\paragraph{D. Solver details.} System prompt, tool schemas, and the exact compile invocation used
+for scoring. \todo{paste}
+
+\paragraph{E. Broader impacts.} The corpus is proof code redistributed from public repositories
+under the licenses surveyed in \S\ref{sec:licensing}; it contains no personal data and no
+dual-use capability of its own. The intended positive impact is to make machine-assisted proof
+engineering measurable on realistic work, which is a prerequisite for lowering the cost of
+formally verifying safety- and security-critical software. Two risks are worth naming. First,
+a benchmark that is optimised against can be gamed at the level of the \emph{statement} rather
+than the proof; \S\ref{sec:tamper} measures exactly this, and the guard of \S\ref{sec:tampercheck}
+is a partial mitigation that we recommend any verified-reward environment adopt. Second, the
+corpus is drawn from projects whose authors did not release their work as an evaluation set; we
+mitigate by pinning and citing every source repository at its exact revision, surveying licenses
+at that revision, and flagging rather than silently including repositories whose terms do not
+clearly permit redistribution (\S\ref{sec:licensing}).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \newpage
 \input{checklist.tex}
-
 
 \end{document}


### PR DESCRIPTION
## Summary

Replaces the stock NeurIPS 2026 template in `comms/vericode-workshop/` with a real draft of the VeriCodeGen workshop submission, and adds `OUTLINE.md` as the companion planning artifact.

**`comms/vericode-workshop/OUTLINE.md`** (new)
- Every one of the five claims mapped to the single experiment issue that discharges it: #129 (holing strategies), #132/#133/#134 (contamination), #135 (difficulty model), #136 (tamper rate).
- An explicit list of claims we are *not* making, so the draft doesn't drift into them.
- Section-by-section outline with page budgets, and a full figure/table list with each float mapped to its producing issue plus a stated trim order for when the page limit bites.
- Open decisions before submission: page limit, anonymization, the 5 licensing-flagged repos, the model grid.

**`neurips_2026_vericode_workshop.tex`** — drafted end to end for everything that doesn't depend on results:
- **Method (§3)**: ablation as proof repair; the two holing strategies; why the slice is corollary-anchored not hole-anchored (hole-anchoring shipped byte-identical challenges under distinct ids and duplicated ~half the corpus); `challenge_id` as the key that makes the two splits a *matched* pair; two-sided compile validation including the "validation is a build problem" hazard that cost ~3,700 valid challenges; the outcome taxonomy and which classes leave the PASS denominator; the tamper guard and its Lean-vs-Coq/Isabelle asymmetry.
- **Dataset (§4)**: 57 repos, 26,157 mined candidates per strategy, 21,692 leaf + 21,718 whole-body = 43,410 validated. Every figure read off `artifacts/lean-ablate-whole/_index.json`, not from memory. Pinning/provenance, the license survey at pinned revisions (and why the platform's license metadata is the wrong field to trust), corpus skew (evm-asm 33.8%, top three 53.4%) with the macro-averaging commitment stated up front.
- **Related work (§2)**: positioned against competition-math benchmarks (miniF2F, ProofNet, PutnamBench, FIMO), repository-scale extraction (LeanDojo, LeanStep, CoqGym — real repos, but no both-sides validation and a next-tactic rather than repair task), execution-scored repair benchmarks (SWE-bench — right task shape, unsound oracle), and the contamination methodology §5.3 borrows. Differentiator stated in one sentence.
- **Contamination (§5.3)** framed as `docs/contamination.agents.md` asks: instance-level memorization defeated by construction, knowledge-level not, three instruments positioned as measuring where the first stops mattering. Includes why repository popularity is *not* used as a proxy.
- **Limitations (§6)**: Lean-only (l4v partial — 14,594 of 19,018 challenges under `Refine`, blocked on seL4's generated design spec; Rocq unmined); budget-dependent pass rates (turn-limit was modal in the first baseline); scoring needs a built checkout with only a demo subset of closures published (#143); corpus skew; ~10% of challenges over a 262,144-token context. Plus a sixth on unresolved licensing.
- Appendix E adds a broader-impacts paragraph so the checklist can answer that item.

**`checklist.tex`** — instruction block removed per the template's own directive; all 16 items answered with justifications pointing at concrete sections. Only compute-resources stays `\answerTODO`, since honest numbers need #130/#131.

**No fabricated numbers.** Every results slot is a clearly-marked `\todo{}` naming the issue that will fill it — 18 in the paper, 4 in the checklist.

## Test plan

There is no CI and no build for `comms/`; the check that matters is that the document typesets.

- `pdflatex` **is** available here, but the Times/psnfss and Latin Modern font packages are **not**, so the document cannot be typeset with the NeurIPS style's own fonts on this machine (`ptmr8t` / `lmodern.sty` both missing — a texlive-basic install).
- Worked around by compiling an unmodified copy of the real `.tex` against a Computer Modern substitute (`OT1` encoding, `microtype` disabled — the latter needs scalable fonts). This exercises the actual document, only the typeface differs.
- **Result: clean two-pass build. Zero errors, zero LaTeX warnings, no undefined references or citations.** 19 pages: ~10 content + references + appendix + 8 of checklist.
- This is how the missing `amsmath` dependency was found (`\text` in the `challenge_id` display), now added to the preamble.
- Reviewer note: **content runs ~10 pages** under the wider substitute font, so ~9 with Times, before any results text or figures are added. It will need trimming to the workshop limit; `OUTLINE.md` records the trim order and flags confirming the limit as open decision #1.
- Diff is confined to `comms/vericode-workshop/`; no Python touched, so the `ruff`/`ty`/`pytest` suites in `scaffold/` and `experiments/` are unaffected.

Closes #147
