### PR TITLE
docs: reframe CLAUDE.md, README, and SoW around syntactic ablation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,27 +1,36 @@
-# proof engineering evals via git history
+# proof engineering evals via syntactic proof ablation
 
-An obvious instrument in the secure program synthesis (SPS) arsenal is formal methods. While previously prohibitively expensive due to the labor of the proof engineers, we now expect it to sink in cost due to AI driven proof synthesis (and it already has). 
+An obvious instrument in the secure program synthesis (SPS) arsenal is formal methods. While
+previously prohibitively expensive due to the labor of proof engineers, we expect the cost to sink
+due to AI-driven proof synthesis. The bottleneck for evals and RL environments that could push this
+forward is data: real proof-engineering repos (CompCert, seL4, fiat-crypto, Nova, and the long tail
+of Lean projects) contain enormous amounts of verified ground truth, but none of it is packaged as
+an eval.
 
-One kinda silly bottleneck to the evals and RL envs that could push this forward faster is cultural— proof engineers from real world codebases like CompCert, SeL4, fiat-crypto, Nova, etc. don’t necessarily know what an eval is and why it’s valuable to register their naturally-occurring data to inspect. I have an unfinished e-book trying to solve this cultural gap. 
+This repo turns those repos into evals by **syntactic proof ablation**. Given a proof file, an
+ablator picks a theorem (the *corollary*), takes its transitive in-file dependency closure, deletes
+one lemma from that closure, and replaces the proof steps that used it with holes (`sorry` /
+`Admitted` / `oops`). The solver must re-derive the deleted lemma and close the holes so the file
+compiles. Both sides of every published pair are **compile-validated** by the real prover, so the
+ground truth is not a guess about what a commit intended.
 
-This codebase, which I prototyped but didn’t finish, targets a specific proof engineering repo, the specs and proofs of Dalek25519 (a cryptographic primitive library that Signal the messaging app uses), currently underway by BAIF: https://github.com/Beneficial-AI-Foundation/git-history-proof-engineering-eval 
-In it, I “mine” the git history to extract challenge problems from commit at time t, which have a ground truth in that they’re solved in the commit at time t+1 in many cases. In doing this (as you’ll see in the code), the hardcoded .git directory scraper makes some assumptions about patterns in commit messages and more generally the conventions with which git is used for collaboration. 
-
-The proper swing at proof engineering evals via git histories would be an agentic miner/scraper, which dynamically finds those assumptions and patterns on the fly, so you have one scaffold and you drop any proof engineering codebase you please into it. 
-
-This effort should also involve conducting baselines.
+The project previously mined git histories for `(commit t, commit t+1)` challenge pairs. That
+method was retired in August 2026 — see `docs/SoW.md` for the pivot, its date, and its rationale.
 
 ## IMPORTANT: See @./docs/SoW.md for milestones
 
-keep us on track. 
+keep us on track.
 
-## Deliverable 
-Evals for at least the Nova hypervisor specs and proofs, SeL4, Compcert, and Fiat-Crypto registered to inspect and listed on huggingface. The generalized scaffold dynamically synthesizing “miner” scripts that walk across the git histories. Reporting baselines of how current language models do, which includes demonstration of how to download the data from huggingface and make a solver. Stretch goal: demonstrate actual posttraining on these eval-as-envs with open weight models. 
+## Deliverable
+
+Compile-validated ablation evals over real proof-engineering repos, published to HuggingFace
+(`for-all-dev/ablation-eval`), plus a prover-agnostic agentic baseline harness and reported
+baselines for current language models. Stretch goal: post-training on these evals-as-envs with
+open-weight models.
 
 ## Quality checks
 
-Run these from `./scaffold/` (and `./experiments/`) every now and then, and
-**certainly before every commit**:
+Run these from `./baselines/` every now and then, and **certainly before every commit**:
 
 ```bash
 uv run ruff format        # autoformat
@@ -30,92 +39,125 @@ uv run ty check           # type check
 uv run pytest             # tests
 ```
 
+The ablators have their own toolchains: `nix develop ablators/lean` (`lake test`),
+`ablators/rocq` (`dune test`), `ablators/isabelle` (`cargo test` under `ablators/isabelle/rust`).
+
 ## repo structure
 
