### PR TITLE
fix(baselines): out.usage is a property in pydantic-ai 2.x

### DIFF
--- a/baselines/src/apply_ablate/solve.py
+++ b/baselines/src/apply_ablate/solve.py
@@ -854,7 +854,8 @@ def solve_one(
         else ("tampered" if tamper else ("gave_up" if v.gave_up else "fail")),
     )
     diff = unified_or_empty(record.challenge_file_content, final)
-    usage = out.usage()
+    # pydantic-ai 2.x exposes usage as a RunUsage property; 1.x had a method
+    usage = out.usage() if callable(out.usage) else out.usage
     return SolveResult(
         task_id=record.task_id,
         assistant=record.assistant,


### PR DESCRIPTION
One-liner: PR #151's turns-used accounting called `out.usage()`; pydantic-ai 2.32 (#162) makes `usage` a property, so every solve died with `TypeError: 'RunUsage' object is not callable`. Found by the first #129 eval attempt (100% harness-err). Handles both shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKkRR9JnZ7hRPwtV77cMJe