### PR TITLE
baselines: repoint integration run.sh at baselines/ (#122)

### DIFF
--- a/baselines/tests/integration/run.sh
+++ b/baselines/tests/integration/run.sh
@@ -13,7 +13,7 @@ set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(cd "$HERE/../../.." && pwd)"
-HARNESS="$REPO/harness"
+HARNESS="$REPO/baselines"
 WORK="$HERE/_work"
 FIX="$HERE/fixtures"
 rm -rf "$WORK"; mkdir -p "$WORK"
@@ -31,6 +31,14 @@ run_prover() {
   echo "===================== $name ====================="
   if ! command -v nix >/dev/null 2>&1; then
     echo "SKIP $name: nix not found"; skipped=$((skipped+1)); return
+  fi
+  # Canary: make sure the prover's nix dev shell actually builds/enters before
+  # committing to the full gen+check run. A missing/unreachable toolchain (no
+  # network to fetch flake inputs, no substituter cache, etc.) should read as a
+  # clear per-prover SKIP, not an opaque FAIL indistinguishable from a real bug.
+  if ! nix develop "path:$flake" --no-write-lock-file -c true >/dev/null 2>&1; then
+    echo "SKIP $name: nix dev shell for $flake did not build (toolchain unavailable in this environment)"
+    skipped=$((skipped+1)); return
   fi
   local src="$WORK/$name/src" dst="$WORK/$name/dst" jsonl="$WORK/$name/out.jsonl"
   mkdir -p "$WORK/$name"


### PR DESCRIPTION
## Summary

- `baselines/tests/integration/run.sh:16` set `HARNESS="$REPO/harness"`, but
  that directory was renamed to `baselines/` long ago — the opt-in
  real-toolchain end-to-end integration tests (the only suite that actually
  invokes `coqc`/`isabelle`/`lake`) have been silently dead.
- Repointed `HARNESS` at `$REPO/baselines`.
- Added a canary (`nix develop "path:$flake" --no-write-lock-file -c true`)
  before the real gen+check run in `run_prover()`, so a missing or
  unreachable toolchain in the current environment (no `nix`, unbuildable
  dev shell, unreachable flake inputs) shows up as a clear per-prover `SKIP`
  line rather than an opaque `FAIL` that's indistinguishable from a real bug.
  (The existing `command -v nix` check already skipped gracefully when `nix`
  itself is missing; this extends that to "nix is present but this
  particular flake/toolchain won't build here.")

## Verification

Ran the script against real toolchains via `nix develop` in this sandbox
(coqc via the rocq-ablator flake, isabelle via the isabelle-ablator/rust
flake, lake/lean via the lean-ablator flake — all resolved from cached nix
store paths, no network needed):

```
$ bash baselines/tests/integration/run.sh
...
integration: 3 passed, 0 failed, 0 skipped
```

All three provers PASS end-to-end: real ablator generates a JSONL from the
synthetic fixture project, `apply-ablate --prepare --full-check` applies the
challenge, the holed challenge compiles (holes allowed), and the recovered
solution compiles clean.

Also verified the SKIP path degrades gracefully rather than dying, both when
`nix` itself is absent from `PATH` and when a flake path can't be resolved
(canary catches it and skips that one prover without affecting the others or
crashing the script).

**No leftover failures to report** — once repointed and run, all three
provers passed cleanly; the only real hiccup was that the lean ablator
binary needed a one-time ~3.5 minute `lake build` (cold, no cached
`.lake/build/bin/ablate`) before the harness step ran, which the script
already handles (`[ -x ./.lake/build/bin/ablate ] || lake build`) — just
slow the first time, not a bug.

Scope note: per issue guidance, `docs/ablation-baseline-findings.md`'s stale
`harness/` references (lines 107, 151) are intentionally left untouched here
— that's being handled by issue #145 in a parallel task. This diff is
restricted to `baselines/tests/`.

## Test plan

- [x] `bash baselines/tests/integration/run.sh` — all 3 provers PASS (coq,
      isabelle, lean) against real toolchains via nix
- [x] `bash baselines/tests/integration/run.sh coq` (single-prover mode) —
      PASS
- [x] SKIP path when `nix` absent from `PATH` — verified graceful, exit 0
- [x] SKIP path when a flake dir doesn't resolve — verified via canary,
      doesn't crash the script
- [x] `cd baselines && uv run ruff format && uv run ruff check --fix && uv run ty check && uv run pytest` — all green (114 passed)

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKkRR9JnZ7hRPwtV77cMJe