### PR TITLE
chore(baselines): drop 1.x usage() compat guard

### DIFF
--- a/baselines/src/apply_ablate/solve.py
+++ b/baselines/src/apply_ablate/solve.py
@@ -872,8 +872,7 @@ def solve_one(
         else ("tampered" if tamper else ("gave_up" if v.gave_up else "fail")),
     )
     diff = unified_or_empty(record.challenge_file_content, final)
-    # pydantic-ai 2.x exposes usage as a RunUsage property; 1.x had a method
-    usage = out.usage() if callable(out.usage) else out.usage
+    usage = out.usage
     return SolveResult(
         task_id=record.task_id,
         assistant=record.assistant,


### PR DESCRIPTION
Follow-up to #174 per review: baselines pins pydantic-ai 2.32 and nothing 1.x remains in-tree, so `out.usage` is accessed as the plain 2.x property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKkRR9JnZ7hRPwtV77cMJe