### PR TITLE
comms: drop competition-template mentions

### DIFF
--- a/comms/README.md
+++ b/comms/README.md
@@ -1,10 +1,10 @@
 # Communication Materials
 
-This directory holds communication materials, including workshop papers and competition documentation for NeurIPS 2026 VeriCodeGen.
+This directory holds communication materials, including the NeurIPS 2026 VeriCodeGen workshop paper.
 
 ## Overleaf Sync Workflow
 
-The workshop and competition templates are synced with an Overleaf project (`proofablate__vericode-workshop`) using the `olcli` command-line tool.
+The workshop paper is synced with an Overleaf project (`proofablate__vericode-workshop`) using the `olcli` command-line tool. (The NeurIPS competition-track template is irrelevant to this submission; any `*_competition.*` files that appear on the Overleaf side should be ignored, not pulled into the repo.)
 
 ### Before Editing
 


### PR DESCRIPTION
Per review: the competition-track template is irrelevant — workshop track only. Removes the mentions from comms/README.md and documents that *_competition.* Overleaf files are to be ignored. The tracked .olcli.json manifest was already competition-free; the paper's competition-*mathematics* related-work positioning (miniF2F/PutnamBench) is content, not template, and stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKkRR9JnZ7hRPwtV77cMJe