### PR TITLE
baselines: isolate test_sample_reproducibility from the real artifacts tree (fixes #175)

### DIFF
--- a/baselines/tests/test_sample_paired.py
+++ b/baselines/tests/test_sample_paired.py
@@ -116,12 +116,18 @@ def test_intersection_excludes_unpaired_ids(fixture_root: Path) -> None:
     assert set(pairs["repo_b"]) == {"b1", "b2"}
 
 
-def test_main_emits_paired_dirs_with_equal_challenge_id_sets(fixture_root: Path) -> None:
+def test_main_emits_paired_dirs_with_equal_challenge_id_sets(
+    fixture_root: Path,
+) -> None:
     out_dir = fixture_root / "out"
     sample_paired.main([str(out_dir), "5", "--seed", "42"])
 
-    easy_sample = [json.loads(line) for line in (out_dir / "easy" / "sample.jsonl").open()]
-    hard_sample = [json.loads(line) for line in (out_dir / "hard" / "sample.jsonl").open()]
+    easy_sample = [
+        json.loads(line) for line in (out_dir / "easy" / "sample.jsonl").open()
+    ]
+    hard_sample = [
+        json.loads(line) for line in (out_dir / "hard" / "sample.jsonl").open()
+    ]
 
     easy_ids = {r["challenge_id"] for r in easy_sample}
     hard_ids = {r["challenge_id"] for r in hard_sample}
@@ -161,11 +167,18 @@ def test_main_different_seed_can_differ(fixture_root: Path) -> None:
     out2 = fixture_root / "out2"
     sample_paired.main([str(out1), "2", "--seed", "1"])
     sample_paired.main([str(out2), "2", "--seed", "2"])
-    ids1 = {json.loads(line)["challenge_id"] for line in (out1 / "easy" / "sample.jsonl").open()}
-    ids2 = {json.loads(line)["challenge_id"] for line in (out2 / "easy" / "sample.jsonl").open()}
+    ids1 = {
+        json.loads(line)["challenge_id"]
+        for line in (out1 / "easy" / "sample.jsonl").open()
+    }
+    ids2 = {
+        json.loads(line)["challenge_id"]
+        for line in (out2 / "easy" / "sample.jsonl").open()
+    }
     # both still pair correctly regardless of which ids the seed happened to pick
     hard_ids2 = {
-        json.loads(line)["challenge_id"] for line in (out2 / "hard" / "sample.jsonl").open()
+        json.loads(line)["challenge_id"]
+        for line in (out2 / "hard" / "sample.jsonl").open()
     }
     assert ids2 == hard_ids2
     # not asserting ids1 != ids2 (small pool -- a coincidental match is possible); the
@@ -194,7 +207,14 @@ def test_subprocess_reproducibility_across_processes(fixture_root: Path) -> None
     env = {"PIPELINE_SAMPLE_ROOT": str(fixture_root), "PATH": "/usr/bin:/bin"}
     for out in (out1, out2):
         result = subprocess.run(
-            [sys.executable, str(PIPELINE_DIR / "sample_paired.py"), str(out), "4", "--seed", "9"],
+            [
+                sys.executable,
+                str(PIPELINE_DIR / "sample_paired.py"),
+                str(out),
+                "4",
+                "--seed",
+                "9",
+            ],
             capture_output=True,
             text=True,
             env=env,

--- a/baselines/tests/test_sample_reproducibility.py
+++ b/baselines/tests/test_sample_reproducibility.py
@@ -1,11 +1,11 @@
 """Test for reproducibility of sample_disjoint.py across separate processes."""
 
 import json
+import os
 import subprocess
 import sys
-from pathlib import Path
 import tempfile
-import hashlib
+from pathlib import Path
 
 # Add pipeline to path
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -17,117 +17,108 @@ def test_sample_disjoint_seed_reproducibility() -> None:
     Test that the same seed produces byte-identical sample.jsonl across two separate processes.
     This verifies that the seed-based randomness is properly implemented and not affected by
     PEP 456 PYTHONHASHSEED randomization.
+
+    Runs in an isolated temporary directory, never touching the real artifacts/ or registry.
     """
-    # Use two temporary directories to simulate independent runs
-    with tempfile.TemporaryDirectory() as tmpdir1:
-        with tempfile.TemporaryDirectory() as tmpdir2:
-            tmpdir1_path = Path(tmpdir1)
-            tmpdir2_path = Path(tmpdir2)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
 
-            # Create temporary test data that sample_disjoint.py can use
-            # We need to create artifacts/lean-ablate structure with challenges
-            test_repo_name = "test_repo"
-            artifacts_dir = Path(tmpdir1_path.parent) / "artifacts" / "lean-ablate" / test_repo_name
-            artifacts_dir.mkdir(parents=True, exist_ok=True)
+        # Create isolated artifacts/lean-ablate/test_repo structure
+        artifacts_dir = tmpdir_path / "artifacts" / "lean-ablate" / "test_repo"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
 
-            # Create a sample challenges.jsonl file with 10 test challenges
-            challenges_file = artifacts_dir / "challenges.jsonl"
-            test_challenges = []
-            for i in range(10):
-                test_challenges.append({
+        # Create pipeline directory for registry
+        pipeline_dir = tmpdir_path / "pipeline"
+        pipeline_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create test challenges.jsonl with 10 synthetic challenges
+        challenges_file = artifacts_dir / "challenges.jsonl"
+        test_challenges = []
+        for i in range(10):
+            test_challenges.append(
+                {
                     "challenge_file_content": f"challenge {i} content to be hashed",
                     "challenge_id": f"ch_{i}",
                     "solution_file_content": f"solution {i}",
-                })
+                }
+            )
 
-            with open(challenges_file, "w") as f:
-                for ch in test_challenges:
-                    f.write(json.dumps(ch) + "\n")
+        with open(challenges_file, "w") as f:
+            for ch in test_challenges:
+                f.write(json.dumps(ch) + "\n")
 
-            # Create registry file
-            registry_file = PIPELINE_DIR / "registry_all.tsv"
-            # We need to back up the original if it exists
-            registry_backup = None
-            if registry_file.exists():
-                import shutil
-                registry_backup = registry_file.read_text()
+        # Create minimal registry with test repo
+        registry_file = pipeline_dir / "registry_all.tsv"
+        with open(registry_file, "w") as f:
+            f.write("test_repo\thttps://test.repo/url\n")
 
-            # Create a minimal registry with our test repo
-            with open(registry_file, "w") as f:
-                f.write(f"{test_repo_name}\thttps://test.repo/url\n")
+        # Run sample_disjoint.py twice with the same seed in separate processes
+        seed = 42
+        out_dir1 = tmpdir_path / "sample1"
+        out_dir2 = tmpdir_path / "sample2"
 
-            try:
-                # Run sample_disjoint.py twice with the same seed in separate processes
-                seed = 42
-                out_dir1 = tmpdir1_path / "sample1"
-                out_dir2 = tmpdir2_path / "sample2"
+        # Build environment with PIPELINE_SAMPLE_ROOT pointing to our isolated temp dir
+        env = {**os.environ, "PIPELINE_SAMPLE_ROOT": str(tmpdir_path)}
 
-                # First run
-                result1 = subprocess.run(
-                    [
-                        sys.executable,
-                        str(PIPELINE_DIR / "sample_disjoint.py"),
-                        str(out_dir1),
-                        "5",
-                        "--seed",
-                        str(seed),
-                    ],
-                    capture_output=True,
-                    text=True,
-                )
-                assert result1.returncode == 0, f"First run failed: {result1.stderr}"
+        # First run
+        result1 = subprocess.run(
+            [
+                sys.executable,
+                str(PIPELINE_DIR / "sample_disjoint.py"),
+                str(out_dir1),
+                "5",
+                "--seed",
+                str(seed),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result1.returncode == 0, f"First run failed: {result1.stderr}"
 
-                # Second run (in a separate process)
-                result2 = subprocess.run(
-                    [
-                        sys.executable,
-                        str(PIPELINE_DIR / "sample_disjoint.py"),
-                        str(out_dir2),
-                        "5",
-                        "--seed",
-                        str(seed),
-                    ],
-                    capture_output=True,
-                    text=True,
-                )
-                assert result2.returncode == 0, f"Second run failed: {result2.stderr}"
+        # Second run (in a separate process)
+        result2 = subprocess.run(
+            [
+                sys.executable,
+                str(PIPELINE_DIR / "sample_disjoint.py"),
+                str(out_dir2),
+                "5",
+                "--seed",
+                str(seed),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result2.returncode == 0, f"Second run failed: {result2.stderr}"
 
-                # Read the generated sample.jsonl files
-                sample_file1 = out_dir1 / "sample.jsonl"
-                sample_file2 = out_dir2 / "sample.jsonl"
+        # Read the generated sample.jsonl files
+        sample_file1 = out_dir1 / "sample.jsonl"
+        sample_file2 = out_dir2 / "sample.jsonl"
 
-                assert sample_file1.exists(), f"Sample file 1 not found: {sample_file1}"
-                assert sample_file2.exists(), f"Sample file 2 not found: {sample_file2}"
+        assert sample_file1.exists(), f"Sample file 1 not found: {sample_file1}"
+        assert sample_file2.exists(), f"Sample file 2 not found: {sample_file2}"
 
-                # Compare byte-for-byte
-                content1 = sample_file1.read_bytes()
-                content2 = sample_file2.read_bytes()
+        # Compare byte-for-byte
+        content1 = sample_file1.read_bytes()
+        content2 = sample_file2.read_bytes()
 
-                assert (
-                    content1 == content2
-                ), f"Sample files differ:\nFile 1 size: {len(content1)}\nFile 2 size: {len(content2)}"
+        assert content1 == content2, (
+            f"Sample files differ:\nFile 1 size: {len(content1)}\nFile 2 size: {len(content2)}"
+        )
 
-                # Also verify manifest.json contains the seed
-                manifest1 = json.loads((out_dir1 / "manifest.json").read_text())
-                manifest2 = json.loads((out_dir2 / "manifest.json").read_text())
+        # Also verify manifest.json contains the seed
+        manifest1 = json.loads((out_dir1 / "manifest.json").read_text())
+        manifest2 = json.loads((out_dir2 / "manifest.json").read_text())
 
-                for entry in manifest1:
-                    assert "seed" in entry, f"Seed not found in manifest entry: {entry}"
-                    assert entry["seed"] == seed, f"Seed mismatch in manifest1: {entry['seed']} != {seed}"
+        for entry in manifest1:
+            assert "seed" in entry, f"Seed not found in manifest entry: {entry}"
+            assert entry["seed"] == seed, (
+                f"Seed mismatch in manifest1: {entry['seed']} != {seed}"
+            )
 
-                for entry in manifest2:
-                    assert "seed" in entry, f"Seed not found in manifest entry: {entry}"
-                    assert entry["seed"] == seed, f"Seed mismatch in manifest2: {entry['seed']} != {seed}"
-
-            finally:
-                # Restore registry file
-                if registry_backup is not None:
-                    with open(registry_file, "w") as f:
-                        f.write(registry_backup)
-                elif registry_file.exists():
-                    registry_file.unlink()
-
-                # Clean up artifacts
-                if artifacts_dir.exists():
-                    import shutil
-                    shutil.rmtree(artifacts_dir.parent)
+        for entry in manifest2:
+            assert "seed" in entry, f"Seed not found in manifest entry: {entry}"
+            assert entry["seed"] == seed, (
+                f"Seed mismatch in manifest2: {entry['seed']} != {seed}"
+            )

--- a/pipeline/sample_disjoint.py
+++ b/pipeline/sample_disjoint.py
@@ -27,7 +27,9 @@ import shutil
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parent.parent
+ROOT = Path(
+    os.environ.get("PIPELINE_SAMPLE_ROOT") or Path(__file__).resolve().parent.parent
+)
 
 MODE_ARTIFACT_DIR = {
     "leaves": "artifacts/lean-ablate",


### PR DESCRIPTION
`sample_disjoint.py` gains the `PIPELINE_SAMPLE_ROOT` override (same pattern as `sample_paired.py`); the test builds an isolated fake tree under a tempdir and passes it via env to both subprocess runs. No more globbing the real `artifacts/` or mutating the real `registry_all.tsv`. Full suite green (131 passed), ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1sB38rMa7yJxVjhAFDit4