### PR TITLE
fix(baselines): openai: routing uses the Responses API

### DIFF
--- a/baselines/src/apply_ablate/solve.py
+++ b/baselines/src/apply_ablate/solve.py
@@ -226,10 +226,12 @@ def make_agent(model: str):
             provider=MistralProvider(http_client=_retrying_async_client()),
         )
     elif model.startswith("openai:"):
-        from pydantic_ai.models.openai import OpenAIChatModel
+        # Responses API, not chat/completions: gpt-5.6 reasoning models reject
+        # function tools alongside reasoning_effort on /v1/chat/completions
+        from pydantic_ai.models.openai import OpenAIResponsesModel
         from pydantic_ai.providers.openai import OpenAIProvider
 
-        model_obj = OpenAIChatModel(
+        model_obj = OpenAIResponsesModel(
             model.removeprefix("openai:"),
             provider=OpenAIProvider(
                 api_key=os.environ.get("OPENAI_API_KEY"),

--- a/baselines/tests/test_make_agent.py
+++ b/baselines/tests/test_make_agent.py
@@ -32,11 +32,11 @@ def test_bare_and_anthropic_prefix_route_to_anthropic(model: str) -> None:
 
 
 def test_openai_prefix_routes_to_openai_chat_model() -> None:
-    from pydantic_ai.models.openai import OpenAIChatModel
+    from pydantic_ai.models.openai import OpenAIResponsesModel
 
     agent = make_agent("openai:gpt-5.6-sol")
 
-    assert isinstance(agent.model, OpenAIChatModel)
+    assert isinstance(agent.model, OpenAIResponsesModel)
     assert agent.model.model_name == "gpt-5.6-sol"
 
 


### PR DESCRIPTION
gpt-5.6-sol returned HTTP 400 on every call — function tools with reasoning_effort are unsupported on /v1/chat/completions. Switch the openai: branch from OpenAIChatModel to OpenAIResponsesModel (pydantic-ai 2.32). Routing test updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKkRR9JnZ7hRPwtV77cMJe