-- `./scaffold/`: Python project (uv-managed) containing:
-  - `src/scaffold/`: the **profile-driven** miner/scraper. Two tiers: (1) `profiler/` — a pydantic-ai + `pydantic-ai-harness` CodeMode **calibration agent** that explores a repo + its git history and synthesises a `RepoProfile`; (2) the deterministic engine (`git_walker`, `pattern_detector`, `analyzers/ProfileAnalyzer`) that runs the full history parameterised by that profile — no LLM in the hot loop. `profile.py` is the `RepoProfile` contract (globs, hole markers, declaration patterns, commit-signal banks, tactic vocab/groups — everything that used to be hardcoded, now data). `dataset.py` writes mined evals as manifest-schema version dirs (see `artifacts/MANIFEST_SCHEMA.md`).
-  - `src/quali/`: qualitative study tool — uses pydantic-ai to analyze per-theorem proof evolution trajectories (human baseline for contrast with agent trajectories)
-  - `src/scripts/analysis/`: proof lifecycle reporting scripts
-- `./experiments/`: second uv project — the eval *runner* for fiat-crypto per-commit challenges:
-  - `run_experiment.py`: single-shot Claude baseline across all slots (`eval-baseline`)
-  - `agent/`: pydantic-ai ReAct agent (`runner.py`, `agent.py`, `tools.py`, `deps.py`) + `run_agent_experiment.py` (`eval-agent`)
-  - `shared/`: splice, prompts, compile helpers used by both drivers
-  - `docker/`: layered Dockerfiles — `base` (coq + uv), `deps` (opam layer), `commit` (per-SHA fiat-crypto checkout + warm build)
-  - `orchestrate/`: bash + docker-compose glue. `run-all.sh` spawns a detached tmux session with one window per SHA; each window runs `run-commit.sh` against a `gen-compose.py`-produced compose file. `aggregate.sh` pulls per-SHA named volumes (`results-<prefix>`) into `results/<run_id>/`. `attach.sh` attaches to a running session.
-  - `summary.py`: cross-run aggregator — per-(mode, deletion_size) drift ratios (vo_bytes, compile_time, proof_chars/lines, tactic_count) vs human reference, baseline-vs-agent deltas, per-metric Pearson r vs deletion_size as a faithfulness check
-  - `results/<run_id>/`: host-side mirror of the per-SHA volumes (see `experiments/results/README.md`)
-- **Ablators** (syntactic proof-ablation tools — each parses a proof file and replaces
-  selected proofs/lemmas with holes, emitting `(challenge, solution)` JSONL pairs; all
-  share the `record.py`-compatible schema). Four implementations, kept in lockstep:
-  - `./rocq-ablator/`: OCaml/dune, for Coq/Rocq `.v` (CLI `bin/main.ml` + WASM).
-  - `./lean-ablator/`: Lean 4/lake, for `.lean` (`Main.lean`, core in `Ablator/`, WASM).
-  - `./isabelle-ablator/rust/`: Rust/cargo, for Isabelle `.thy` (clap CLI + WASM).
-  Key flags (all four): `--delete-lemmas[=N]` / `--delete-lemmas-leaves` (delete N
-  eligible lemmas + hole their in-file users at smallest-enclosing-block granularity),
-  `--corollary-delete-lemmas[=N]` / `-uniform` / `-leaves` (same, but candidates are
-  restricted to one random theorem's — the "corollary" — transitive in-file dependency
-  closure: pick a corollary uniformly, draw deletions from its closure fan-in-weighted
-  (or uniform), re-picking a corollary only when the closure runs dry),
-  `--count N`, `--shrink-challenge-minimal` / `--shrink-solution-minimal` (slice to the
-  holes' dependency closure), `--compact` (JSONL), `--text`, `--check-build`. Ablators
-  **skip emitting a record when nothing was deleted/holed** (challenge == solution) so
-  trivial challenges never reach a baseline. (Isabelle-only: apply-scripts are
-  prefix-cut by default — keep a prefix of `apply` steps, `sorry` the rest — or dropped
-  whole with `--ablate-scripts`.)
-- `./baselines/`: uv project — the **prover-agnostic agentic baseline harness**
-  (formerly `harness/`; the older single-shot whole-file baseline is now
-  `./baselines-old/`). Package `apply_ablate`: `solve.py` is a pydantic-ai ReAct loop
-  that re-derives the deleted lemma(s) into a compiling, hole-free file; `provers/`
-  has the Coq/Isabelle/Lean backends (`coqc`, session-aware `isabelle build` with
-  prebuilt-deps + `skip_proofs`, bare `lean` with a reconstructed `LEAN_PATH` — never
-  `lake env`, which would write through the `.lake` symlink into src, #119);
-  `apply.py` splices a challenge into
-  a work copy (symlinking heavy dep dirs like `.lake`); `record.py` is the shared JSONL
-  schema; `obs.py` wires Logfire (`instrument_pydantic_ai` + per-compile/per-outcome
-  spans). Pre-flight validation marks challenges that don't compile `malformed` and
-  empty-diff ones `trivial`, both excluded from the PASS rate.
-- `./ablators/isabelle/flake.nix`: pins the **official** Isabelle releases the baseline evaluator
-  must run under — `isabelle-2025` for **l4v** (@429d778 needs the base release), `isabelle-2025-2`
-  for the **AFP**. nixpkgs' Isabelle breaks `smt` reconstruction, so it cannot be used. (The Scala
-  ablator that used to own this flake has been deleted; the Rust ablator does the ablation.)
-- `./data/`: source repos, **organised by language**: `data/lean/<repo>` (50 mined Lean repos +
+- `./ablators/`: the three **ablators** — each parses a proof file, replaces selected
+  proofs/lemmas with holes, and emits `(challenge, solution)` JSONL pairs sharing the
+  `record.py` schema. Kept in lockstep, each also built to WASM for the website.
+  - `./ablators/lean/`: Lean 4 / lake, for `.lean` (`Main.lean`, core in `Ablator/`).
+  - `./ablators/rocq/`: OCaml / dune, for Coq/Rocq `.v` (CLI `bin/main.ml`, core in `lib/`).
+  - `./ablators/isabelle/rust/`: Rust / cargo, for Isabelle `.thy` (clap CLI).
+  - `./ablators/isabelle/flake.nix`: pins the **official** Isabelle releases the baseline
+    evaluator must run under — `isabelle-2025` for **l4v** (@429d778 needs the base release),
+    `isabelle-2025-2` for the **AFP**. nixpkgs' Isabelle breaks `smt` reconstruction, so it
+    cannot be used.
+
+  Key flags (all three): `--delete-lemmas[=N]` / `--delete-lemmas-leaves` (delete N eligible
+  lemmas + hole their in-file users at smallest-enclosing-block granularity);
+  `--corollary-delete-lemmas[=N]` / `-uniform` / `-leaves` (same, but candidates are restricted
+  to one random theorem's — the "corollary" — transitive in-file dependency closure: pick a
+  corollary uniformly, draw deletions from its closure fan-in-weighted (or uniform), re-picking a
+  corollary only when the closure runs dry); `--count N`;
+  `--shrink-challenge-minimal` / `--shrink-solution-minimal` (slice to the corollary's dependency
+  closure); `--compact` (JSONL); `--text`; `--check-build`. Ablators **skip emitting a record
+  when nothing was deleted/holed** (challenge == solution) so trivial challenges never reach a
+  baseline. (Isabelle-only: apply-scripts are prefix-cut by default — keep a prefix of `apply`
+  steps, `sorry` the rest — or dropped whole with `--ablate-scripts`.)
+
+- `./baselines/`: uv project — the **prover-agnostic agentic baseline harness**, package
+  `apply_ablate`. `solve.py` is a pydantic-ai ReAct loop that re-derives the deleted lemma(s)
+  into a compiling, hole-free file; `provers/` has the Coq/Isabelle/Lean backends (`coqc`;
+  session-aware `isabelle build` with prebuilt deps + `skip_proofs`; bare `lean` with a
+  reconstructed `LEAN_PATH` — never `lake env`, which would write through the `.lake` symlink
+  into src, #119); `apply.py` splices a challenge into a work copy (symlinking heavy dep dirs
+  like `.lake`); `record.py` is the shared JSONL schema; `obs.py` wires Logfire
+  (`instrument_pydantic_ai` + per-compile/per-outcome spans); `difficulty/` is the
+  feature/label layer for the difficulty classifier. Pre-flight validation marks challenges that
+  don't compile `malformed` and empty-diff ones `trivial`, both excluded from the PASS rate.
+
+- `./pipeline/`: the ablation pipeline — mine -> build -> validate -> index -> publish -> eval.
+  `run.sh` is the single entry point; `repos.tsv` (name, language, url, revision, path,
+  toolchain) is the single source of truth for the corpus; `clone_repos.sh` materialises it.
+  `publish_hf.sh` rebuilds and publishes the `for-all-dev/ablation-eval` easy/hard splits;
+  `upload_ablations.sh` pushes bulk JSONL to DO Spaces. See `pipeline/README.md`, and
+  **read its "Validation is a build problem" section before trusting any `malformed` count** —
+  an incompletely built source tree reports every challenge as malformed (this understated
+  hex-dev by 2,881 challenges).
+
+- `./data/`: source repos, organised by language: `data/lean/<repo>` (the mined Lean corpus +
   `_triage/` of unmined candidates), `data/isabelle/l4v`, `data/rocq/{CompCert,fiat-crypto,BRiCk}`.
-  Only the 4 Rocq/Isabelle repos are git submodules; the Lean checkouts are pinned in
-  `pipeline/repos.tsv` (url + revision + toolchain) and materialised by `pipeline/clone_repos.sh`
-  — they are multi-GB once built, so they are gitignored rather than vendored.
-- `./pipeline/`: the ablation pipeline — mine -> build -> validate -> publish. See
-  `pipeline/README.md`; **read its "Validation is a build problem" section before trusting any
-  `malformed` count**, since an incompletely-built source tree reports every challenge as
-  malformed (this understated hex-dev by 2,881 challenges).
+  Only the Rocq/Isabelle repos are git submodules; the Lean checkouts are pinned in
+  `pipeline/repos.tsv` and materialised by `clone_repos.sh` — they are multi-GB once built, so
+  they are gitignored rather than vendored.
+
+- `./artifacts/`: mined datasets, one directory per mode:
+  - `artifacts/lean-ablate/<repo>/manifest.json` — **corollary-leaves** mode (only the leaf
+    tactic steps that cited the deleted lemma are holed).
+  - `artifacts/lean-ablate-whole/<repo>/manifest.json` — **corollary-whole** mode (each user's
+    entire proof body is holed; strictly harder).
+
+  Each manifest records repo, git revision, proof assistant, exact ablator flags, seed, the
+  validation command, and mined/kept/malformed counts, so a published row always traces back to
+  an exact tree. `_index.json` + `README.md` per mode are regenerated by `pipeline/write_index.py`.
+  Bulk `*.jsonl` payloads are sha256-addressed blobs declared in the manifests and gitignored.
+  (`artifacts/cedar-spec-eval/` is a leftover bundle from the retired git-history miner.)
+
+- `./website/`: the **Proof Ablation Playground** — a Vite/React static site (deployed on Vercel)
+  that runs all three ablators as WASM entirely in the browser. Paste a theory, get back the
+  ablated challenge file or the JSON eval records. The `.wasm` bundles are prebuilt and committed
+  under `public/wasm/`. See `website/README.md`.
+
 - `./flake.nix`: the pipeline toolchain — a `cc` wrapper adding `-D_GNU_SOURCE` (Lean C FFI),
   elan/lake, s3cmd, and a uv2nix-built python env exposing `ablate-baseline` with no uv at
   runtime (`nix run .#ablate-baseline`).
-- `./artifacts/`: mined eval datasets as versioned bundles — `<repo>-eval/<tag>-<hash>/{manifest.json, miner/profile.json, challenges.jsonl}` per `MANIFEST_SCHEMA.md`, indexed by `_index.json`. Each dataset owns exactly one profile (at `<version>/miner/profile.json`); the blessed `<repo>-eval/profile.json` that `mine-all` reads is a relative **symlink** into the canonical version's profile, not a copy. Bulk `*.jsonl`/`*.txt` payloads are sha256 blobs declared in manifests and gitignored.
-- `./dashboard/`: Next.js app for exploring JSONL benchmark artifacts
-- `./docs/`: changelog for the pattern detector (`PatternDetectorChanges.md`) + agent task template
+
+- `./docs/`: findings and planning. `ablation-baseline-findings.md` (agentic baseline results +
+  ablator bugs found by running it), `dataset-issues.md` (the inspection that motivated the
+  pivot), `lean-ablate-datasets.md`, `lean-ablate-repo-gotchas.md`, `difficulty-features.md`,
+  `rocq-ablate-candidates.md`, `contamination.agents.md`, `SoW.md`.
+
+- `model-roles.json` at the repo root configures the cheap/mid/decision model roles.
 
 ### CLI tools
 
-From `./scaffold/`:
-- `uv run scaffold profile <repo> --tag <label> [--promote]` — Tier-1 calibration agent: synthesise a `RepoProfile`, mine, and write a versioned dataset bundle under `artifacts/<repo>-eval/<tag>-<hash>/`
-- `uv run scaffold materialize <repo> -p <profile.json> --tag <label> [--kind handcrafted] [--promote]` — bundle an existing profile into a dataset version dir without the agent (used to migrate hand-authored profiles). `--promote` symlinks `<repo>-eval/profile.json` at the new version.
-- `uv run scaffold calibrate --bundle <version-dir>` — calibrate a **repo-specific curation prompt** (issue #84): iteratively draws fresh random samples, labels them with the decision model, evaluates candidate prompts (tier-1 scoring + mechanical threshold sweep with a 10% defer-rate cap + tier-2 escalation), and lets a persistent decision-model "writer" analyze failures and propose variants. Writes `<version>/curation/{criteria.txt, tier1_prompt.txt, tier2_prompt.txt, calibration.json}`; consume via `scaffold curate <challenges.jsonl> --calibration <version>/curation`. Model roles (cheap/mid/decision — currently Haiku/Sonnet/Opus) are configured in `model-roles.json` at the monorepo root (see `scaffold/src/scaffold/model_roles.py`).
-- `uv run scaffold` — Tier-2 deterministic mining: `mine`/`mine-all`/`dump-commits`/`enrich-commits`/`diff-enrich`/`stratify-tactics`/`group-tactics`, each taking `--profile/-p` (see `scaffold --help`)
-- `uv run quali` — qualitative trajectory analysis via LLM (reads from artifacts, writes `*-quali.jsonl`)
+From `./pipeline/` (inside `nix develop`):
+
+- `bash pipeline/clone_repos.sh lean` — fetch source repos at their pinned revisions
+- `bash pipeline/run.sh all <scratch>` — mine -> validate -> index -> eval, both modes
+- `bash pipeline/run.sh mine|validate|index|eval <scratch> …` — one stage at a time
+- `bash pipeline/upload_ablations.sh` — publish bulk JSONL to `s3://forall-ablations/lean/<mode>/<repo>/`
+- `bash pipeline/publish_hf.sh` — rebuild + publish the `for-all-dev/ablation-eval` easy/hard splits
 
 From `./baselines/`:
-- `uv run ablate-baseline <challenges.jsonl> <src> [--model … --max-turns N --timeout S --out F]` — run the pydantic-ai ReAct agent over ablator-generated challenges, scoring each by real compilation; reports PASS / trivial / malformed / turn-limit / harness-err. Run inside the relevant prover's nix shell (so `coqc`/`isabelle`/`lake` are on PATH) with `ANTHROPIC_API_KEY` in the repo `.env`. (For Coq, use the opam `coqc` that built the `.vo`, not the rocq-ablator nix shell's Rocq.)
-- `uv run difficulty extract <challenges.jsonl> [--out-jsonl F --out-csv F]` / `uv run difficulty build-table <challenges.jsonl> <results.jsonl> [--out-* F]` — the **difficulty-classifier** feature/label layer (`apply_ablate.difficulty`). `extract` flattens each enriched ablator record into a fixed per-challenge feature vector (fan-in, sub-proof/tactic/cyclomatic aggregates over deleted lemmas + holes + corollary, sizes, closure_size); `build-table` joins those to `ablate-baseline` outcomes (PASS label + reconstructed outcome class) via the stable `challenge_id`. The proof-complexity metrics are computed *inside* the four ablators (visible in the JSONL); Python only aggregates. Model is deferred — see `apply_ablate.difficulty.model` and `docs/difficulty-features.md`.
 
-From `./experiments/`:
-- `uv run eval-baseline` — single-shot Claude baseline across slots; writes `results/<run_id>/baseline.jsonl`
-- `uv run eval-agent` — pydantic-ai ReAct loop alternative; writes `results/<run_id>/agent.jsonl`
-- `uv run python summary.py --inputs <glob>` — aggregate one or more JSONLs into summary.json + summary.md
-- `./orchestrate/run-all.sh` — end-to-end: build images, gen compose, spawn tmux session per SHA
-- `./orchestrate/aggregate.sh [<run_id>]` — post-run concat + summary + `latest` symlink
-- `./orchestrate/attach.sh [<run_id>]` — attach to a running `proof-eval-<run_id>` tmux session
+- `uv run ablate-baseline <challenges.jsonl> <src> [--model … --max-turns N --timeout S --out F]`
+  — run the pydantic-ai ReAct agent over ablator-generated challenges, scoring each by real
+  compilation; reports PASS / trivial / malformed / turn-limit / harness-err. Run inside the
+  relevant prover's nix shell (so `coqc`/`isabelle`/`lean` are on PATH) with `ANTHROPIC_API_KEY`
+  in the repo `.env`. (For Coq, use the opam `coqc` that built the `.vo`, not the
+  `ablators/rocq` nix shell's Rocq.)
+- `uv run apply-ablate <jsonl> <index> <src> <dst> [--prepare --check --full-check …]` —
+  materialise a single challenge (or its solution) onto disk and verify it builds.
+- `uv run difficulty extract <challenges.jsonl>` / `uv run difficulty build-table
+  <challenges.jsonl> <results.jsonl>` — the difficulty-classifier feature/label layer. `extract`
+  flattens each enriched ablator record into a fixed per-challenge feature vector (fan-in,
+  sub-proof/tactic/cyclomatic aggregates over deleted lemmas + holes + corollary, sizes,
+  closure_size); `build-table` joins those to `ablate-baseline` outcomes via the stable
+  `challenge_id`. The proof-complexity metrics are computed *inside* the ablators (visible in the
+  JSONL); Python only aggregates. See `docs/difficulty-features.md`.
+
+Ablator CLIs (each from its own `nix develop`):
+
+- `ablators/lean`: `lake exe ablate <file.lean> [flags]` (tests: `lake exe ablate-test`)
+- `ablators/rocq`: `dune exec bin/main.exe -- <file.v> [flags]`
+- `ablators/isabelle/rust`: `cargo run --features cli --bin ablate -- <file.thy> [flags]`
 
 ### source data repos
+
+- 57 Lean repos pinned in `pipeline/repos.tsv` (the mined corpus)
 - https://github.com/seL4/l4v (Isabelle)
 - https://github.com/mit-plv/fiat-crypto (Coq)
 - https://github.com/AbsInt/CompCert (Coq)

--- a/README.md
+++ b/README.md
@@ -1,121 +1,115 @@
 # git-history-evals
 
-Proof-engineering evals mined from real-world formal-methods git histories. Each challenge is a theorem whose proof was completed at commit `t+1`; the eval asks a language model to reproduce the proof given the state at commit `t`, and scores it on compile success plus drift metrics against the human reference.
+**Proof-engineering evals built by syntactic proof ablation.**
 
-Two Python projects live here:
+Take a real, verified proof file. Pick a theorem — the **corollary**. Take its transitive in-file
+dependency closure, delete one lemma from that closure, and replace the proof steps that cited it
+with holes (`sorry` / `Admitted` / `oops`). Slice the file down to the corollary's closure so the
+context stays small. That ablated file is the challenge; the original is the solution. The solver
+must re-derive the deleted lemma and close the holes so the file compiles.
 
-- `scaffold/` — quantitative miner + qualitative study. Walks a target repo's git history, classifies commits, and extracts per-theorem challenge slots. See `scaffold/README.md`.
-- `experiments/` — the eval *runner*. Baseline (single-shot Claude) and pydantic-ai ReAct agent drivers, plus a layered Docker + tmux + `docker compose` pipeline that runs one container per fiat-crypto SHA in parallel. See `experiments/README.md`.
+Both sides of every published pair are checked by the real prover before publication, so the
+ground truth is a proof that actually compiles rather than an inference about what a commit meant
+to do.
 
-Target repos (git submodules under `data/`): fiat-crypto (Coq), CompCert (Coq), BRiCk (Coq), l4v (Isabelle).
+The published dataset is **[`for-all-dev/ablation-eval`](https://huggingface.co/datasets/for-all-dev/ablation-eval)**
+(`easy` / `hard` splits). The **Proof Ablation Playground** in `website/` runs all three ablators as WASM
+client-side, so you can paste a theory and see the challenge it becomes without installing a
+prover (see `website/README.md`).
+
+> The project began as a git-history miner: challenges were `(commit t, commit t+1)` pairs. That
+> method was retired in August 2026 in favour of ablation. `docs/SoW.md` records the pivot and why.
+
+## Two modes
+
+Both delete one lemma from a corollary's closure; they differ in how the lemma's *users* are holed.
+
+| mode | what gets holed | artifacts |
+|---|---|---|
+| `corollary-leaves` | only the **leaf tactic steps** that cited the lemma — the rest of each user's proof survives | `artifacts/lean-ablate/` |
+| `corollary-whole` | each user's **entire proof body** — solve from the statement alone (strictly harder) | `artifacts/lean-ablate-whole/` |
+
+## What's here
+
+- `ablators/{lean,rocq,isabelle}` — three ablators (Lean 4/lake, OCaml/dune, Rust/cargo) sharing
+  one record schema, each also compiled to WASM for the website.
+- `baselines/` — the prover-agnostic agentic baseline harness (`ablate-baseline`): a pydantic-ai
+  ReAct loop that re-derives the deleted lemma, scored by real compilation.
+- `pipeline/` — mine → build → validate → index → publish → eval. `repos.tsv` pins the corpus.
+- `artifacts/` — per-repo manifests (repo, revision, ablator flags, seed, counts) per mode.
+- `data/` — source repos by language (`data/lean/…`, `data/isabelle/l4v`, `data/rocq/…`).
+- `website/` — the Proof Ablation Playground.
 
 ## Prereqs
 
-- `docker` + `docker compose` (v2)
-- `tmux`
-- `jq`
-- `uv` (Python package manager)
-- `ANTHROPIC_API_KEY` — set in a `.env` at the repo root
+- `nix` (flakes enabled) — `flake.nix` provides the pipeline toolchain
+- `uv` (only if you want to run `baselines/` outside nix)
+- `ANTHROPIC_API_KEY` in a `.env` at the repo root, for baseline runs
 
-## One-time setup
+## Quickstart
 
 ```bash
-git submodule update --init --recursive data/fiat-crypto
-echo "ANTHROPIC_API_KEY=sk-ant-..." >> .env
-cd experiments && uv sync && cd ..
+nix develop                                   # wrapped cc, elan/lake, ablate-baseline, s3cmd
+bash pipeline/clone_repos.sh lean             # fetch source repos at pinned revisions
+bash pipeline/run.sh all /path/to/scratch     # mine -> validate -> index -> eval, both modes
 ```
 
-## Mainline: dockerized end-to-end run
+One stage at a time:
 
-One command builds the images, generates a per-run `compose.yml`, and spawns a detached tmux session with one window per mined fiat-crypto SHA:
+| command | what |
+|---|---|
+| `run.sh mine <scratch> [leaves\|whole]` | ablate every repo (syntactic — needs no build) |
+| `run.sh validate <scratch> [leaves\|whole]` | really compile challenge + ground truth; write `artifacts/` |
+| `run.sh index <scratch>` | regenerate `_index.json` (counts + sha256 per blob) |
+| `run.sh eval <scratch> <n> [model]` | sample, solve, train the difficulty model, test on a disjoint sample |
+
+Publishing:
 
 ```bash
-cd experiments
-./orchestrate/run-all.sh --mode both --max-parallel 4
+bash pipeline/upload_ablations.sh   # bulk JSONL -> s3://forall-ablations/lean/<mode>/<repo>/
+bash pipeline/publish_hf.sh         # easy/hard splits -> for-all-dev/ablation-eval
 ```
 
-On success it prints a block like:
+See `pipeline/README.md` — and **read its "Validation is a build problem" section before trusting
+any `malformed` count**: an incompletely built source tree reports every challenge as malformed.
 
-```
-Started session: proof-eval-<run-id>
-Results dir:    experiments/results/<run-id>/
-Compose file:   experiments/results/<run-id>/compose.yml
-Attach with:    ./attach.sh <run-id>
-Aggregate with: ./aggregate.sh <run-id>
-```
+## Running a baseline
 
-Useful flags:
-
-- `--mode {baseline|agent|both}` — which driver(s) to run inside each container (default `both`)
-- `--max-parallel N` — cap on concurrent per-SHA image builds and containers (default 4)
-- `--shas <sha1,sha2,...>` — restrict to an explicit SHA list; otherwise all SHAs from `meta.json` are used
-- `--skip-build` — assume images are already built
-- `--run-id <id>` — override the timestamp-based run id
-- `--dry-run` — print the plan without executing
-
-Attach to the running session (each SHA has its own tmux window):
+From inside the relevant prover's nix shell (so `coqc` / `isabelle` / `lean` are on PATH):
 
 ```bash
-./orchestrate/attach.sh <run-id>
+cd baselines
+uv run ablate-baseline <challenges.jsonl> <src-checkout> --max-turns 40 --out results.jsonl
 ```
 
-Once all windows have finished, aggregate:
+Outcomes are `PASS` / `trivial` / `malformed` / `turn-limit` / `harness-err`; `trivial` and
+`malformed` are excluded from the PASS rate. Results and the ablator bugs that running it exposed
+are written up in `docs/ablation-baseline-findings.md`.
+
+## Ablating one file directly
 
 ```bash
-./orchestrate/aggregate.sh <run-id>
+nix develop ablators/lean
+lake exe ablate MyTheory.lean --corollary-delete-lemmas-leaves --shrink-solution-minimal --compact
 ```
 
-This copies the per-SHA Docker named volumes (`results-<sha-prefix>`) into `experiments/results/<run-id>/raw/`, concatenates per-mode JSONLs, invokes `summary.py`, and updates the `experiments/results/latest` symlink.
-
-## Inspecting results
-
-```
-experiments/results/<run-id>/
-├── compose.yml              # snapshot of the generated compose file
-├── run.log                  # per-run controller log
-├── raw/<sha-prefix>/        # one dir per SHA, copied from the named volume
-│   ├── agent.jsonl
-│   ├── baseline.jsonl
-│   └── transcripts/<slot>_d<size>.json
-├── agent.jsonl              # concatenated across SHAs
-├── baseline.jsonl
-├── summary.json             # per-(mode, deletion_size) + drift + Pearson r
-└── summary.md               # three tables: baseline, agent, baseline-vs-agent
-```
-
-The drift columns in `summary.md` (vo_bytes, compile_time, proof_chars/lines, tactic_count, n_assumptions) answer "is the LLM more/less X than the human reference?" directly. Per-metric Pearson r vs `deletion_size` is the faithfulness check.
-
-Re-aggregating a prior run is safe and idempotent (named volumes persist):
-
-```bash
-./orchestrate/aggregate.sh <old-run-id>
-```
-
-## Single-slot local iteration (no Docker)
-
-For fast iteration on prompt / agent changes against a host fiat-crypto checkout:
-
-```bash
-export FIAT_CRYPTO_DIR=/abs/path/to/fiat-crypto
-cd experiments
-uv run eval-baseline --max-challenges 1 --skip-a
-uv run eval-agent    --max-challenges 1 --skip-a
-uv run python summary.py --inputs "results/**/*.jsonl" --markdown /tmp/summary.md
-```
+Equivalents: `dune exec bin/main.exe -- file.v …` (`ablators/rocq`),
+`cargo run --features cli --bin ablate -- file.thy …` (`ablators/isabelle/rust`).
 
 ## Testing
 
 ```bash
-cd experiments
-uv run pytest -v                   # Python tests
-bash orchestrate/test_*.sh         # bash smoke tests (no Docker required)
+cd baselines && uv run ruff check && uv run ty check && uv run pytest
+nix develop ablators/lean --command lake exe ablate-test
+nix develop ablators/rocq --command dune test
 ```
 
 ## More depth
 
 - `CLAUDE.md` — repo-wide agent/developer context
-- `artifacts/MANIFEST_SCHEMA.md` — mined-dataset persistence model (git for manifests, DO Spaces for bulk, HuggingFace for published cuts) and the per-dataset `manifest.json` spec
-- `experiments/README.md` — pipeline internals and layout
-- `experiments/results/README.md` — per-run artifact layout and two-layer persistence
-- `scaffold/README.md` — mining + qualitative study pipelines
-- GitHub epic [#27](https://github.com/for-all-dev/git-history-evals/issues/27) — history of how the `experiments/` pipeline was built
+- `docs/SoW.md` — statement of work, milestones, and the August 2026 pivot
+- `docs/ablation-baseline-findings.md` — agentic baseline results and parity work across provers
+- `docs/dataset-issues.md` — the dataset inspection that motivated retiring git-history mining
+- `pipeline/README.md` — pipeline internals, l4v/Isabelle constraints, validation caveats
+- `baselines/README.md` — `apply-ablate` stages and prover backends
+- `website/README.md` — WASM playground architecture and deployment

--- a/docs/SoW.md
+++ b/docs/SoW.md
@@ -1,5 +1,13 @@
 # Statement of Work
 
+> **Status note (August 2026).** The method described in the original scope below —
+> mining git histories for `(commit t, commit t+1)` challenge pairs — has been
+> **superseded by syntactic proof ablation**. The original text is retained verbatim
+> so the change is visible rather than hidden; see
+> [Pivot: git-history mining → syntactic ablation](#pivot-august-2026-git-history-mining--syntactic-ablation)
+> for the date, the rationale, the restated deliverable, and an honest account of the
+> gap between what this document named as targets and what actually shipped.
+
 ## Mike Dodds (Twitter)
 
 > Someone should build seL4-ablate-bench. Progressively delete proofs, lemmas, theorems and see how much a long-running AI agent can reconstruct. End state: just give the AI the seL4 code + top spec, and re-synthesise the whole 1m+ line Isabelle proof. The seL4 proofs are OSS so they’re in the model training set. But even so, reconstructing 1m+ lines of proof is an insanely hard coordination challenge, far beyond current agents. And there’s no equivalent closed dataset at this scale. Fun exercise: predict what year an agent with sufficient scaffolding could reconstruct the entire seL4 proof. Estimates at Galois ranged from “2040” to “this year” :)
@@ -18,7 +26,7 @@ The proper swing at proof engineering evals via git histories would be an agenti
 
 This effort should also involve conducting baselines. 
 
-### Deliverable 
+### Deliverable  *(superseded August 2026 — see the pivot section below)*
 
 Evals for at least the Nova hypervisor specs and proofs, SeL4, Compcert, and Fiat-Crypto registered to inspect and listed on huggingface. The generalized scaffold dynamically synthesizing “miner” scripts that walk across the git histories. Reporting baselines of how current language models do, which includes demonstration of how to download the data from huggingface and make a solver. Stretch goal: demonstrate actual posttraining on these eval-as-envs with open weight models. 
 
@@ -27,6 +35,87 @@ Evals for at least the Nova hypervisor specs and proofs, SeL4, Compcert, and Fia
 There’s a whole lot about the ceiling of this project that won’t get done with SPAR resources, but the key idea (liberating human-provenance proof engineering data for huggingface) should be able to hit roughly its ceiling with the resources we’re asking for. Specifically, that would mean “ablation studies” of several major proof engineering repos exposed to huggingface. 
 
 In the long run, proofs are cheap. Having a proof oracle even a few months sooner than the default path could increase our security posture by proving critical infrastructure (including advanced AI training and deployment stacks) correct at crunch time. 
+
+## Pivot (August 2026): git-history mining → syntactic ablation
+
+**Date of decision: August 2026.** As of this date the project no longer mines git
+histories for challenges. Every dataset it produces comes from **syntactic proof
+ablation**, and the git-history miner, its dashboard, and the per-commit replay
+experiments have been removed from the tree. The previously published git-history cuts
+(`for-all-dev/{fiat-crypto,CompCert,l4v}-eval`) are retired.
+
+### Why
+
+The mined datasets were inspected statically in June 2026 (`docs/dataset-issues.md`) and
+found to be substantively broken as evals. Six issues were filed upstream as **#102–#107**:
+
+- **#102** — `holes_filled` empty in 100% of sampled rows across all three datasets: the
+  published schema predates per-hole metadata, so a consumer cannot even locate the hole
+  without diffing challenge against solution.
+- **#103** — most challenges contain no placeholder marker at all (~82% fiat-crypto, ~98%
+  l4v, 100% of the CompCert sample), so they are not "fill the hole" tasks; the dataset
+  card oversold them.
+- **#104** — the *ground truth* still contains `Admitted`/`sorry` in ~11% of fiat-crypto
+  and ~1.3% of l4v rows: the mined child commit did not actually close the goal, so the
+  label is wrong.
+- **#105** — degenerate new-file rows with an empty challenge: nothing to complete, only a
+  commit message to author 3k–16k characters from.
+- **#106** — no-op rows where challenge and solution are byte-identical.
+- **#107** — whole-file challenges are intractable at scale: median l4v challenge ~139k
+  characters (p90 ~322k), beyond any output-token budget; the whole-file baseline skipped
+  100% of sampled l4v challenges as `TOO_LARGE`.
+
+Common root cause: a commit diff is a *noisy, unvalidated* proxy for "here is a proof
+problem and here is its answer." Nothing in the mining pipeline could check that the
+challenge was well-posed or that the solution compiled, because doing so requires
+building the repo at that commit — which is the expensive part the mining approach was
+meant to avoid.
+
+Ablation inverts this. The challenge is *constructed* by deleting a lemma from a
+compiling file, so the hole location is known exactly, the ground truth is by
+construction a proof that compiles, no-op and empty challenges are impossible (the
+ablators refuse to emit a record when nothing was deleted), and the corollary-closure
+slice keeps challenges small instead of whole-file. Both sides are then really compiled
+before publication; anything that fails is marked `malformed` and excluded. Ablation is
+also more contamination-resistant: the deletion is drawn from a seeded random choice over
+a dependency closure, so the exact (challenge, solution) pair is not text that exists
+anywhere upstream.
+
+### Restated deliverable
+
+Compile-validated **ablation** evals over real proof-engineering repos, published to
+HuggingFace as `for-all-dev/ablation-eval` (easy/hard splits), together with:
+
+- three ablators (Lean, Rocq/Coq, Isabelle) sharing one record schema, each also compiled
+  to WASM and exposed through a browser playground, so any proof engineer can drop their
+  own repo in — including a private one, since the ablator runs locally;
+- a reproducible nix pipeline (mine → build → validate → index → publish → eval) with a
+  pinned corpus (`pipeline/repos.tsv`) so every published row traces to an exact tree;
+- a prover-agnostic agentic baseline harness (`ablate-baseline`) scored by real
+  compilation, with reported baselines for current language models;
+- an ablation *slider* (which lemma, how many, leaves vs. whole proof body) so the
+  difficulty of the generated dataset is a knob rather than an accident of history.
+
+Stretch goal (unchanged): post-training on these evals-as-envs with open-weight models.
+
+### Target vs. delivered — the honest gap
+
+This document named **Nova, seL4, CompCert, and fiat-crypto**. That is not what shipped.
+
+| named target | status |
+|---|---|
+| Nova hypervisor | **not attempted.** No Nova eval exists. |
+| seL4 (l4v, Isabelle) | **partial.** l4v is mined (19,018 challenges) but only partially *validated*: the `ExecSpec`/`ASpec` sessions require `spec/design/*.thy`, which are generated from seL4's Haskell model and absent from a plain checkout. Until that generation runs, only sessions below the design spec (Lib, Word_Lib, Monads, …) validate — and **14,594 of the 19,018 challenges sit under `Refine`**, which needs it. The flagship refinement proof is therefore not yet in a published, compile-validated cut. |
+| CompCert (Coq) | **not mined under ablation.** The checkout is present; the Rocq ablator exists and passes its own tests; the corpus has not been mined and validated. |
+| fiat-crypto (Coq) | **not mined under ablation.** Same as CompCert. The retired git-history cut is withdrawn, so there is currently no fiat-crypto dataset. |
+| *(not named in the SoW)* | **57 Lean repos**, mined in both modes, compile-validated, and published as `for-all-dev/ablation-eval`. This is the bulk of what shipped. |
+
+So the delivered corpus is broader than the SoW in repo count and narrower in prover
+coverage: strong on Lean, partial on Isabelle, empty on Rocq/Coq under the new method.
+The Lean corpus was where the pivot could be validated end-to-end fastest (a uniform
+toolchain, elan/lake, and repos that build in minutes rather than hours), and building it
+out was prioritised over reproducing the named Coq targets. Closing the Rocq gap and
+unblocking l4v's `Refine` sessions are the outstanding items against the original scope.
 
 ## Milestones
 
@@ -38,6 +127,12 @@ Preliminary huggingface MVPs for a couple of the repos. Scaffold repo is possibl
 
 Scaffold repo is agentic, repo and proofstack agnostic (done). Expanding to Isabelle's AFP, with nonmath repos as priority. Some way of attaching a slider to the generator of the dataset to ablate more or ablate less and export dataset on the fly — with symbolic ablations and perturbations as a more contamination-proof alternative to git-history deletion. Reproducible pipeline where all tools are installed automatically (i.e. docker or nix). Rudimentary/preliminary baselines demonstration. Huggingface posts continually updated.
 
+*(The "scaffold repo is agentic" criterion refers to the git-history miner and is
+superseded — the agentic calibration miner has been removed. Its successor criterion is
+"the ablators are repo- and proofstack-agnostic and need no per-repo calibration", which
+holds: ablation is purely syntactic, so a new repo needs no profile, only a build.
+The "slider" and "reproducible nix pipeline" criteria carried over intact and are met.)*
+
 ### [ ] August 18th ish
 
 Approximately conference tier writeup (not necessarily submitted or worried about specific peer review), with accompanying websites consisting of baseline information and lightweight “scaling laws” information. MIT licensed scaffold repo with method clear to reproduce for repos we did not ship to huggingface (including, in principle, sensitive/confidential repos). 
@@ -45,6 +140,14 @@ Approximately conference tier writeup (not necessarily submitted or worried abou
 Since the goal is to get stolen by frontier companies, ideally we’d catch wind of some internal pilots happening on posttraining teams by now, but this shouldn’t be a hard KPI because if it happens it might not be right away and we might not hear about it. 
 
 # Changelog
+
+**August 2026 — method pivot:**
+- Retired git-history mining in favour of syntactic proof ablation (rationale and
+  target-vs-delivered gap in the pivot section above; underlying defects filed as #102–#107)
+- Removed the miner, dashboard, and per-commit replay experiments from the tree
+- Withdrew `for-all-dev/{fiat-crypto,CompCert,l4v}-eval`; `for-all-dev/ablation-eval` is the
+  single published dataset
+- 57 Lean repos mined and compile-validated in both ablation modes
 
 **June 22 Checkin notes:**
 - Posted three benches on HuggingFace

--- a/docs/ablation-baseline-findings.md
+++ b/docs/ablation-baseline-findings.md
@@ -1,7 +1,7 @@
 # Ablation-baseline findings (agentic harness on real repos)
 
-This covers the **agentic** baseline in `harness/` (`ablate-baseline`) — distinct from
-the single-shot whole-file baseline in `baselines/` over the published HuggingFace
+This covers the **agentic** baseline in `baselines/` (`ablate-baseline`) — distinct from
+the retired single-shot whole-file baseline that ran over the git-history HuggingFace
 cuts (`docs/dataset-issues.md`). Here challenges come from the ablators' *leaf*
 deletion (`--delete-lemmas-leaves --count 5 --shrink-challenge-minimal
 --shrink-solution-minimal`); a pydantic-ai ReAct agent re-derives the deleted lemma(s)
@@ -28,14 +28,14 @@ into a compiling, hole-free file, and we score by real compilation.
 | malformed | 0/5 |
 
 fiat-crypto's number-theory lemmas are hard; 1/5 with budget the dominant limiter again.
-0 malformed confirms the rocq-ablator fixes below.
+0 malformed confirms the Rocq-ablator fixes below.
 
 ### Environment gotcha (coqc version)
 
 The `.vo` deps must be built and checked with the **same** coqc. fiat-crypto's `make`
-uses the opam **Coq 8.20.0** on PATH; the `rocq-ablator` nix shell ships **Rocq 9.1.1**
+uses the opam **Coq 8.20.0** on PATH; the `ablators/rocq` nix shell ships **Rocq 9.1.1**
 (whose split-out `Stdlib` isn't even present → `From Coq Require …` fails). Run the Coq
-baseline with the opam coqc (default PATH), *not* inside the rocq-ablator shell. The
+baseline with the opam coqc (default PATH), *not* inside the `ablators/rocq` shell. The
 ablator binary is built in its shell once; the baseline only needs `coqc` on PATH.
 Build deps via `make -f Makefile.coq <targets>` (the top `Makefile` drags in uninited
 `bedrock2`/`coqutil` submodules; `Makefile.coq` builds only the Coq closure).
@@ -76,7 +76,7 @@ Single-file checks (`lake env lean`, `coqc`) only read them, so the symlink is s
 ## Lean-ablator bugs surfaced by ryu (both fixed)
 
 Real Lean (mathlib-style) exercised two span/boundary bugs the synthetic fixtures
-never hit. Both are fixed in `lean-ablator/Ablator/Span.lean`, with regressions in
+never hit. Both are fixed in `ablators/lean/Ablator/Span.lean`, with regressions in
 `Tests.lean` (`letDocTests`); malformed dropped **6/13 → 0/13** (all challenges *and*
 ground-truth solutions now compile).
 
@@ -99,17 +99,34 @@ ground-truth solutions now compile).
    its decl. Hit `Classify`, `Value`, `FullRoundtrip`, and (downstream) `Interval`,
    `ShortestRep`.
 
-**Parity TODO:** the same two bugs almost certainly exist in the Isabelle (rust/scala)
-and Coq (OCaml) ablators' analogous span logic; port `findDeclBody`/`attachedStart`
-once a real Coq/Isabelle corpus is buildable here.
+**Parity TODO (scoped).** The two fixes do *not* port symmetrically; only one of them
+crosses provers at all.
+
+- **`attachedStart` ports to neither.** Both other ablators already attach leading
+  comments to the declaration that follows them, so bug 2 cannot occur there. The Rocq
+  ablator accumulates space and comment tokens into `cur` and flushes them with the next
+  sentence (`ablators/rocq/lib/span.ml:106`), so a doc comment is part of its decl's span.
+  The Isabelle ablator collects non-command tokens as `Ignored` spans and folds them into
+  the following command (`ablators/isabelle/rust/src/span.rs:114`). Nothing to port.
+- **`findDeclBody` ports to Rocq only.** Isabelle theory syntax has no `:=` proof
+  delimiter, so bug 1 has no analogue there. Rocq does, and its `has_assign`
+  (`ablators/rocq/lib/span.ml:80`) is `List.exists (Token.is_symbol_named ":=")` over the
+  span — *no depth tracking at all*, so it is strictly weaker than the pre-fix Lean
+  `findAssign`, which at least required depth 0. A `Definition`/`Let` with a `:=` nested
+  inside a type will confuse it the same way. This is the one genuine port.
+- **The real cross-prover gap is attribute retention**, which is missing in *both* the
+  Rocq and Isabelle ablators: attributes/annotations preceding a declaration are not
+  carried with it when the declaration is deleted or holed. That, not the two Lean span
+  bugs, is what should be fixed in lockstep once a real Coq/Isabelle corpus is buildable
+  here.
 
 ## Isabelle session-aware checking + the SMT-solver wall
 
-`harness/provers/isabelle.py` now auto-discovers a target theory's enclosing AFP/l4v
-`ROOT`, computes its in-session import closure, and checks just that closure as one
+`baselines/src/apply_ablate/provers/isabelle.py` now auto-discovers a target theory's
+enclosing AFP/l4v `ROOT`, computes its in-session import closure, and checks just that closure as one
 throwaway session (cross-session deps pruned to only those the closure imports; heavy
 `thys/` never registered wholesale). Validated end-to-end on a synthetic multi-theory
-session (valid → ok; `oops` → caught). Unit tests in `harness/tests/test_prover_cmds.py`
+session (valid → ok; `oops` → caught). Unit tests in `baselines/tests/test_prover_cmds.py`
 cover the ROOT parser, import closure, dep-session pruning, and discovery.
 
 **But** real AFP Solidity / l4v proofs replay `smt`/`sledgehammer` tactics, which need


### PR DESCRIPTION
## Summary

Reframes the funder- and reviewer-facing docs around syntactic proof ablation, which is
what the project actually does now, and describes only the tree that survives #144.

- **CLAUDE.md** — repo-structure and CLI sections rebuilt around `ablators/{lean,rocq,isabelle}`,
  `baselines/`, `pipeline/`, `website/`, `data/`, `artifacts/lean-ablate*`. The scaffold,
  dashboard, and experiments sections are gone.
- **README.md** — leads with corollary-closure ablation and `for-all-dev/ablation-eval`;
  quickstart is the `nix develop` + `pipeline/run.sh` flow, plus baseline and single-file
  ablation recipes.
- **docs/SoW.md** — records the **August 2026 pivot explicitly** instead of quietly
  rewriting it: original scope kept verbatim, a status banner and a superseded marker on the
  old deliverable, and a new pivot section with the rationale (#102–#107 — empty
  `holes_filled`, unmarked challenges, ground truth still containing `sorry`/`Admitted`,
  empty and no-op rows, whole-file challenges too large to be tractable — against which
  ablation gives compile-validated ground truth on both sides), the restated deliverable,
  and an honest target-vs-delivered table: Nova not attempted; l4v mined but `Refine`
  (14,594 of 19,018 challenges) blocked on seL4's generated design spec; CompCert and
  fiat-crypto unmined under the new method; 57 Lean repos shipped.
- **docs/ablation-baseline-findings.md** — the parity TODO was mis-scoped. `attachedStart`
  ports to neither other ablator (Rocq attaches comments at `ablators/rocq/lib/span.ml:106`,
  Isabelle via `Ignored` spans at `ablators/isabelle/rust/src/span.rs:114`); `findDeclBody`
  ports to Rocq only, where `has_assign` (`span.ml:80`) has no depth tracking at all; the
  genuine cross-prover gap is attribute retention, missing in both. Stale `harness/` and
  `*-ablator/` paths fixed.

## Test plan

Docs-only change; no code touched.

- `cd baselines && uv run pytest -q` → **114 passed**
- `uv run ruff check .` / `ruff format --check` → the pre-existing findings on
  `tests/test_sample_reproducibility.py` and one fixable lint, unchanged by this PR
- Every path, file, flag, and CLI entry point named in the new prose was checked against
  the tree (`pipeline/repos.tsv` = 57 repos, `artifacts/lean-ablate{,-whole}`,
  `baselines/pyproject.toml` `[project.scripts]`, the three ablator build files)

## Depends on

- #144 "remove miner, dashboard, commit-replay experiments" → branch `dispatch/144-remove-legacy` (https://github.com/for-all-dev/git-history-evals/pull/172)

Closes #145
